### PR TITLE
fix: remove two events from history at a time

### DIFF
--- a/crates/q_cli/src/cli/chat/conversation_state.rs
+++ b/crates/q_cli/src/cli/chat/conversation_state.rs
@@ -223,6 +223,7 @@ impl ConversationState {
         assert!(self.next_message.is_some());
         while self.history.len() > MAX_CONVERSATION_STATE_HISTORY_LEN {
             self.history.pop_front();
+            self.history.pop_front();
         }
 
         // The current state we want to send


### PR DESCRIPTION
*Description of changes:*
- Remove two messages from the history at a time. This is required to make sure the user message is always the first in the history.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
