### PR TITLE
Add desktop filter for building cargo tests on Linux minimal

### DIFF
--- a/build-scripts/test.py
+++ b/build-scripts/test.py
@@ -52,6 +52,9 @@ def run_cargo_tests(
     if target:
         args.extend(["--target", target])
 
+    if Variant.FULL not in variants:
+        args.extend(["--exclude", DESKTOP_PACKAGE_NAME])
+
     if features:
         args.extend(
             [


### PR DESCRIPTION
The build is failing for minimal Linux environments since they are trying to build the desktop app, which results in missing dependency errors.