### PR TITLE
fix: minimal Linux installation filetype

### DIFF
--- a/crates/fig_install/src/index.rs
+++ b/crates/fig_install/src/index.rs
@@ -386,7 +386,7 @@ fn get_file_type(ctx: &Context, variant: &Variant) -> Result<FileType, Error> {
             match variant {
                 // Linux desktop currently cannot distinguish between AppImage and packages.
                 Variant::Full => Err(Error::FileTypeNotFound),
-                Variant::Minimal => Ok(FileType::TarGz),
+                Variant::Minimal => Ok(FileType::TarZst),
                 Variant::Other(_) => Err(Error::UnsupportedPlatform),
             }
         },

--- a/crates/fig_install/src/lib.rs
+++ b/crates/fig_install/src/lib.rs
@@ -35,6 +35,7 @@ pub use os::uninstall_terminal_integrations;
 use thiserror::Error;
 use tokio::sync::mpsc::Receiver;
 use tracing::{
+    debug,
     error,
     info,
 };
@@ -180,6 +181,7 @@ pub async fn update(
     info!("Checking for updates...");
     if let Some(update) = check_for_updates(ignore_rollout).await? {
         info!("Found update: {}", update.version);
+        debug!("Update info: {:?}", update);
 
         if ctx.platform().os() == Os::Linux && manifest().variant == Variant::Full {
             return Err(Error::UpdateFailed(

--- a/crates/fig_install/src/linux.rs
+++ b/crates/fig_install/src/linux.rs
@@ -14,7 +14,10 @@ use fig_util::directories::{
     local_webview_data_dir,
 };
 use tokio::sync::mpsc::Sender;
-use tracing::warn;
+use tracing::{
+    debug,
+    warn,
+};
 use url::Url;
 
 use crate::download::download_file;
@@ -79,6 +82,7 @@ fn extract_archive(archive_path: &Path, tempdir: &Path) -> Result<(), Error> {
     let file = std::fs::File::open(archive_path)?;
     let mut decoder = zstd::Decoder::new(file)?;
     let mut tar = tar::Archive::new(&mut decoder);
+    debug!("unpacking tar to directory: {:?}", tempdir);
     tar.unpack(tempdir)?;
     Ok(())
 }
@@ -141,6 +145,7 @@ pub(crate) async fn update(
 
     let archive_path = tempdir.path().join(archive.file_name);
 
+    debug!("downloading file: {:?} to path: {:?}", download_url, archive_path);
     let real_hash = download_file(download_url.clone(), &archive_path, size, Some(tx.clone())).await?;
     if sha256 != real_hash {
         return Err(Error::UpdateFailed(format!(


### PR DESCRIPTION
*Description of changes:*
- Update the file type of update packages for Linux minimal installations to tarZst instead of tarGz. The release for v1.4.6 (included in v1.5.0) has broken update logic for Linux minimal installs where the app will always download a tarGz and attempt to unpack using zstd. This change will revert back to the previous behavior of always using tarZst.
- Add some extra debug statements when updating.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
