### PR TITLE
pops 2 messages at a time when truncating history

### DIFF
--- a/crates/q_cli/src/cli/chat/conversation_state.rs
+++ b/crates/q_cli/src/cli/chat/conversation_state.rs
@@ -223,6 +223,7 @@ impl ConversationState {
         assert!(self.next_message.is_some());
         while self.history.len() > MAX_CONVERSATION_STATE_HISTORY_LEN {
             self.history.pop_front();
+            self.history.pop_front();
         }
 
         // The current state we want to send


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We need to ensure the history sent to the model always starts with user input. Therefore when truncating history, we need to do it in pairs. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
