### PR TITLE
chore: add ghostty terminal support wording

### DIFF
--- a/packages/dashboard-app/src/pages/settings/integrations.tsx
+++ b/packages/dashboard-app/src/pages/settings/integrations.tsx
@@ -18,7 +18,7 @@ export default function Page() {
             Beta
           </span>
           <span className="leading-none">
-            Want support for JetBrains, Alacritty, and Kitty?
+            Want support for JetBrains, Alacritty, Kitty, and Ghostty?
           </span>
         </h2>
         <p>{parseBackticksToCode(setupString)}</p>


### PR DESCRIPTION
*Description of changes:*
While I was setting up my terminal with the amazon-q, I didn't realize it supports Ghostty so added Ghostty wording specifically. https://github.com/aws/amazon-q-developer-cli/pull/335 
