### PR TITLE
fix: response stream parser buffering assistant text until the end

### DIFF
--- a/crates/q_cli/src/cli/chat/parser.rs
+++ b/crates/q_cli/src/cli/chat/parser.rs
@@ -86,11 +86,10 @@ impl ResponseParser {
             self.next().await?;
             match self.peek().await? {
                 Some(ChatResponseStream::CodeReferenceEvent(_)) => (),
-                Some(_) => {
+                _ => {
                     self.assistant_text.push_str(&content);
                     return Ok(ResponseEvent::AssistantText(content));
                 },
-                None => (),
             }
         }
 

--- a/crates/q_cli/src/cli/chat/parser.rs
+++ b/crates/q_cli/src/cli/chat/parser.rs
@@ -52,10 +52,6 @@ pub struct ResponseParser {
     assistant_text: String,
     /// Tool uses requested by the model.
     tool_uses: Vec<ToolUse>,
-    /// Buffered line required in case we need to discard a code reference event
-    buffered_line: Option<String>,
-    /// Short circuit and return early since we simply need to clear our buffered line
-    short_circuit: bool,
     /// Whether or not we are currently receiving tool use delta events. Tuple of
     /// `Some((tool_use_id, name))` if true, [None] otherwise.
     parsing_tool_use: Option<(String, String)>,
@@ -69,31 +65,33 @@ impl ResponseParser {
             message_id: None,
             assistant_text: String::new(),
             tool_uses: Vec::new(),
-            buffered_line: None,
-            short_circuit: false,
             parsing_tool_use: None,
         }
     }
 
     /// Consumes the associated [ConverseStreamResponse] until a valid [ResponseEvent] is parsed.
     pub async fn recv(&mut self) -> Result<ResponseEvent> {
-        if self.short_circuit {
-            let message = Message(ChatMessage::AssistantResponseMessage(AssistantResponseMessage {
-                message_id: self.message_id.take(),
-                content: std::mem::take(&mut self.assistant_text),
-                tool_uses: if self.tool_uses.is_empty() {
-                    None
-                } else {
-                    Some(self.tool_uses.clone().into_iter().map(Into::into).collect())
-                },
-            }));
-            return Ok(ResponseEvent::EndStream { message });
-        }
-
         if let Some((id, name)) = self.parsing_tool_use.take() {
             let tool_use = self.parse_tool_use(id, name).await?;
             self.tool_uses.push(tool_use.clone());
             return Ok(ResponseEvent::ToolUse(tool_use));
+        }
+
+        // First, handle discarding AssistantResponseEvent's that immediately precede a
+        // CodeReferenceEvent.
+        let peek = self.peek().await?;
+        if let Some(ChatResponseStream::AssistantResponseEvent { content }) = peek {
+            // Cloning to bypass borrowchecker stuff.
+            let content = content.clone();
+            self.next().await?;
+            match self.peek().await? {
+                Some(ChatResponseStream::CodeReferenceEvent(_)) => (),
+                Some(_) => {
+                    self.assistant_text.push_str(&content);
+                    return Ok(ResponseEvent::AssistantText(content));
+                },
+                None => (),
+            }
         }
 
         loop {
@@ -101,14 +99,7 @@ impl ResponseParser {
                 Ok(Some(output)) => match output {
                     ChatResponseStream::AssistantResponseEvent { content } => {
                         self.assistant_text.push_str(&content);
-                        let text = self.buffered_line.take();
-                        self.buffered_line = Some(content);
-                        if let Some(text) = text {
-                            return Ok(ResponseEvent::AssistantText(text));
-                        }
-                    },
-                    ChatResponseStream::CodeReferenceEvent(_) => {
-                        self.buffered_line = None;
+                        return Ok(ResponseEvent::AssistantText(content));
                     },
                     ChatResponseStream::InvalidStateEvent { reason, message } => {
                         error!(%reason, %message, "invalid state event");
@@ -141,11 +132,6 @@ impl ResponseParser {
                     _ => {},
                 },
                 Ok(None) => {
-                    if let Some(text) = self.buffered_line.take() {
-                        self.short_circuit = true;
-                        return Ok(ResponseEvent::AssistantText(text));
-                    }
-
                     let message = Message(ChatMessage::AssistantResponseMessage(AssistantResponseMessage {
                         message_id: self.message_id.take(),
                         content: std::mem::take(&mut self.assistant_text),
@@ -248,6 +234,10 @@ mod tests {
             ChatResponseStream::AssistantResponseEvent {
                 content: " there".to_string(),
             },
+            ChatResponseStream::AssistantResponseEvent {
+                content: "IGNORE ME PLEASE".to_string(),
+            },
+            ChatResponseStream::CodeReferenceEvent(()),
             ChatResponseStream::ToolUseEvent {
                 tool_use_id: tool_use_id.clone(),
                 name: tool_name.clone(),


### PR DESCRIPTION
*Description of changes:*
- Fix the parser to not buffer assistant text until the end.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
