### PR TITLE
Minor agentic tool type changes

### DIFF
--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -433,7 +433,7 @@ Hi, I'm <g>Amazon Q</g>. I can answer questions about your workspace and tooling
                 if let Some(ref id) = self.current_user_input_id {
                     event_builder.user_input_id = Some(id.clone());
                 }
-                match Tool::from_tool_use(tool_use) {
+                match Tool::try_from(tool_use) {
                     Ok(mut tool) => {
                         match tool.validate(&self.ctx).await {
                             Ok(()) => {
@@ -486,7 +486,7 @@ Hi, I'm <g>Amazon Q</g>. I can answer questions about your workspace and tooling
                 queue!(self.output, style::Print(format!(" {} ", tool.display_name())))?;
                 queue!(self.output, cursor::MoveToNextLine(1))?;
                 queue!(self.output, style::SetAttribute(Attribute::NormalIntensity))?;
-                tool.show_readable_intention(self.output)?;
+                tool.queue_description(self.output)?;
                 queue!(self.output, cursor::MoveToNextLine(1))?;
             }
             queue!(self.output, style::Print("─".repeat(terminal_width)))?;

--- a/crates/q_cli/src/cli/chat/tools/execute_bash.rs
+++ b/crates/q_cli/src/cli/chat/tools/execute_bash.rs
@@ -25,10 +25,6 @@ pub struct ExecuteBash {
 }
 
 impl ExecuteBash {
-    pub fn display_name() -> String {
-        "Execute Bash".to_owned()
-    }
-
     pub async fn invoke(&self, mut updates: impl Write) -> Result<InvokeOutput> {
         queue!(
             updates,
@@ -60,10 +56,10 @@ impl ExecuteBash {
         })
     }
 
-    pub fn show_readable_intention(&self, updates: &mut impl Write) -> Result<()> {
+    pub fn queue_description(&self, updates: &mut impl Write) -> Result<()> {
         Ok(queue!(
             updates,
-            style::Print("Command: "),
+            style::Print("I will run the following command using your bash environment:\n"),
             style::SetForegroundColor(Color::Green),
             style::Print(&self.command),
             style::ResetColor,
@@ -71,6 +67,7 @@ impl ExecuteBash {
     }
 
     pub async fn validate(&mut self, _ctx: &Context) -> Result<()> {
+        // TODO: probably some small amount of PATH checking
         Ok(())
     }
 }

--- a/crates/q_cli/src/cli/chat/tools/fs_read.rs
+++ b/crates/q_cli/src/cli/chat/tools/fs_read.rs
@@ -43,10 +43,6 @@ impl FsRead {
         }
     }
 
-    pub fn display_name() -> String {
-        "File System Read".to_owned()
-    }
-
     pub async fn invoke(&self, ctx: &Context, updates: &mut impl Write) -> Result<InvokeOutput> {
         // Required for testing scenarios: since the path is passed directly as a command argument,
         // we need to pass it through the Context first.
@@ -162,7 +158,7 @@ impl FsRead {
         }
     }
 
-    pub fn show_readable_intention(&self, updates: &mut impl Write) -> Result<()> {
+    pub fn queue_description(&self, updates: &mut impl Write) -> Result<()> {
         let is_file = self.ty.expect("Tool needs to have been validated");
 
         if is_file {

--- a/crates/q_cli/src/cli/chat/tools/fs_write.rs
+++ b/crates/q_cli/src/cli/chat/tools/fs_write.rs
@@ -39,10 +39,6 @@ pub enum FsWrite {
 }
 
 impl FsWrite {
-    pub fn display_name() -> String {
-        "File System Write".to_owned()
-    }
-
     pub async fn invoke(&self, ctx: &Context, updates: &mut impl Write) -> Result<InvokeOutput> {
         let fs = ctx.fs();
         let cwd = ctx.env().current_dir()?;
@@ -114,7 +110,7 @@ impl FsWrite {
         }
     }
 
-    pub fn show_readable_intention(&self, updates: &mut impl Write) -> Result<()> {
+    pub fn queue_description(&self, updates: &mut impl Write) -> Result<()> {
         match self {
             FsWrite::Create { path, file_text } => Ok(queue!(
                 updates,

--- a/crates/q_cli/src/cli/chat/tools/use_aws.rs
+++ b/crates/q_cli/src/cli/chat/tools/use_aws.rs
@@ -57,10 +57,6 @@ impl UseAws {
         Err(AwsToolError::ForbiddenOperation(operation_name.clone()))
     }
 
-    pub fn display_name() -> String {
-        "Use AWS Readonly".to_owned()
-    }
-
     pub async fn invoke(&self, _ctx: &Context, _updates: impl Write) -> Result<InvokeOutput> {
         let mut command = tokio::process::Command::new("aws");
         command.envs(std::env::vars()).arg("--region").arg(&self.region);


### PR DESCRIPTION
- **feat: support for Trae (#488)**
- **feat: add Q_AUTOCOMPLETE_DISABLED env var (#563)**
- **fix: truncate FileContext to limits (#572)**
- **fix: Update amzn clients (#588)**
- **fix: add app version to user agent (#590)**
- **fix: flush telemetry events more often and rate limit (#606)**
- **chore: bump to 1.6.2 (#607)**
- **fix: remove unwrap in inline (#609)**
- **chore: bump to 1.6.3 (#610)**
- **feat: Agentic chat (#623)**
- **fix: display, use settings instead of state for api endpoint (#632)**
- **fix things**
- **make small changes to tool type**
