### PR TITLE
ci: add registry-url and provenance to npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   publish:
@@ -24,9 +25,11 @@ jobs:
         with:
           node-version-file: package.json
           cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
       - name: Install npm dependencies
         run: pnpm install --frozen-lockfile
       - run: pnpm build
-      - run: pnpm publish --recursive
+      - run: pnpm publish --recursive --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
*Description of changes:*
The first attempt at running the action failed, this update applies some of the config from here: https://docs.npmjs.com/generating-provenance-statements#example-github-actions-workflow

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
