### PR TITLE
Build one deb package for Ubuntu 22 and 24, include shas for deb and AppImage

### DIFF
--- a/bundle/deb/control_ubuntu22_deb10-12
+++ b/bundle/deb/control_ubuntu22_deb10-12
@@ -1,8 +1,0 @@
-Package: amazon-q
-Description: Amazon Q CLI for Linux
-Maintainer: Amazon Q CLI Team <q-cli@amazon.com>
-Homepage: https://github.com/aws/q-cli
-Version: $VERSION
-Architecture: $APT_ARCH
-Conflicts: amazon-q-minimal
-Depends: libayatana-appindicator3-1, libwebkit2gtk-4.0-37, libgtk-3-0, util-linux

--- a/bundle/deb/control_ubuntu24_deb13
+++ b/bundle/deb/control_ubuntu24_deb13
@@ -1,8 +1,0 @@
-Package: amazon-q
-Description: Amazon Q CLI for Linux
-Maintainer: Amazon Q CLI Team <q-cli@amazon.com>
-Homepage: https://github.com/aws/q-cli
-Version: $VERSION
-Architecture: $APT_ARCH
-Conflicts: amazon-q-minimal
-Depends: libayatana-appindicator3-1, libwebkit2gtk-4.1-0, libgtk-3-0, util-linux


### PR DESCRIPTION
*Description of changes:*
- Building only a single `deb` across Ubuntu 22 and 24 since it seems that the dependency `libwebkit2gtk-4.1-0` now works across both.
- Including sha256 hashes for the deb and AppImage


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
