### PR TITLE
fix: revert back to rust 1.84

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.84.0"
 profile = "minimal"
 components = ["rustfmt", "clippy"]
 targets = [


### PR DESCRIPTION
*Description of changes:*
- macOS build is failing since going to 1.85, reverting to unblock builds.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
