### PR TITLE
feat: add /clear command, fix use_aws parameters bug, add tilde expansion, minor fixes

### DIFF
--- a/crates/q_cli/src/cli/chat/conversation_state.rs
+++ b/crates/q_cli/src/cli/chat/conversation_state.rs
@@ -94,6 +94,12 @@ impl ConversationState {
         }
     }
 
+    /// Clears the conversation history.
+    pub fn clear(&mut self) {
+        self.next_message = None;
+        self.history.clear();
+    }
+
     pub async fn append_new_user_message(&mut self, input: String) {
         debug_assert!(self.next_message.is_none(), "next_message should not exist");
         if let Some(next_message) = self.next_message.as_ref() {

--- a/crates/q_cli/src/cli/chat/prompt.rs
+++ b/crates/q_cli/src/cli/chat/prompt.rs
@@ -23,6 +23,7 @@ use rustyline::{
 use winnow::stream::AsChar;
 
 const MODIFIERS: &[&str] = &["@history", "@git", "@env"];
+const COMMANDS: &[&str] = &["/clear"];
 
 pub struct ChatCompleater {}
 
@@ -46,6 +47,12 @@ impl Completer for ChatCompleater {
             start,
             if word.starts_with('@') {
                 MODIFIERS
+                    .iter()
+                    .filter(|p| p.starts_with(word))
+                    .map(|s| (*s).to_owned())
+                    .collect()
+            } else if word.starts_with('/') {
+                COMMANDS
                     .iter()
                     .filter(|p| p.starts_with(word))
                     .map(|s| (*s).to_owned())

--- a/crates/q_cli/src/cli/chat/tools/use_aws.rs
+++ b/crates/q_cli/src/cli/chat/tools/use_aws.rs
@@ -66,6 +66,8 @@ impl UseAws {
         command.arg(&self.service_name).arg(&self.operation_name);
         if let Some(parameters) = &self.parameters {
             for (param_name, val) in parameters {
+                // Model might sometimes give parameters capitalized.
+                let param_name = param_name.to_lowercase();
                 if param_name.starts_with("--") {
                     command.arg(param_name).arg(val);
                 } else {


### PR DESCRIPTION
*Description of changes:*
- Adding the `/clear` command to clear conversation history. This is useful in the case where the state gets in a bad state where only InternalServerExceptions are created. This is done by looping in the main `prompt_and_send_request` function which caused a larger diff than usual.
- Add tilde expansion for path handling in `fs_read` and `fs_write`
- Fix a bug with `use_aws` where parameters are sometimes returned capitalized by the model. In this case, we always lowercase parameters.
- Don't prompt for consent on readonly commands. This is currently for all `fs_read` and `use_aws` tools.
- Other minor fixes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
