### PR TITLE
chore: add ignore for RUSTSEC-2017-0008

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ nix = { version = "0.29.0", features = [
 objc = "0.2.7"
 once_cell = { version = "1.18.0", features = ["parking_lot"] }
 percent-encoding = "2.2.0"
-portable-pty = "0.8.0"
+portable-pty = "0.8.1"
 rand = "0.8.5"
 regex = "1.7.0"
 reqwest = { version = "0.12.5", default-features = false, features = [

--- a/deny.toml
+++ b/deny.toml
@@ -11,6 +11,8 @@ ignore = [
   # instant is dependency of notify and tao, until those remove instant this
   # will be allowed
   "RUSTSEC-2024-0384",
+  # blocked on portable-pty migrating away from serial
+  "RUSTSEC-2017-0008",
 ]
 
 [licenses]


### PR DESCRIPTION
*Description of changes:*
- This PR adds an ignore for [RUSTSEC-2017-0008](https://rustsec.org/advisories/RUSTSEC-2017-0008.html) which is currently causing the cargo deny checks to fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
