### PR TITLE
fix: accept text through pipes in chat

### DIFF
--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -20,9 +20,9 @@ use crossterm::style::{
 };
 use crossterm::{
     cursor,
-    style,
+    execute,
     queue,
-    execute
+    style,
 };
 use eyre::{
     Result,
@@ -127,7 +127,10 @@ async fn try_chat<W: Write>(output: &mut W, mut input: String, interactive: bool
                 queue!(output, style::SetForegroundColor(Color::Reset))?;
                 execute!(output, style::Print("\n"))?;
             } else if fig_settings::settings::get_bool_or("chat.greeting.enabled", true) {
-                execute!(output, style::Print(format!("
+                execute!(
+                    output,
+                    style::Print(format!(
+                        "
 Hi, I'm Amazon Q. I can answer questions about your shell and CLI tools!
 You can include additional context by adding the following to your prompt:
 
@@ -135,10 +138,11 @@ You can include additional context by adding the following to your prompt:
 {} to pass information about your current git repository
 {} to pass your shell environment
 ",
-                    "@history".bold(),
-                    "@git".bold(),
-                    "@env".bold()
-                )))?;
+                        "@history".bold(),
+                        "@git".bold(),
+                        "@env".bold()
+                    ))
+                )?;
             }
         }
 
@@ -194,19 +198,24 @@ You can include additional context by adding the following to your prompt:
 
                                 match error {
                                     Some(error) => {
-                                        queue!(output,
+                                        queue!(
+                                            output,
                                             style::SetForegroundColor(Color::Red),
                                             style::SetAttribute(Attribute::Bold),
                                             style::Print("error"),
                                             style::SetForegroundColor(Color::Reset),
                                             style::SetAttribute(Attribute::Reset),
-                                            style::Print(format!(": {error}\n")))?;
-                                        }
+                                            style::Print(format!(": {error}\n"))
+                                        )?;
+                                    },
                                     None => {
-                                        queue!(output, style::Print(
-                                            "Amazon Q is having trouble responding right now. Try again later.",
-                                        ))?;
-                                    }
+                                        queue!(
+                                            output,
+                                            style::Print(
+                                                "Amazon Q is having trouble responding right now. Try again later.",
+                                            )
+                                        )?;
+                                    },
                                 };
                             }
 
@@ -224,10 +233,12 @@ You can include additional context by adding the following to your prompt:
 
                 if !buf.is_empty() && interactive {
                     _spinner = None;
-                    queue!(output, 
+                    queue!(
+                        output,
                         crossterm::terminal::Clear(crossterm::terminal::ClearType::CurrentLine),
                         cursor::MoveToColumn(0),
-                        cursor::Show)?;
+                        cursor::Show
+                    )?;
                 }
 
                 loop {
@@ -252,17 +263,22 @@ You can include additional context by adding the following to your prompt:
 
                 if ended {
                     if interactive {
-                        queue!(output,
+                        queue!(
+                            output,
                             style::ResetColor,
                             style::SetAttribute(Attribute::Reset),
-                            Print("\n"))?;
+                            Print("\n")
+                        )?;
 
                         for (i, citation) in &state.citations {
-                            queue!(output, style::SetForegroundColor(Color::Blue),
+                            queue!(
+                                output,
+                                style::SetForegroundColor(Color::Blue),
                                 style::Print(format!("{i} ")),
                                 style::SetForegroundColor(Color::DarkGrey),
                                 style::Print(format!("{citation}\n")),
-                                style::SetForegroundColor(Color::Reset))?;
+                                style::SetForegroundColor(Color::Reset)
+                            )?;
                         }
 
                         if !state.citations.is_empty() {

--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -3,8 +3,10 @@ mod parse;
 mod prompt;
 
 use std::io::{
+    IsTerminal,
     Stderr,
     Write,
+    Read,
     stderr,
     stdin,
 };
@@ -74,7 +76,7 @@ pub async fn chat(mut input: String) -> Result<ExitCode> {
     let is_piped = !stdin.is_terminal();
     if is_piped {
         // append to input string any extra info that was provided.
-        stdin.lock().read_to_string(&mut input).unwrap()
+        stdin.lock().read_to_string(&mut input).unwrap();
     }
     let result = try_chat(&mut stderr, input).await;
 

--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -48,7 +48,6 @@ use self::parse::{
     ParseState,
     interpret_markdown,
 };
-use self::terminal::WriteOutput;
 use crate::util::region_check;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -78,10 +77,7 @@ pub async fn chat(mut input: String) -> Result<ExitCode> {
         stdin.lock().read_to_string(&mut input).unwrap();
     }
     let mut output = terminal::new(is_interactive);
-    let result = match output {
-        WriteOutput::Interactive(ref mut w) => try_chat(w, input).await,
-        WriteOutput::NonInteractive(ref mut w) => try_chat_and_output_all(w, input).await,
-    };
+    let result = try_chat(&mut output, input, is_interactive).await;
 
     if is_interactive {
         queue!(output, style::SetAttribute(Attribute::Reset), style::ResetColor).ok();
@@ -91,153 +87,70 @@ pub async fn chat(mut input: String) -> Result<ExitCode> {
     result.map(|_| ExitCode::SUCCESS)
 }
 
-async fn try_chat_and_output_all<W: Write>(output: &mut W, input: String) -> Result<()> {
-    let client = StreamingClient::new().await?;
-    let mut rx = None;
-    let mut conversation_id: Option<String> = None;
-    let mut message_id = None;
-
-    // Make request with input provided through pipe
-    if !input.is_empty() {
-        rx = Some(send_message(client.clone(), input.clone(), conversation_id.clone()).await?);
-    }
-
-    // Print response as we receive it
-    if let Some(rx) = &mut rx {
-        let mut buf = String::new();
-        let mut offset = 0;
-        let mut ended = false;
-
-        let columns = crossterm::terminal::window_size()?.columns.into();
-        let mut state = ParseState::new(columns);
-
-        loop {
-            if let Some(response) = rx.recv().await {
-                match response {
-                    ApiResponse::Text(content) => match buf.is_empty() {
-                        true => buf.push_str(content.trim_start()),
-                        false => buf.push_str(&content),
-                    },
-                    ApiResponse::ConversationId(id) => {
-                        if conversation_id.is_none() {
-                            fig_telemetry::send_start_chat(id.clone()).await;
-
-                            tokio::task::spawn(async move {
-                                tokio::signal::ctrl_c().await.unwrap();
-                                if let Some(conversation_id) = &conversation_id {
-                                    fig_telemetry::send_end_chat(conversation_id.clone()).await;
-                                    fig_telemetry::finish_telemetry().await;
-                                    #[allow(clippy::exit)]
-                                    std::process::exit(0);
-                                }
-                            });
-                        }
-
-                        conversation_id = Some(id);
-                    },
-                    ApiResponse::MessageId(id) => message_id = Some(id),
-                    ApiResponse::End | ApiResponse::Error(_) => {
-                        output.flush()?;
-                        ended = true;
-                    },
-                }
-            }
-
-            // this is a hack since otherwise the parser might report Incomplete with useful data
-            // still left in the buffer. I'm not sure how this is intended to be handled.
-            if ended {
-                buf.push('\n');
-            }
-
-            loop {
-                let input = Partial::new(&buf[offset..]);
-                // fresh reborrow required on output
-                match interpret_markdown(input, &mut *output, &mut state) {
-                    Ok(parsed) => {
-                        offset += parsed.offset_from(&input);
-                        output.flush()?;
-                        // output.lock().flush()?;
-                        state.newline = state.set_newline;
-                        state.set_newline = false;
-                    },
-                    Err(err) => match err.into_inner() {
-                        Some(err) => return Err(eyre!(err.to_string())),
-                        None => break, // Data was incomplete
-                    },
-                }
-
-                tokio::time::sleep(Duration::from_millis(2)).await;
-            }
-
-            if ended {
-                if let (Some(conversation_id), Some(message_id)) = (&conversation_id, &message_id) {
-                    fig_telemetry::send_chat_added_message(conversation_id.to_owned(), message_id.to_owned()).await;
-                }
-
-                break;
-            }
-        }
-    }
-    Ok(())
-}
-
-async fn try_chat<W: Write>(output: &mut W, mut input: String) -> Result<()> {
-    let mut rl = rl()?;
+async fn try_chat<W: Write>(output: &mut W, mut input: String, interactive: bool) -> Result<()> {
+    let mut rl = if interactive { Some(rl()?) } else { None };
     let client = StreamingClient::new().await?;
     let mut rx = None;
     let mut conversation_id: Option<String> = None;
     let mut message_id = None;
 
     loop {
-        // Make request with input
-        match input.trim() {
-            "exit" | "quit" => {
-                if let Some(conversation_id) = conversation_id {
-                    fig_telemetry::send_end_chat(conversation_id.clone()).await;
+        // Make request with input, otherwise used already provided buffer for input
+        if !interactive {
+            rx = Some(send_message(client.clone(), input.clone(), conversation_id.clone()).await?);
+        } else {
+            match input.trim() {
+                "exit" | "quit" => {
+                    if let Some(conversation_id) = conversation_id {
+                        fig_telemetry::send_end_chat(conversation_id.clone()).await;
+                    }
+                    return Ok(());
+                },
+                _ => (),
+            }
+
+            if !input.is_empty() {
+                queue!(output, style::SetForegroundColor(Color::Magenta))?;
+                if input.contains("@history") {
+                    queue!(output, style::Print("Using shell history\n"))?;
                 }
-                return Ok(());
-            },
-            _ => (),
-        }
 
-        if !input.is_empty() {
-            queue!(output, style::SetForegroundColor(Color::Magenta))?;
-            if input.contains("@history") {
-                queue!(output, style::Print("Using shell history\n"))?;
-            }
+                if input.contains("@git") {
+                    queue!(output, style::Print("Using git context\n"))?;
+                }
 
-            if input.contains("@git") {
-                queue!(output, style::Print("Using git context\n"))?;
-            }
+                if input.contains("@env") {
+                    queue!(output, style::Print("Using environment\n"))?;
+                }
 
-            if input.contains("@env") {
-                queue!(output, style::Print("Using environment\n"))?;
-            }
-
-            rx = Some(send_message(client.clone(), input, conversation_id.clone()).await?);
-            queue!(output, style::SetForegroundColor(Color::Reset))?;
-            execute!(output, style::Print("\n"))?;
-        } else if fig_settings::settings::get_bool_or("chat.greeting.enabled", true) {
-            execute!(output, style::Print(format!(
-                "
+                rx = Some(send_message(client.clone(), input.clone(), conversation_id.clone()).await?);
+                queue!(output, style::SetForegroundColor(Color::Reset))?;
+                execute!(output, style::Print("\n"))?;
+            } else if fig_settings::settings::get_bool_or("chat.greeting.enabled", true) {
+                execute!(output, style::Print(format!("
 Hi, I'm Amazon Q. I can answer questions about your shell and CLI tools!
 You can include additional context by adding the following to your prompt:
 
 {} to pass your shell history
 {} to pass information about your current git repository
 {} to pass your shell environment
-
 ",
-                "@history".bold(),
-                "@git".bold(),
-                "@env".bold()
-            )))?;
+                    "@history".bold(),
+                    "@git".bold(),
+                    "@env".bold()
+                )))?;
+            }
         }
 
         // Print response as we receive it
         if let Some(rx) = &mut rx {
-            queue!(output, cursor::Hide)?;
-            let mut spinner = Some(Spinner::new(Spinners::Dots, "Generating your answer...".to_owned()));
+            // compiler complains about unused variable for spinner (bad global state usage)
+            let mut _spinner = if interactive {
+                queue!(output, cursor::Hide)?;
+                Some(Spinner::new(Spinners::Dots, "Generating your answer...".to_owned()))
+            } else {
+                None
+            };
 
             let mut buf = String::new();
             let mut offset = 0;
@@ -275,25 +188,27 @@ You can include additional context by adding the following to your prompt:
                             ended = true;
                         },
                         ApiResponse::Error(error) => {
-                            drop(spinner.take());
-                            queue!(output, cursor::MoveToColumn(0))?;
+                            if interactive {
+                                _spinner = None;
+                                queue!(output, cursor::MoveToColumn(0))?;
 
-                            match error {
-                                Some(error) => {
-                                    queue!(output,
-                                        style::SetForegroundColor(Color::Red),
-                                        style::SetAttribute(Attribute::Bold),
-                                        style::Print("error"),
-                                        style::SetForegroundColor(Color::Reset),
-                                        style::SetAttribute(Attribute::Reset),
-                                        style::Print(format!(": {error}\n")))?;
+                                match error {
+                                    Some(error) => {
+                                        queue!(output,
+                                            style::SetForegroundColor(Color::Red),
+                                            style::SetAttribute(Attribute::Bold),
+                                            style::Print("error"),
+                                            style::SetForegroundColor(Color::Reset),
+                                            style::SetAttribute(Attribute::Reset),
+                                            style::Print(format!(": {error}\n")))?;
+                                        }
+                                    None => {
+                                        queue!(output, style::Print(
+                                            "Amazon Q is having trouble responding right now. Try again later.",
+                                        ))?;
                                     }
-                                None => {
-                                    queue!(output, style::Print(
-                                        "Amazon Q is having trouble responding right now. Try again later.",
-                                    ))?;
-                                }
-                            };
+                                };
+                            }
 
                             output.flush()?;
                             ended = true;
@@ -307,7 +222,8 @@ You can include additional context by adding the following to your prompt:
                     buf.push('\n');
                 }
 
-                if !buf.is_empty() && spinner.take().is_some() {
+                if !buf.is_empty() && interactive {
+                    _spinner = None;
                     queue!(output, 
                         crossterm::terminal::Clear(crossterm::terminal::ClearType::CurrentLine),
                         cursor::MoveToColumn(0),
@@ -335,21 +251,23 @@ You can include additional context by adding the following to your prompt:
                 }
 
                 if ended {
-                    queue!(output,
-                        style::ResetColor,
-                        style::SetAttribute(Attribute::Reset),
-                        Print("\n"))?;
+                    if interactive {
+                        queue!(output,
+                            style::ResetColor,
+                            style::SetAttribute(Attribute::Reset),
+                            Print("\n"))?;
 
-                    for (i, citation) in &state.citations {
-                        queue!(output, style::SetForegroundColor(Color::Blue),
-                            style::Print(format!("{i} ")),
-                            style::SetForegroundColor(Color::DarkGrey),
-                            style::Print(format!("{citation}\n")),
-                            style::SetForegroundColor(Color::Reset))?;
-                    }
+                        for (i, citation) in &state.citations {
+                            queue!(output, style::SetForegroundColor(Color::Blue),
+                                style::Print(format!("{i} ")),
+                                style::SetForegroundColor(Color::DarkGrey),
+                                style::Print(format!("{citation}\n")),
+                                style::SetForegroundColor(Color::Reset))?;
+                        }
 
-                    if !state.citations.is_empty() {
-                        execute!(output, Print("\n"))?;
+                        if !state.citations.is_empty() {
+                            execute!(output, Print("\n"))?;
+                        }
                     }
 
                     if let (Some(conversation_id), Some(message_id)) = (&conversation_id, &message_id) {
@@ -361,14 +279,17 @@ You can include additional context by adding the following to your prompt:
             }
         }
 
+        if !interactive {
+            break Ok(());
+        }
         loop {
-            let readline = rl.readline(PROMPT);
+            let readline = rl.as_mut().unwrap().readline(PROMPT);
             match readline {
                 Ok(line) => {
                     if line.trim().is_empty() {
                         continue;
                     }
-                    let _ = rl.add_history_entry(line.as_str());
+                    let _ = rl.as_mut().unwrap().add_history_entry(line.as_str());
                     input = line;
                     break;
                 },

--- a/crates/q_cli/src/cli/chat/terminal.rs
+++ b/crates/q_cli/src/cli/chat/terminal.rs
@@ -1,0 +1,35 @@
+use std::io::{
+    Stderr,
+    Stdout,
+    Write,
+};
+
+pub enum WriteOutput {
+    Interactive(Stderr),
+    NonInteractive(Stdout)
+}
+
+// wraps the stderr/stdout handle with a enum type.
+pub fn new(is_interactive: bool) -> WriteOutput {
+    if is_interactive {
+        WriteOutput::Interactive(std::io::stderr())
+    } else {
+        WriteOutput::NonInteractive(std::io::stdout())
+    }
+}
+
+impl Write for WriteOutput {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match self {
+            WriteOutput::Interactive(stderr) => stderr.write(buf),
+            WriteOutput::NonInteractive(stdout) => stdout.write(buf),
+        }
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            WriteOutput::Interactive(stderr) => stderr.flush(),
+            WriteOutput::NonInteractive(stdout) => stdout.flush(),
+        }
+    }
+}
+

--- a/crates/q_cli/src/cli/chat/terminal.rs
+++ b/crates/q_cli/src/cli/chat/terminal.rs
@@ -6,7 +6,7 @@ use std::io::{
 
 pub enum WriteOutput {
     Interactive(Stderr),
-    NonInteractive(Stdout)
+    NonInteractive(Stdout),
 }
 
 // wraps the stderr/stdout handle with a enum type.
@@ -25,6 +25,7 @@ impl Write for WriteOutput {
             WriteOutput::NonInteractive(stdout) => stdout.write(buf),
         }
     }
+
     fn flush(&mut self) -> std::io::Result<()> {
         match self {
             WriteOutput::Interactive(stderr) => stderr.flush(),
@@ -32,4 +33,3 @@ impl Write for WriteOutput {
         }
     }
 }
-


### PR DESCRIPTION
For the `q chat` command, also allow piping text into the q chat command.

*Issue #, if available:*
#258 
*Description of changes:*
Similarly to `smartcat`, check if we're piping text, if so, then the chat input will be fetched from the stdin.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.