### PR TITLE
fix: sha calculation for the Linux deb

### DIFF
--- a/build-scripts/build.py
+++ b/build-scripts/build.py
@@ -713,6 +713,9 @@ def build_linux_full(
         run_cmd(["dpkg-sig", "-k", signer.gpg_id, "-s", "builder", deb_output.deb_path], env=signer.gpg_env())
         run_cmd(["dpkg-sig", "-l", deb_output.deb_path], env=signer.gpg_env())
         run_cmd(["gpg", "--verify", deb_output.deb_path], env=signer.gpg_env())
+        deb_output.sha_path = generate_sha(
+            deb_output.deb_path
+        )  # Need to regenerate the sha since the signature is embedded inside the deb
 
         signer.clean()
 


### PR DESCRIPTION
*Description of changes:*
- Recalculate the sha for the deb when signing is enabled. This shouldn't cause any issues with updating since this is the first version released for Linux.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
