### PR TITLE
Fix macOS broken lints

### DIFF
--- a/crates/fig_desktop/src/local_ipc/commands.rs
+++ b/crates/fig_desktop/src/local_ipc/commands.rs
@@ -272,6 +272,7 @@ pub fn dump_state(
     ))))
 }
 
+#[allow(unused_variables)]
 pub async fn connect_to_ibus(proxy: EventLoopProxy, platform_state: &PlatformState) -> LocalResult {
     cfg_if::cfg_if! {
         if #[cfg(target_os = "linux")] {

--- a/crates/fig_desktop/src/platform/macos.rs
+++ b/crates/fig_desktop/src/platform/macos.rs
@@ -147,7 +147,7 @@ struct Unmanaged {
 }
 
 #[derive(Debug, Serialize)]
-pub(super) struct PlatformStateImpl {
+pub struct PlatformStateImpl {
     #[serde(skip)]
     proxy: EventLoopProxy,
     #[serde(skip)]

--- a/crates/fig_desktop/src/platform/mod.rs
+++ b/crates/fig_desktop/src/platform/mod.rs
@@ -104,6 +104,7 @@ impl PlatformState {
     }
 
     /// Returns the platform specific implementation.
+    #[allow(dead_code)]
     pub fn inner(&self) -> Arc<PlatformStateImpl> {
         Arc::clone(&self.0)
     }

--- a/crates/fig_util/src/directories.rs
+++ b/crates/fig_util/src/directories.rs
@@ -640,9 +640,9 @@ mod tests {
 
     #[test]
     fn snapshot_themes_dir() {
-        linux!(themes_dir(), @"/usr/share/fig/themes");
-        macos!(themes_dir(), @"/Applications/Amazon Q.app/Contents/Resources/themes");
-        windows!(themes_dir(), @r"C:\Users\$USER\AppData\Local\Fig\userdata\themes\themes");
+        linux!(themes_dir(&Context::new()), @"/usr/share/fig/themes");
+        macos!(themes_dir(&Context::new()), @"/Applications/Amazon Q.app/Contents/Resources/themes");
+        windows!(themes_dir(&Context::new()), @r"C:\Users\$USER\AppData\Local\Fig\userdata\themes\themes");
     }
 
     #[test]


### PR DESCRIPTION
*Description of changes:*
- Ran `cargo test` and `cargo clippy --locked --color always -- -D warnings` and it passed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
