### PR TITLE
fix: allow user to retry on non-client error

### DIFF
--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -245,7 +245,9 @@ Hi, I'm <g>Amazon Q</g>. Ask me anything.
                             style::SetForegroundColor(Color::Reset),
                             style::SetAttribute(Attribute::Reset),
                         )?;
-                        self.conversation_state.history.pop_back();
+                        if self.conversation_state.next_message.is_none() {
+                            self.conversation_state.history.pop_back();
+                        }
                         continue;
                     },
                 }
@@ -322,7 +324,9 @@ Hi, I'm <g>Amazon Q</g>. Ask me anything.
                             style::SetForegroundColor(Color::Reset),
                             style::SetAttribute(Attribute::Reset),
                         )?;
-                        self.conversation_state.history.pop_back();
+                        if self.conversation_state.next_message.is_none() {
+                            self.conversation_state.history.pop_back();
+                        }
                         break;
                     },
                 }

--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -315,7 +315,10 @@ Hi, I'm <g>Amazon Q</g>. Ask me anything.
                             self.output,
                             style::SetAttribute(Attribute::Bold),
                             style::SetForegroundColor(Color::Red),
-                            style::Print(format!("We're having trouble responding right now, please try again later: {:?}", err)),
+                            style::Print(format!(
+                                "We're having trouble responding right now, please try again later: {:?}",
+                                err
+                            )),
                             style::SetForegroundColor(Color::Reset),
                             style::SetAttribute(Attribute::Reset),
                         )?;

--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -221,7 +221,35 @@ Hi, I'm <g>Amazon Q</g>. Ask me anything.
         }
 
         loop {
-            let mut response = self.prompt_and_send_request().await?;
+            let mut response = loop {
+                match self.prompt_and_send_request().await {
+                    Ok(resp) => {
+                        break resp;
+                    },
+                    Err(e) => {
+                        if self.is_interactive && self.spinner.is_some() {
+                            drop(self.spinner.take());
+                            queue!(
+                                self.output,
+                                terminal::Clear(terminal::ClearType::CurrentLine),
+                                cursor::MoveToColumn(0),
+                                cursor::Show
+                            )?;
+                        }
+                        execute!(
+                            self.output,
+                            style::SetAttribute(Attribute::Bold),
+                            style::SetForegroundColor(Color::Red),
+                            style::Print(format!("Amazon Q is having trouble responding right now: {:?}\n", e)),
+                            style::Print("Please try again later.\n"),
+                            style::SetForegroundColor(Color::Reset),
+                            style::SetAttribute(Attribute::Reset),
+                        )?;
+                        self.conversation_state.history.pop_back();
+                        continue;
+                    },
+                }
+            };
             let response = match response.take() {
                 Some(response) => response,
                 None => {
@@ -274,10 +302,25 @@ Hi, I'm <g>Amazon Q</g>. Ask me anything.
                         };
                     },
                     Err(err) => {
-                        bail!(
-                            "We're having trouble responding right now, please try again later: {:?}",
-                            err
-                        );
+                        if self.is_interactive && self.spinner.is_some() {
+                            drop(self.spinner.take());
+                            queue!(
+                                self.output,
+                                terminal::Clear(terminal::ClearType::CurrentLine),
+                                cursor::MoveToColumn(0),
+                                cursor::Show
+                            )?;
+                        }
+                        execute!(
+                            self.output,
+                            style::SetAttribute(Attribute::Bold),
+                            style::SetForegroundColor(Color::Red),
+                            style::Print(format!("We're having trouble responding right now, please try again later: {:?}", err)),
+                            style::SetForegroundColor(Color::Reset),
+                            style::SetAttribute(Attribute::Reset),
+                        )?;
+                        self.conversation_state.history.pop_back();
+                        break;
                     },
                 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Retry path:
<img width="796" alt="image" src="https://github.com/user-attachments/assets/3c3bbbf2-7005-4e32-b09d-2d5b6e23acef" />

Happy path:
<img width="798" alt="image" src="https://github.com/user-attachments/assets/191766ba-594a-44d8-8d87-a7717a0e206a" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
