### PR TITLE
fix: improve terminal detection on Linux

### DIFF
--- a/crates/fig_desktop/src/platform/linux/ibus.rs
+++ b/crates/fig_desktop/src/platform/linux/ibus.rs
@@ -80,10 +80,13 @@ pub async fn launch_ibus_connection(proxy: EventLoopProxy, platform_state: Arc<P
                                     active_input_contexts.remove(path.as_str());
                                 },
                                 "SetCursorLocation" => {
-                                    if !active_input_contexts.contains(path.as_str()) {
+                                    if !active_input_contexts.contains(path.as_str())
+                                        || platform_state.active_terminal.lock().is_none()
+                                    {
                                         debug!("SetCursorLocation rejected on {}", path.as_str());
                                         continue;
                                     }
+
                                     let body = match msg.body().deserialize::<(i32, i32, i32, i32)>() {
                                         Ok(body) => body,
                                         Err(err) => {

--- a/crates/fig_util/src/terminal.rs
+++ b/crates/fig_util/src/terminal.rs
@@ -464,12 +464,14 @@ impl Terminal {
         }
     }
 
+    /// Returns the "Class" part of the WM_CLASS property.
     pub fn wm_class(&self) -> Option<&'static str> {
         match self {
             Terminal::VSCode => Some("Code"),
             Terminal::VSCodeInsiders => Some("Vscode-insiders"),
             Terminal::GnomeConsole => Some("Kgx"),
             Terminal::GnomeTerminal => Some("Gnome-terminal"),
+            Terminal::Guake => Some("Guake"),
             Terminal::Hyper => Some("Hyper"),
             Terminal::Konsole => Some("konsole"),
             Terminal::Tilix => Some("Tilix"),
@@ -485,22 +487,18 @@ impl Terminal {
         }
     }
 
-    // corresponds to GSE source type
-    pub fn gnome_id(&self) -> Option<&'static str> {
+    /// Returns the "Instance" part of the WM_CLASS property.
+    pub fn wm_class_instance(&self) -> Option<&'static str> {
         match self {
-            // Terminal::Vscode => Some("Code"),
-            // Terminal::VSCodeInsiders => Some("Code - Insiders"),
+            Terminal::GnomeConsole => Some("org.gnome.Console"),
             Terminal::GnomeTerminal => Some("gnome-terminal-server"),
-            // Terminal::Konsole => Some("org.kde.konsole"),
-            Terminal::Tilix => Some("tilix"),
-            Terminal::Alacritty => Some("Alacritty"),
-            Terminal::Kitty => Some("kitty"),
-            Terminal::XfceTerminal => Some("xfce4-terminal"),
+            Terminal::Guake => Some("guake"),
+            Terminal::Hyper => Some("hyper"),
             Terminal::Terminator => Some("terminator"),
-            // Terminal::Terminology => Some("terminology"),
-            // Terminal::WezTerm => Some("org.wezfurlong.wezterm"),
-            // Terminal::Tabby => Some("tabby"),
-            _ => None,
+            Terminal::Tilix => Some("tilix"),
+            // Many terminals seem to use the same name for both, falling back to Class name
+            // as a default.
+            _ => self.wm_class(),
         }
     }
 

--- a/extensions/gnome-extension/src/extension.ts
+++ b/extensions/gnome-extension/src/extension.ts
@@ -701,6 +701,7 @@ export default class QCliExtension extends Extension {
    * @param {boolean} overlay_pressed
    */
   #send_window_data(overlay_pressed) {
+    // Mutter populates wm class/instance with the app_id on Wayland.
     const wm_class = this.#window.get_wm_class();
     // https://mutter.gnome.org/meta/method.Window.get_frame_rect.html
     const inner_rect = this.#window.get_frame_rect();

--- a/extensions/gnome-legacy-extension/src/extension.js
+++ b/extensions/gnome-legacy-extension/src/extension.js
@@ -727,6 +727,7 @@ class Extension extends GObject.Object {
    * @param {boolean} overlay_pressed
    */
   #send_window_data(overlay_pressed) {
+    // Mutter populates wm class/instance will the app_id on Wayland.
     const wm_class = this.#window.get_wm_class();
     // https://mutter.gnome.org/meta/method.Window.get_frame_rect.html
     const inner_rect = this.#window.get_frame_rect();


### PR DESCRIPTION
*Description of changes:*
- Improves terminal detection on Linux by updating the active terminal state whenever we receive notifications from Xorg or the GNOME Shell extension. This is required for Guake support, and should fix some other flaky edge cases as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
