### PR TITLE
fix: update build script to not run doc tests

### DIFF
--- a/build-scripts/const.py
+++ b/build-scripts/const.py
@@ -22,6 +22,7 @@ LINUX_MODERN_GNOME_EXTENSION_UUID = "amazon-q-for-cli-gnome-integration@aws.amaz
 CLI_PACKAGE_NAME = "q_cli"
 PTY_PACKAGE_NAME = "figterm"
 DESKTOP_PACKAGE_NAME = "fig_desktop"
+DESKTOP_FUZZ_PACKAGE_NAME = "fig_desktop-fuzz"
 
 DESKTOP_PACKAGE_PATH = pathlib.Path("crates", "fig_desktop")
 

--- a/build-scripts/test.py
+++ b/build-scripts/test.py
@@ -3,7 +3,7 @@ import os
 from typing import List, Mapping, Sequence
 from rust import cargo_cmd_name, rust_env
 from util import isLinux, run_cmd, get_variants, Variant
-from const import DESKTOP_PACKAGE_NAME
+from const import DESKTOP_FUZZ_PACKAGE_NAME, DESKTOP_PACKAGE_NAME
 
 
 def run_clippy(
@@ -53,7 +53,7 @@ def run_cargo_tests(
         args.extend(["--target", target])
 
     if Variant.FULL not in variants:
-        args.extend(["--exclude", DESKTOP_PACKAGE_NAME])
+        args.extend(["--exclude", DESKTOP_PACKAGE_NAME, "--exclude", DESKTOP_FUZZ_PACKAGE_NAME])
 
     if features:
         args.extend(
@@ -73,14 +73,15 @@ def run_cargo_tests(
 
     args = [cargo_cmd_name()]
 
-    args.extend(["test", "--locked", "--workspace"])
+    # Run all lib, bin, and integration tests. Required to exclude running doc tests.
+    args.extend(["test", "--locked", "--workspace", "--lib", "--bins", "--test", "*"])
 
     if target:
         args.extend(["--target", target])
 
     # disable desktop tests for now
     if isLinux():
-        args.extend(["--exclude", DESKTOP_PACKAGE_NAME])
+        args.extend(["--exclude", DESKTOP_PACKAGE_NAME, "--exclude", DESKTOP_FUZZ_PACKAGE_NAME])
 
     if features:
         args.extend(


### PR DESCRIPTION
*Description of changes:*
- Update the build script to not run doc tests. Can't just exclude doc tests alone so instead run all lib, binary, and integration tests.
  - Required for bypassing current issues with rust fmt and the smithy-generated amzn clients causing `cargo test` to fail. 
  - We don't rely on any doc tests in our application.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
