### PR TITLE
fix: deletes history on tool deny

### DIFF
--- a/crates/q_cli/src/cli/chat/conversation_state.rs
+++ b/crates/q_cli/src/cli/chat/conversation_state.rs
@@ -166,6 +166,36 @@ impl ConversationState {
         self.next_message = Some(msg);
     }
 
+    pub fn abandon_tool_use(&mut self, tools_to_be_abandoned: Vec<(String, super::tools::Tool)>, deny_input: String) {
+        let tool_results = tools_to_be_abandoned
+            .into_iter()
+            .map(|(tool_use_id, _)| ToolResult {
+                tool_use_id,
+                content: vec![ToolResultContentBlock::Text(
+                    "Tool use was cancelled by the user".to_string(),
+                )],
+                status: fig_api_client::model::ToolResultStatus::Error,
+            })
+            .collect::<Vec<_>>();
+        let user_input_message_context = UserInputMessageContext {
+            shell_state: None,
+            env_state: Some(build_env_state(None)),
+            tool_results: Some(tool_results),
+            tools: if self.tools.is_empty() {
+                None
+            } else {
+                Some(self.tools.clone())
+            },
+            ..Default::default()
+        };
+        let msg = Message(ChatMessage::UserInputMessage(UserInputMessage {
+            content: deny_input,
+            user_input_message_context: Some(user_input_message_context),
+            user_intent: None,
+        }));
+        self.next_message = Some(msg);
+    }
+
     /// Returns a [FigConversationState] capable of being sent by
     /// [fig_api_client::StreamingClient] while preparing the current conversation state to be sent
     /// in the next message.

--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -629,6 +629,21 @@ Hi, I'm <g>Amazon Q</g>. I can answer questions about your workspace and tooling
                     self.spinner = Some(Spinner::new(Spinners::Dots, "Thinking...".to_owned()));
                 }
 
+                let should_delete_history = self
+                    .conversation_state
+                    .history
+                    .back()
+                    .and_then(|last_msg| match &last_msg.0 {
+                        fig_api_client::model::ChatMessage::AssistantResponseMessage(msg) => Some(msg),
+                        fig_api_client::model::ChatMessage::UserInputMessage(_) => None,
+                    })
+                    .and_then(|msg| msg.tool_uses.as_ref())
+                    .is_some_and(|tool_use| !tool_use.is_empty());
+
+                if should_delete_history {
+                    self.conversation_state.history = std::collections::VecDeque::new();
+                }
+
                 self.conversation_state.append_new_user_message(user_input).await;
                 self.send_tool_use_telemetry().await;
                 Ok(Some(

--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -629,7 +629,7 @@ Hi, I'm <g>Amazon Q</g>. I can answer questions about your workspace and tooling
                     self.spinner = Some(Spinner::new(Spinners::Dots, "Thinking...".to_owned()));
                 }
 
-                let should_delete_history = self
+                let should_abandon_tool_use = self
                     .conversation_state
                     .history
                     .back()
@@ -640,11 +640,12 @@ Hi, I'm <g>Amazon Q</g>. I can answer questions about your workspace and tooling
                     .and_then(|msg| msg.tool_uses.as_ref())
                     .is_some_and(|tool_use| !tool_use.is_empty());
 
-                if should_delete_history {
-                    self.conversation_state.history = std::collections::VecDeque::new();
+                if should_abandon_tool_use {
+                    self.conversation_state.abandon_tool_use(queued_tools, user_input);
+                } else {
+                    self.conversation_state.append_new_user_message(user_input).await;
                 }
 
-                self.conversation_state.append_new_user_message(user_input).await;
                 self.send_tool_use_telemetry().await;
                 Ok(Some(
                     self.client


### PR DESCRIPTION
*Issue #, if available:*
- At the time of writing, backend will return ISE if user denies tool use request. 
- This is rectified by deleting the convo history prior to sending a new message. 

*Description of changes:*
- Deletes convo history on tool deny

<img width="934" alt="image" src="https://github.com/user-attachments/assets/2d17a64b-4c9e-4bc8-9ef1-1a1b8f7e7e2a" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
