### PR TITLE
Bump version to 1.5.0, add feed.json entry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty_terminal"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "bitflags 2.6.0",
  "camino",
@@ -293,7 +293,7 @@ checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
 
 [[package]]
 name = "appkit-nsworkspace-bindings"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "bindgen 0.69.5",
  "objc",
@@ -2187,7 +2187,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "dbus"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "async_zip",
  "fig_os_shim",
@@ -2623,7 +2623,7 @@ dependencies = [
 
 [[package]]
 name = "fig-api-mock"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -2636,7 +2636,7 @@ dependencies = [
 
 [[package]]
 name = "fig_api_client"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "amzn-codewhisperer-client",
  "amzn-codewhisperer-streaming-client",
@@ -2674,7 +2674,7 @@ dependencies = [
 
 [[package]]
 name = "fig_auth"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "async-trait",
  "aws-credential-types",
@@ -2709,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "fig_aws_common"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "aws-runtime",
  "aws-smithy-runtime",
@@ -2722,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "fig_desktop"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -2802,7 +2802,7 @@ dependencies = [
 
 [[package]]
 name = "fig_desktop_api"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "anstream",
  "async-trait",
@@ -2839,7 +2839,7 @@ dependencies = [
 
 [[package]]
 name = "fig_diagnostic"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "cfg-if",
  "clap",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "fig_input_method"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "apple-bundle",
  "cocoa",
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "fig_install"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "bitflags 2.6.0",
  "bytes",
@@ -2917,7 +2917,7 @@ dependencies = [
 
 [[package]]
 name = "fig_integrations"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "accessibility-sys",
  "async-trait",
@@ -2950,7 +2950,7 @@ dependencies = [
 
 [[package]]
 name = "fig_ipc"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "fig_log"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "console-subscriber",
  "fig_util",
@@ -2983,7 +2983,7 @@ dependencies = [
 
 [[package]]
 name = "fig_os_shim"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "cfg-if",
  "dirs",
@@ -2996,7 +2996,7 @@ dependencies = [
 
 [[package]]
 name = "fig_proto"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -3017,7 +3017,7 @@ dependencies = [
 
 [[package]]
 name = "fig_remote_ipc"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3035,7 +3035,7 @@ dependencies = [
 
 [[package]]
 name = "fig_request"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -3061,7 +3061,7 @@ dependencies = [
 
 [[package]]
 name = "fig_settings"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "fd-lock",
  "fig_test",
@@ -3083,7 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "fig_telemetry"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "amzn-codewhisperer-client",
  "amzn-toolkit-telemetry",
@@ -3118,7 +3118,7 @@ dependencies = [
 
 [[package]]
 name = "fig_telemetry_core"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "amzn-codewhisperer-client",
  "amzn-toolkit-telemetry",
@@ -3132,7 +3132,7 @@ dependencies = [
 
 [[package]]
 name = "fig_test"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "fig_test_macro",
  "tokio",
@@ -3140,7 +3140,7 @@ dependencies = [
 
 [[package]]
 name = "fig_test_macro"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "quote",
  "syn 2.0.85",
@@ -3148,7 +3148,7 @@ dependencies = [
 
 [[package]]
 name = "fig_util"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "appkit-nsworkspace-bindings",
  "bstr",
@@ -3186,7 +3186,7 @@ dependencies = [
 
 [[package]]
 name = "figterm"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -3251,7 +3251,7 @@ dependencies = [
 
 [[package]]
 name = "figterm2"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4806,7 +4806,7 @@ dependencies = [
 
 [[package]]
 name = "macos-utils"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -6399,7 +6399,7 @@ dependencies = [
 
 [[package]]
 name = "q_cli"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "amzn-codewhisperer-client",
  "amzn-codewhisperer-streaming-client",
@@ -7593,7 +7593,7 @@ dependencies = [
 
 [[package]]
 name = "shell-color"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "bitflags 2.6.0",
  "fig_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ authors = [
 edition = "2021"
 homepage = "https://aws.amazon.com/q/"
 publish = false
-version = "1.4.6"
+version = "1.5.0"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]

--- a/feed.json
+++ b/feed.json
@@ -12,6 +12,18 @@
     },
     {
       "type": "release",
+      "date": "2024-11-21",
+      "version": "1.5.0",
+      "title": "Version 1.5.0",
+      "changes": [
+        {
+          "type": "added",
+          "description": "Support for Linux desktop. See the [AWS documentation](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line.html) for more information."
+        }
+      ]
+    },
+    {
+      "type": "release",
       "date": "2024-11-15",
       "version": "1.4.6",
       "title": "Version 1.4.6",


### PR DESCRIPTION
*Description of changes:*
- Bumping version to 1.5.0
- Adding feed.json entry announcing Linux desktop support.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
