### PR TITLE
fix: codepipeline failures when running cargo

### DIFF
--- a/build-config/buildspec-linux-minimal.yml
+++ b/build-config/buildspec-linux-minimal.yml
@@ -20,6 +20,7 @@ phases:
       # Install cargo
       - curl --retry 5 --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - . "$HOME/.cargo/env"
+      - rustup toolchain install `cat rust-toolchain.toml | grep channel | cut -d '=' -f2 | tr -d ' "'`
       # Install cross only if the musl env var is set and not null
       - if [ ! -z "${AMAZON_Q_BUILD_MUSL:+x}" ]; then cargo install cross --git https://github.com/cross-rs/cross; fi
       # Install python/node via mise (https://mise.jdx.dev/continuous-integration.html)

--- a/build-config/buildspec-linux-ubuntu.yml
+++ b/build-config/buildspec-linux-ubuntu.yml
@@ -19,6 +19,7 @@ phases:
       # Install cargo
       - curl --retry 5 --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - . "$HOME/.cargo/env"
+      - rustup toolchain install `cat rust-toolchain.toml | grep channel | cut -d '=' -f2 | tr -d ' "'`
       # Install tauri-cli, required for building and bundling the desktop app
       - cargo install --version 1.6.2 tauri-cli
       # Install cross only if the musl env var is set and not null


### PR DESCRIPTION
*Description of changes:*
- rustup no longer installs implicit tool chains, hence we need to do it manually now. Taking it from the `rust-toolchain.toml` file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
