### PR TITLE
fix: validate FileContext limits

### DIFF
--- a/crates/fig_api_client/src/clients/mod.rs
+++ b/crates/fig_api_client/src/clients/mod.rs
@@ -2,5 +2,10 @@ mod client;
 mod shared;
 mod streaming_client;
 
-pub use client::Client;
+pub use client::{
+    Client,
+    FILE_CONTEXT_FILE_NAME_MAX_LEN,
+    FILE_CONTEXT_LEFT_FILE_CONTENT_MAX_LEN,
+    FILE_CONTEXT_RIGHT_FILE_CONTENT_MAX_LEN,
+};
 pub use streaming_client::StreamingClient;

--- a/crates/fig_api_client/src/error.rs
+++ b/crates/fig_api_client/src/error.rs
@@ -49,6 +49,13 @@ pub enum Error {
 
     #[error("unsupported action by consolas: {0}")]
     UnsupportedConsolas(&'static str),
+
+    #[error("validation error: {} must be at least {} characters and at most {} characters", .field, .min_size, .max_length)]
+    LengthValidation {
+        field: &'static str,
+        min_size: usize,
+        max_length: usize,
+    },
 }
 
 impl Error {
@@ -66,7 +73,8 @@ impl Error {
             Error::CodewhispererChatResponseStream(_)
             | Error::QDeveloperChatResponseStream(_)
             | Error::SmithyBuild(_)
-            | Error::UnsupportedConsolas(_) => false,
+            | Error::UnsupportedConsolas(_)
+            | Error::LengthValidation { .. } => false,
         }
     }
 
@@ -82,7 +90,8 @@ impl Error {
             Error::CodewhispererChatResponseStream(_)
             | Error::QDeveloperChatResponseStream(_)
             | Error::SmithyBuild(_)
-            | Error::UnsupportedConsolas(_) => false,
+            | Error::UnsupportedConsolas(_)
+            | Error::LengthValidation { .. } => false,
         }
     }
 }

--- a/crates/fig_api_client/src/lib.rs
+++ b/crates/fig_api_client/src/lib.rs
@@ -1,4 +1,4 @@
-pub(crate) mod clients;
+pub mod clients;
 pub(crate) mod consts;
 pub(crate) mod credentials;
 mod customization;
@@ -6,7 +6,6 @@ mod endpoints;
 mod error;
 pub(crate) mod interceptor;
 pub mod model;
-// mod stage;
 
 pub use clients::{
     Client,


### PR DESCRIPTION
*Description of changes:*
This PR adds validation of the max length of the FileContext fields.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
