### PR TITLE
feat: add env var to skip tool use consent, other minor changes

### DIFF
--- a/crates/q_cli/src/cli/chat/tools/tool_index.json
+++ b/crates/q_cli/src/cli/chat/tools/tool_index.json
@@ -81,7 +81,7 @@
       "properties": {
         "service_name": {
           "type": "string",
-          "description": "The name of the AWS service."
+          "description": "The name of the AWS service. If you want to query s3, you should use s3api if possible."
         },
         "operation_name": {
           "type": "string",


### PR DESCRIPTION
*Description of changes:*
- Adding an env var `Q_CHAT_SKIP_TOOL_CONSENT` to automatically consent to a tool use if set.
- Updating the aws spec to prefer `s3api` over `s3`, since the model seems to generate operations using the `s3api` format and yet still use the `s3` command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
