### PR TITLE
Remove libxdo from the Linux desktop app, fix kitty doctor check on Wayland

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4731,25 +4731,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libxdo"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00333b8756a3d28e78def82067a377de7fa61b24909000aeaa2b446a948d14db"
-dependencies = [
- "libxdo-sys",
-]
-
-[[package]]
-name = "libxdo-sys"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db23b9e7e2b7831bbd8aac0bbeeeb7b68cbebc162b227e7052e8e55829a09212"
-dependencies = [
- "libc",
- "x11",
-]
-
-[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5092,7 +5073,6 @@ dependencies = [
  "dpi",
  "gtk",
  "keyboard-types",
- "libxdo",
  "objc",
  "once_cell",
  "png",

--- a/build-config/buildspec-linux-ubuntu.yml
+++ b/build-config/buildspec-linux-ubuntu.yml
@@ -8,7 +8,7 @@ phases:
     run-as: root
     commands:
       - apt-get update
-      - apt-get install -y -qq build-essential pkg-config jq dpkg curl wget zsh zstd cmake clang libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libdbus-1-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev valac libibus-1.0-dev libglib2.0-dev sqlite3 libxdo-dev protobuf-compiler libfuse2 dpkg-sig
+      - apt-get install -y -qq build-essential pkg-config jq dpkg curl wget zsh zstd cmake clang libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libdbus-1-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev valac libibus-1.0-dev libglib2.0-dev sqlite3 protobuf-compiler libfuse2 dpkg-sig
   pre_build:
     commands:
       - export HOME=/home/codebuild-user

--- a/crates/fig_desktop/Cargo.toml
+++ b/crates/fig_desktop/Cargo.toml
@@ -65,7 +65,7 @@ infer = "0.15.0"
 keyboard-types = "0.7.0"
 mime = "0.3.17"
 moka = { version = "0.12.1", features = ["future"] }
-muda = "0.13.0"
+muda = { version = "0.13.0", default-features = false }
 notify = "6.0.0"
 once_cell.workspace = true
 parking_lot = { version = "0.12.1", features = ["serde"] }
@@ -84,7 +84,7 @@ tempfile.workspace = true
 time.workspace = true
 tokio.workspace = true
 tracing.workspace = true
-tray-icon = "0.13.0"
+tray-icon = { version = "0.13.0", default-features = false }
 url = "2.3.1"
 uuid.workspace = true
 which.workspace = true

--- a/crates/q_cli/src/cli/doctor/checks/linux.rs
+++ b/crates/q_cli/src/cli/doctor/checks/linux.rs
@@ -141,7 +141,8 @@ impl DoctorCheck<LinuxContext> for IBusEnvCheck {
 
         // IME is disabled in Kitty by default.
         // https://github.com/kovidgoyal/kitty/issues/469#issuecomment-419406438
-        if let Some(Terminal::Kitty) = Terminal::parent_terminal(ctx) {
+        if let (Some(Terminal::Kitty), DisplayServer::X11) = (Terminal::parent_terminal(ctx), get_display_server(ctx)?)
+        {
             match env.get("GLFW_IM_MODULE") {
                 Ok(actual) if actual == "ibus" => (),
                 Ok(actual) => errors.push(EnvErr {


### PR DESCRIPTION
*Description of changes:*
- Removing the libxdo dependency since it is not being used.
- Restrict the kitty IME check to X11, since it is only required when under Xorg.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
