### PR TITLE
fix: Increase sleep time in fig_test_utils server test

### DIFF
--- a/crates/fig_test_utils/src/server.rs
+++ b/crates/fig_test_utils/src/server.rs
@@ -169,7 +169,7 @@ mod tests {
         let addr = test_server_addr.address();
         std::mem::drop(test_server_addr);
         // wait for the task to complete
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         let response = reqwest::get(format!("http://{}{}", &addr, &test_path)).await;
         assert!(response.is_err());
     }


### PR DESCRIPTION
*Description of changes:*
- The `fig_test_utils` crate contains a test that verifies that a local server is stopped once the variable owning the value is dropped. This seems to be flaky since we need to wait some time for the OS to release it, therefore just increasing the timeout.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
