### PR TITLE
feat: allow mutative actions with use_aws

### DIFF
--- a/crates/q_cli/src/cli/chat/tools/mod.rs
+++ b/crates/q_cli/src/cli/chat/tools/mod.rs
@@ -63,7 +63,7 @@ impl Tool {
             Tool::FsRead(_) => "Read from filesystem",
             Tool::FsWrite(_) => "Write to filesystem",
             Tool::ExecuteBash(_) => "Execute shell command",
-            Tool::UseAws(_) => "Read AWS resources",
+            Tool::UseAws(_) => "Use AWS CLI",
         }
     }
 
@@ -73,7 +73,7 @@ impl Tool {
             Tool::FsRead(_) => false,
             Tool::FsWrite(_) => true,
             Tool::ExecuteBash(_) => true,
-            Tool::UseAws(_) => false,
+            Tool::UseAws(use_aws) => use_aws.requires_consent(),
         }
     }
 

--- a/crates/q_cli/src/cli/chat/tools/tool_index.json
+++ b/crates/q_cli/src/cli/chat/tools/tool_index.json
@@ -75,7 +75,7 @@
   },
   {
     "name": "use_aws",
-    "description": "Make an AWS CLI api call with the specified service, operation, and parameters. The arguments MUST conform to the AWS CLI specification. You may not create resources or perform any write or mutating actions. You may only use this tool to call read operations with names that start with: get, describe, list, search, batch_get.",
+    "description": "Make an AWS CLI api call with the specified service, operation, and parameters. The arguments MUST conform to the AWS CLI specification.",
     "input_schema": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
- Allowing mutative actions with `use_aws` tool uses. We require consent for any write actions, and otherwise immediately run read-only actions.