### PR TITLE
Fix various Linux bugs around GNOME Shell, improve Linux doctor check…

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -240,20 +240,26 @@ const useNavData = () => {
 };
 
 function Layout() {
+  const [onboardingComplete] = useLocalStateZodDefault(
+    "desktop.completedOnboarding",
+    z.boolean(),
+    false,
+  );
   const platformInfo = usePlatformInfo();
   const [accessibilityCheck] = useAccessibilityCheck();
   const [dotfilesCheck] = useDotfilesCheck();
   const [gnomeExtensionCheck] = useGnomeExtensionCheck();
   const navData = useNavData();
   const error =
-    accessibilityCheck === false ||
-    dotfilesCheck === false ||
-    (platformInfo &&
-      matchesPlatformRestrictions(
-        platformInfo,
-        gnomeExtensionInstallCheck.platformRestrictions,
-      ) &&
-      gnomeExtensionCheck === false);
+    onboardingComplete &&
+    (accessibilityCheck === false ||
+      dotfilesCheck === false ||
+      (platformInfo &&
+        matchesPlatformRestrictions(
+          platformInfo,
+          gnomeExtensionInstallCheck.platformRestrictions,
+        ) &&
+        gnomeExtensionCheck === false));
 
   // eslint-disable-next-line
   const [notifCount, _] = useLocalStateZodDefault(

--- a/apps/dashboard/src/index.css
+++ b/apps/dashboard/src/index.css
@@ -163,3 +163,10 @@
       #301673;
   }
 }
+
+/* Currently an issue with Linux webkit CSS variables */
+/* https://github.com/tailwindlabs/tailwindcss/issues/13844 */
+.backdrop-blur-lg {
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+}

--- a/build-config/buildspec-linux-ubuntu.yml
+++ b/build-config/buildspec-linux-ubuntu.yml
@@ -8,7 +8,7 @@ phases:
     run-as: root
     commands:
       - apt-get update
-      - apt-get install -y -qq build-essential pkg-config jq dpkg curl wget zsh zstd cmake clang libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libdbus-1-dev libwebkit2gtk-4.0-37 libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev valac libibus-1.0-dev libglib2.0-dev sqlite3 libxdo-dev protobuf-compiler libfuse2 dpkg-sig
+      - apt-get install -y -qq build-essential pkg-config jq dpkg curl wget zsh zstd cmake clang libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libdbus-1-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev valac libibus-1.0-dev libglib2.0-dev sqlite3 libxdo-dev protobuf-compiler libfuse2 dpkg-sig
   pre_build:
     commands:
       - export HOME=/home/codebuild-user

--- a/crates/q_cli/src/cli/doctor/mod.rs
+++ b/crates/q_cli/src/cli/doctor/mod.rs
@@ -2237,6 +2237,7 @@ pub async fn doctor_cli(all: bool, strict: bool) -> Result<ExitCode> {
         #[cfg(target_os = "linux")]
         {
             use checks::linux::{
+                DisplayServerCheck,
                 GnomeExtensionCheck,
                 IBusConnectionCheck,
                 IBusEnvCheck,
@@ -2249,6 +2250,7 @@ pub async fn doctor_cli(all: bool, strict: bool) -> Result<ExitCode> {
                 run_checks_with_context(
                     "Let's check Linux integrations",
                     vec![
+                        &DisplayServerCheck,
                         &IBusEnvCheck,
                         &GnomeExtensionCheck,
                         &IBusRunningCheck,


### PR DESCRIPTION
*Description of changes:*
- Hide help/support error in the dashboard navigation if the user hasn't completed onboarding
- Add a timeout in the dashboard when logging in with PKCE to fallback to device code.
- Add manual backdrop-blur css to account for Linux webkit bug.
- Remove `libwebkit2gtk-4.0-37` from the Linux build since it is not necessary and only bloats the AppImage size.
- Account for other GNOME Shell extension states
- Don't try to install the GNOME Shell extension on desktop startup if not on Wayland
- Add a check in `q doctor` for detecting the display server.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
