### PR TITLE
docs: update README for mise installation and rustup command correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ brew install rtx pnpm protobuf zsh bash fish shellcheck jq
 
 ```shell
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-rustup toolchain default stable
+rustup default stable
 # for pre-commit hooks the two following commands are required
 rustup toolchain install nightly
 cargo install typos-cli
@@ -107,7 +107,13 @@ rustup target add x86_64-apple-darwin
 rustup target add aarch64-apple-darwin
 ```
 
-### 3. Setup Python and Node using [`rtx`](https://mise.jdx.dev)
+### 3. Setup Python and Node using [`mise`](https://mise.jdx.dev)
+
+Install mise
+
+```shell
+curl https://mise.run | sh
+```
 
 Add mise integrations to your shell shell
 
@@ -125,6 +131,7 @@ echo 'mise activate fish | source' >> ~/.config/fish/config.fish
 Install the Python and Node toolchains using:
 
 ```shell
+mise trust
 mise install
 ```
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ For MacOS:
 
 ```shell
 xcode-select --install
-brew install rtx pnpm protobuf zsh bash fish shellcheck jq
+brew install mise pnpm protobuf zsh bash fish shellcheck jq
 ```
 
 ### 2. Install Rust toolchain using [Rustup](https://rustup.rs):
@@ -108,12 +108,6 @@ rustup target add aarch64-apple-darwin
 ```
 
 ### 3. Setup Python and Node using [`mise`](https://mise.jdx.dev)
-
-Install mise
-
-```shell
-curl https://mise.run | sh
-```
 
 Add mise integrations to your shell shell
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
discovered some issues while setting up 

- Fix Rust command: `rustup toolchain default stable` → `rustup default stable`
- Update rtx → mise references (tool was renamed)
- Add missing mise installation steps


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
