### PR TITLE
fix: use rust 1.85

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.84.0"
+channel = "1.85.0"
 profile = "minimal"
 components = ["rustfmt", "clippy"]
 targets = [

--- a/typos.toml
+++ b/typos.toml
@@ -30,6 +30,7 @@ zvariant = "zvariant"
 ser = "ser"
 sur = "sur"
 ratatui = "ratatui"
+typ = "typ"
 
 [type.rust.extend-identifiers]
 # typos really wanted to correct 2ND -> 2AND


### PR DESCRIPTION
*Description of changes:*
- Use rust version 1.85

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
