### PR TITLE
fix: handles tool validation errors

### DIFF
--- a/crates/q_cli/src/cli/chat/tools/mod.rs
+++ b/crates/q_cli/src/cli/chat/tools/mod.rs
@@ -83,7 +83,7 @@ impl TryFrom<ToolUse> for Tool {
         let map_err = |parse_error| ToolResult {
             tool_use_id: value.id.clone(),
             content: vec![ToolResultContentBlock::Text(format!(
-                "failed to deserialize with the following error: {parse_error}"
+                "Failed to validate tool parameters: {parse_error}. The model has either suggested tool parameters which are incompatible with the existing tools, or has suggested one or more tool that does not exist in the list of known tools."
             ))],
             status: ToolResultStatus::Error,
         };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Client now televises tool validation error to users prior to sending associated feedback back to model

<img width="1959" alt="image" src="https://github.com/user-attachments/assets/bcc8740c-bbdb-41fe-ada0-a3a47c850883" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
