### PR TITLE
fix(macos-utils): remove redundant `fn main` line

### DIFF
--- a/crates/macos-utils/accessibility-master/aq/src/main.rs
+++ b/crates/macos-utils/accessibility-master/aq/src/main.rs
@@ -64,8 +64,6 @@ pub struct Opt {
 }
 
 fn main() -> Result<(), i32> {
-
-fn main() -> Result<(), i32> {
     let opt = Opt::from_args();
     let app = AXUIElement::application(opt.pid);
     let printy = PrintyBoi::new_with_indentation(4);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
