### PR TITLE
fix: various issues with display and bugs in chat

### DIFF
--- a/crates/q_cli/src/cli/chat/tools/execute_bash.rs
+++ b/crates/q_cli/src/cli/chat/tools/execute_bash.rs
@@ -72,19 +72,19 @@ impl ExecuteBash {
     }
 
     pub fn queue_description(&self, updates: &mut impl Write) -> Result<()> {
-        queue!(
-            updates,
-            style::Print("I will run the following shell command: "),
-            style::SetForegroundColor(Color::Green),
-            style::Print(&self.command),
-        )?;
+        queue!(updates, style::Print("I will run the following shell command: "),)?;
 
         // TODO: Could use graphemes for a better heuristic
         if self.command.len() > 20 {
             queue!(updates, style::Print("\n"),)?;
         }
 
-        Ok(queue!(updates, style::Print(&self.command), style::ResetColor)?)
+        Ok(queue!(
+            updates,
+            style::SetForegroundColor(Color::Green),
+            style::Print(&self.command),
+            style::ResetColor
+        )?)
     }
 
     pub async fn validate(&mut self, _ctx: &Context) -> Result<()> {

--- a/crates/q_cli/src/cli/chat/tools/fs_read.rs
+++ b/crates/q_cli/src/cli/chat/tools/fs_read.rs
@@ -88,7 +88,7 @@ impl FsRead {
                     style::Print("\n"),
                 )?;
 
-                let formatted = stylize_output_if_able(&path, file_contents.as_str(), Some(start + 1), None);
+                let formatted = stylize_output_if_able(ctx, &path, file_contents.as_str(), Some(start + 1), None);
                 queue!(updates, style::Print(formatted), style::ResetColor, style::Print("\n"))?;
                 return Ok(InvokeOutput {
                     output: OutputKind::Text(file_contents),
@@ -96,7 +96,7 @@ impl FsRead {
             }
 
             let file = ctx.fs().read_to_string(&path).await?;
-            let file_text = stylize_output_if_able(path, file.as_str(), None, None);
+            let file_text = stylize_output_if_able(ctx, path, file.as_str(), None, None);
             queue!(
                 updates,
                 style::SetForegroundColor(Color::Green),

--- a/crates/q_cli/src/cli/chat/tools/fs_write.rs
+++ b/crates/q_cli/src/cli/chat/tools/fs_write.rs
@@ -131,8 +131,8 @@ impl FsWrite {
                 )?;
                 if ctx.fs().exists(path) {
                     let prev = ctx.fs().read_to_string_sync(path)?;
-                    let prev = stylize_output_if_able(&relative_path, prev.as_str(), None, Some("-"));
-                    let new = stylize_output_if_able(&relative_path, file_text, None, Some("+"));
+                    let prev = stylize_output_if_able(ctx, &relative_path, prev.as_str(), None, Some("-"));
+                    let new = stylize_output_if_able(ctx, &relative_path, file_text, None, Some("+"));
                     queue!(
                         updates,
                         style::Print("Replacing:\n"),
@@ -145,7 +145,7 @@ impl FsWrite {
                         style::Print("\n\n")
                     )?;
                 } else {
-                    let file = stylize_output_if_able(&relative_path, file_text, None, None);
+                    let file = stylize_output_if_able(ctx, &relative_path, file_text, None, None);
                     queue!(
                         updates,
                         style::Print("Contents:\n"),
@@ -161,7 +161,7 @@ impl FsWrite {
                 new_str,
             } => {
                 let path = format_path(cwd, path);
-                let file = stylize_output_if_able(&path, new_str, Some(*insert_line), Some("+"));
+                let file = stylize_output_if_able(ctx, &path, new_str, Some(*insert_line), Some("+"));
                 queue!(
                     updates,
                     style::Print("Path: "),
@@ -182,8 +182,8 @@ impl FsWrite {
                     Some((start_line, end_line)) => (Some(start_line), Some(end_line)),
                     _ => (None, None),
                 };
-                let old_str = stylize_output_if_able(&path, old_str, start_line, Some("-"));
-                let new_str = stylize_output_if_able(&path, new_str, start_line, Some("+"));
+                let old_str = stylize_output_if_able(ctx, &path, old_str, start_line, Some("-"));
+                let new_str = stylize_output_if_able(ctx, &path, new_str, start_line, Some("+"));
                 queue!(
                     updates,
                     style::Print("Path: "),

--- a/crates/q_cli/src/cli/chat/tools/tool_index.json
+++ b/crates/q_cli/src/cli/chat/tools/tool_index.json
@@ -14,7 +14,7 @@
           "description": "Whether or not the command is interactive. Interactive commands like nano will overtake our conversation until exited. On exit, they will have produced no stderr or stdout."
         }
       },
-      "required": ["command"]
+      "required": ["command", "interactive"]
     }
   },
   {

--- a/crates/q_cli/tests/chat_response_stubs/fs_write_file_unknown.json
+++ b/crates/q_cli/tests/chat_response_stubs/fs_write_file_unknown.json
@@ -1,0 +1,38 @@
+[
+    [
+        "I will use the `fs_write` tool.",
+        {
+            "tool_use_id": "1",
+            "name": "fs_write",
+            "args": {
+                "command": "create",
+                "path": "stub_output/unknown",
+                "file_text": "#[derive(Debug, Clone, Copy)]\npub struct Vec3 {\n    pub x: f32,\n    pub y: f32,\n    pub z: f32,\n}\n\nimpl Vec3 {\n    pub fn new(x: f32, y: f32, z: f32) -> Self {\n        Vec3 { x, y, z }\n    }\n\n    pub fn min(&self, other: &Vec3) -> Vec3 {\n        Vec3 {\n            x: self.x.min(other.x),\n            y: self.y.min(other.y),\n            z: self.z.min(other.z),\n        }\n    }\n\n    pub fn max(&self, other: &Vec3) -> Vec3 {\n        Vec3 {\n            x: self.x.max(other.x),\n            y: self.y.max(other.y),\n            z: self.z.max(other.z),\n        }\n    }\n}\n\n#[derive(Debug)]\npub struct Ray {\n    pub origin: Vec3,\n    pub direction: Vec3,\n}\n\nimpl Ray {\n    pub fn new(origin: Vec3, direction: Vec3) -> Self {\n        Ray { origin, direction }\n    }\n}\n\n#[derive(Debug)]\npub struct Cube {\n    pub min: Vec3,\n    pub max: Vec3,\n}\n\nimpl Cube {\n    pub fn new(min: Vec3, max: Vec3) -> Self {\n        Cube { min, max }\n    }\n\n    // Returns (t_min, t_max) for intersection. If t_min > t_max, there is no intersection\n    pub fn intersect(&self, ray: &Ray) -> (f32, f32) {\n        let mut t_min = f32::NEG_INFINITY;\n        let mut t_max = f32::INFINITY;\n\n        // Check intersection with all three slabs\n        for i in 0..3 {\n            let (origin, direction) = match i {\n                0 => (ray.origin.x, ray.direction.x),\n                1 => (ray.origin.y, ray.direction.y),\n                2 => (ray.origin.z, ray.direction.z),\n                _ => unreachable!(),\n            };\n\n            let (min_val, max_val) = match i {\n                0 => (self.min.x, self.max.x),\n                1 => (self.min.y, self.max.y),\n                2 => (self.min.z, self.max.z),\n                _ => unreachable!(),\n            };\n\n            if direction.abs() < f32::EPSILON {\n                // Ray is parallel to slab. No hit if origin not within slab\n                if origin < min_val || origin > max_val {\n                    return (1.0, -1.0); // No intersection\n                }\n            } else {\n                // Compute intersection t value of ray with near and far plane of slab\n                let t1 = (min_val - origin) / direction;\n                let t2 = (max_val - origin) / direction;\n\n                // Make t1 be intersection with near plane, t2 with far plane\n                let (t1, t2) = if t1 > t2 { (t2, t1) } else { (t1, t2) };\n\n                // Update t_min and t_max\n                t_min = t_min.max(t1);\n                t_max = t_max.min(t2);\n\n                // Exit with no collision as soon as slab intersection becomes empty\n                if t_min > t_max {\n                    return (1.0, -1.0);\n                }\n            }\n        }\n\n        (t_min, t_max)\n    }\n}\n\n#[cfg(test)]\nmod tests {\n    use super::*;\n\n    #[test]\n    fn test_ray_cube_intersection() {\n        // Create a cube centered at origin with size 2\n        let cube = Cube::new(\n            Vec3::new(-1.0, -1.0, -1.0),\n            Vec3::new(1.0, 1.0, 1.0),\n        );\n\n        // Ray starting outside the cube and pointing towards it\n        let ray = Ray::new(\n            Vec3::new(-2.0, 0.0, 0.0),\n            Vec3::new(1.0, 0.0, 0.0),\n        );\n\n        let (t_min, t_max) = cube.intersect(&ray);\n        assert!(t_min <= t_max);\n        assert_eq!(t_min, 1.0); // Should hit at x = -1\n        assert_eq!(t_max, 3.0); // Should exit at x = 1\n\n        // Ray missing the cube\n        let ray_miss = Ray::new(\n            Vec3::new(-2.0, 2.0, 0.0),\n            Vec3::new(1.0, 0.0, 0.0),\n        );\n\n        let (t_min, t_max) = cube.intersect(&ray_miss);\n        assert!(t_min > t_max); // Indicates no intersection\n    }\n}\n\n"
+            }
+        }
+    ],
+    [
+        {
+            "tool_use_id": "2",
+            "name": "fs_write",
+            "args": {
+                "command": "insert",
+                "path": "stub_output/unknown",
+                "insert_line": 1,
+                "new_str": "use std::os::env;\n\n"
+            }
+        }
+    ],
+    [
+        {
+            "tool_use_id": "3",
+            "name": "fs_write",
+            "args": {
+                "command": "str_replace",
+                "path": "stub_output/unknown",
+                "old_str": "        // Ray missing the cube\n        let ray_miss = Ray::new(\n            Vec3::new(-2.0, 2.0, 0.0),\n            Vec3::new(1.0, 0.0, 0.0),\n        );\n\n",
+                "new_str": "        if ray.has_more_data() {\n            bail!(\"Unexpected more data\");\n        }\n\n\n"
+            }
+        }
+    ]
+]


### PR DESCRIPTION
*Description of changes:*
- Add timing to tool execution, and some extra display demarcation
- don't add syntax highlighting if the terminal does not support 24bit colors
- make "interactive" a required field in `execute_bash`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
