### PR TITLE
fix: Make the execute_bash interactive field an Option

### DIFF
--- a/crates/q_cli/src/cli/chat/tools/execute_bash.rs
+++ b/crates/q_cli/src/cli/chat/tools/execute_bash.rs
@@ -25,7 +25,7 @@ use super::{
 #[derive(Debug, Deserialize)]
 pub struct ExecuteBash {
     pub command: String,
-    pub interactive: bool,
+    pub interactive: Option<bool>,
 }
 
 impl ExecuteBash {
@@ -39,8 +39,8 @@ impl ExecuteBash {
         )?;
 
         let (stdin, stdout, stderr) = match self.interactive {
-            true => (Stdio::inherit(), Stdio::inherit(), Stdio::inherit()),
-            false => (Stdio::piped(), Stdio::piped(), Stdio::piped()),
+            Some(true) => (Stdio::inherit(), Stdio::inherit(), Stdio::inherit()),
+            _ => (Stdio::piped(), Stdio::piped(), Stdio::piped()),
         };
 
         let output = tokio::process::Command::new("bash")
@@ -58,7 +58,7 @@ impl ExecuteBash {
         let stdout = output.stdout.to_str_lossy();
         let stderr = output.stderr.to_str_lossy();
 
-        if !self.interactive {
+        if let Some(false) = self.interactive {
             execute!(updates, style::Print(&stdout))?;
         }
 


### PR DESCRIPTION
*Description of changes:*
- Making the `interactive` field an option in rust, since I encountered one edge case where it still seemed to fail validation. This shouldn't be required but is added just as an extra precaution.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
