### PR TITLE
fix: correct history truncation, tool interruption on ctrl c

### DIFF
--- a/build-config/buildspec-linux-minimal.yml
+++ b/build-config/buildspec-linux-minimal.yml
@@ -20,6 +20,7 @@ phases:
       # Install cargo
       - curl --retry 5 --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - . "$HOME/.cargo/env"
+      - rustup toolchain install `cat rust-toolchain.toml | grep channel | cut -d '=' -f2 | tr -d ' "'`
       # Install cross only if the musl env var is set and not null
       - if [ ! -z "${AMAZON_Q_BUILD_MUSL:+x}" ]; then cargo install cross --git https://github.com/cross-rs/cross; fi
       # Install python/node via mise (https://mise.jdx.dev/continuous-integration.html)

--- a/build-config/buildspec-linux-ubuntu.yml
+++ b/build-config/buildspec-linux-ubuntu.yml
@@ -19,6 +19,7 @@ phases:
       # Install cargo
       - curl --retry 5 --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - . "$HOME/.cargo/env"
+      - rustup toolchain install `cat rust-toolchain.toml | grep channel | cut -d '=' -f2 | tr -d ' "'`
       # Install tauri-cli, required for building and bundling the desktop app
       - cargo install --version 1.6.2 tauri-cli
       # Install cross only if the musl env var is set and not null

--- a/crates/fig_api_client/src/clients/streaming_client.rs
+++ b/crates/fig_api_client/src/clients/streaming_client.rs
@@ -159,7 +159,7 @@ impl StreamingClient {
                 ))
             },
             inner::Inner::Mock(events) => {
-                let mut new_events = events.lock().unwrap().next().unwrap().clone();
+                let mut new_events = events.lock().unwrap().next().unwrap_or_default().clone();
                 new_events.reverse();
                 Ok(SendMessageOutput::Mock(new_events))
             },

--- a/packages/dashboard-app/src/pages/terminal/chat.tsx
+++ b/packages/dashboard-app/src/pages/terminal/chat.tsx
@@ -1,5 +1,4 @@
 import { UserPrefView } from "@/components/preference/list";
-import { Code } from "@/components/text/code";
 import { Terminal } from "@/components/ui/terminal";
 import settings, { intro } from "@/data/chat";
 import chatWithContextDemo from "@assets/images/chat_with_context_demo.gif";

--- a/typos.toml
+++ b/typos.toml
@@ -30,6 +30,7 @@ zvariant = "zvariant"
 ser = "ser"
 sur = "sur"
 ratatui = "ratatui"
+typ = "typ"
 
 [type.rust.extend-identifiers]
 # typos really wanted to correct 2ND -> 2AND


### PR DESCRIPTION
*Description of changes:*
- Updating the history truncation logic to never surpass the max limit.
- Fix bug with invariants around the history - user message will always be first now.
- Add "tool use interrupted" as a tool result option in the event that the user ctrl+c's during tool execution.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
