### PR TITLE
fix: outputs error when tool execution fails

### DIFF
--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -6,31 +6,68 @@ mod prompt;
 mod stdio;
 mod tools;
 use std::collections::HashMap;
-use std::io::{IsTerminal, Read, Write};
+use std::io::{
+    IsTerminal,
+    Read,
+    Write,
+};
 use std::process::ExitCode;
 use std::sync::Arc;
 
 use color_eyre::owo_colors::OwoColorize;
 use conversation_state::ConversationState;
-use crossterm::style::{Attribute, Color};
-use crossterm::{cursor, execute, queue, style, terminal};
-use eyre::{Result, bail};
+use crossterm::style::{
+    Attribute,
+    Color,
+};
+use crossterm::{
+    cursor,
+    execute,
+    queue,
+    style,
+    terminal,
+};
+use eyre::{
+    Result,
+    bail,
+};
 use fig_api_client::StreamingClient;
 use fig_api_client::clients::SendMessageOutput;
-use fig_api_client::model::{ChatResponseStream, ToolResult, ToolResultContentBlock, ToolResultStatus};
+use fig_api_client::model::{
+    ChatResponseStream,
+    ToolResult,
+    ToolResultContentBlock,
+    ToolResultStatus,
+};
 use fig_os_shim::Context;
 use fig_util::CLI_BINARY_NAME;
 use futures::StreamExt;
 use input_source::InputSource;
-use parser::{ResponseParser, ToolUse};
+use parser::{
+    ResponseParser,
+    ToolUse,
+};
 use serde_json::Map;
-use spinners::{Spinner, Spinners};
-use tools::{Tool, ToolSpec};
-use tracing::{debug, error, trace};
+use spinners::{
+    Spinner,
+    Spinners,
+};
+use tools::{
+    Tool,
+    ToolSpec,
+};
+use tracing::{
+    debug,
+    error,
+    trace,
+};
 use winnow::Partial;
 use winnow::stream::Offset;
 
-use crate::cli::chat::parse::{ParseState, interpret_markdown};
+use crate::cli::chat::parse::{
+    ParseState,
+    interpret_markdown,
+};
 use crate::util::region_check;
 
 const MAX_TOOL_USE_RECURSIONS: u32 = 50;

--- a/crates/q_cli/src/cli/chat/tools/use_aws.rs
+++ b/crates/q_cli/src/cli/chat/tools/use_aws.rs
@@ -87,13 +87,17 @@ impl UseAws {
         let stdout = output.stdout.to_str_lossy();
         let stderr = output.stderr.to_str_lossy();
 
-        Ok(InvokeOutput {
-            output: OutputKind::Json(serde_json::json!({
-                "exit_status": status,
-                "stdout": stdout,
-                "stderr": stderr
-            })),
-        })
+        if status.eq("0") {
+            Ok(InvokeOutput {
+                output: OutputKind::Json(serde_json::json!({
+                    "exit_status": status,
+                    "stdout": stdout,
+                    "stderr": stderr
+                })),
+            })
+        } else {
+            Err(eyre::eyre!(stderr.to_string()))
+        }
     }
 
     pub fn show_readable_intention(&self, updates: &mut impl Write) -> Result<()> {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Error case (with no validation):
<img width="797" alt="image" src="https://github.com/user-attachments/assets/1564b7e6-e49f-4e57-a4e8-03a595b8cdcf" />

Happy path:
<img width="796" alt="image" src="https://github.com/user-attachments/assets/8072383a-9d24-4fab-ae37-72b1a17e221c" />

Tested using the stub of: 
```json
[
    [
        "Let me use the `use_aws` tool to get your item.",
        {
            "tool_use_id": "1",
            "name": "use_aws",
            "args": {
              "service_name": "dynamodb",
              "operation_name": "get-item",
              "parameters": {
                  "--table-name": "AGI_MEMORY",
                  "--key": "{\"memory_id\": {\"S\": \"49d649c7-b772-4578-968c-c20240844a4a\"}}"
              },
              "region": "us-west-2",
              "profile_name": "default",
              "label": ""
            }
        }
    ],
    [
        "Hope that looks good to you!"
    ]
]

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
