### PR TITLE
Fix: Update fs_read tool so that it is used more often

### DIFF
--- a/crates/q_cli/src/cli/chat/tools/tool_index.json
+++ b/crates/q_cli/src/cli/chat/tools/tool_index.json
@@ -19,7 +19,7 @@
   },
   {
     "name": "fs_read",
-    "description": "A tool for viewing files and directories.\n* If `path` is a file, this tool displays the result of applying `cat -n`.\n* If `path` is a directory, this tool lists files and directories\n",
+    "description": "A tool for reading files (e.g. `cat -n`), or listing files/directories (e.g. `ls -la` or `find . -maxdepth 2). The behavior of this tool is determined by the `path` parameter pointing to a file or directory.\n* If `path` is a file, this tool returns the result of running `cat -n`, and the optional `read_range` determines what range of lines will be read from the specified file.\n* If `path` is a directory, this tool returns the listed files and directories of the specified path, as if running `ls -la`. If the `read_range` parameter is provided, the tool acts like the `find . -maxdepth <read_range>`, where `read_range` is the number of subdirectories deep to search, e.g. [2] will run `find . -maxdepth 2`.",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -40,7 +40,7 @@
   },
   {
     "name": "fs_write",
-    "description": "A tool for creating and editing files\n * The `create` command will override the file at `path` if it already exists as a file, and otherwise create a new file\n * Please prefer creating smaller files even when asked otherwise as large file creations are likely to fail.\n Notes for using the `str_replace` command:\n * The `old_str` parameter should match EXACTLY one or more consecutive lines from the original file. Be mindful of whitespaces!\n * If the `old_str` parameter is not unique in the file, the replacement will not be performed. Make sure to include enough context in `old_str` to make it unique\n * The `new_str` parameter should contain the edited lines that should replace the `old_str`",
+    "description": "A tool for creating and editing files\n * The `create` command will override the file at `path` if it already exists as a file, and otherwise create a new file\n * Please prefer creating smaller files even when asked otherwise as large file creations are likely to fail.\n Notes for using the `str_replace` command:\n * The `old_str` parameter should match EXACTLY one or more consecutive lines from the original file. Be mindful of whitespaces!\n * If the `old_str` parameter is not unique in the file, the replacement will not be performed. Make sure to include enough context in `old_str` to make it unique\n * The `new_str` parameter should contain the edited lines that should replace the `old_str`.",
     "input_schema": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
*Description of changes:*

Update the fs_read tool description so that it is used more often. Currently, the model prefers to use the bash tool for listing files in a directory, which requires customer consent.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
