### PR TITLE
fix: build config on Ubuntu

### DIFF
--- a/build-config/buildspec-linux-ubuntu.yml
+++ b/build-config/buildspec-linux-ubuntu.yml
@@ -30,7 +30,7 @@ phases:
       # Download version of pnpm configured in package.json.
       # Note that we download from the pnpm install script instead of corepack
       # since corepack is broken in codebuild for some reason.
-      - curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=$(jq -r '.packageManager' package.json | cut -d@ -f2) SHELL=$(which bash) sh -
+      - curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=$(jq -r '.packageManager' package.json | cut -d@ -f2 | cut -d+ -f1) SHELL=$(which bash) sh -
       - . "$HOME/.bashrc"
       # Install python deps
       - pip3 install -r build-scripts/requirements.txt


### PR DESCRIPTION
*Description of changes:*
- `pnpm` is failing to download because the version configured in the package.json includes a `+sha` suffix. Therefore, extracting only the version.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
