### PR TITLE
chay/ux changes

### DIFF
--- a/crates/q_cli/src/cli/chat/tools/mod.rs
+++ b/crates/q_cli/src/cli/chat/tools/mod.rs
@@ -69,6 +69,17 @@ impl Tool {
         }
     }
 
+    // TODO: Remove, just roll with it for now ya?
+    pub fn display_name_action(&self) -> String {
+        match self {
+            Tool::FsRead(_) => "Reading from filesystem",
+            Tool::FsWrite(_) => "Writing to filesystem",
+            Tool::ExecuteBash(execute_bash) => return format!("Executing `{}`", execute_bash.command),
+            Tool::UseAws(_) => "Using AWS CLI",
+        }
+        .to_owned()
+    }
+
     /// Whether or not the tool should prompt the user for consent before [Self::invoke] is called.
     pub fn requires_consent(&self, _ctx: &Context) -> bool {
         match self {


### PR DESCRIPTION
- **feat: show users when quota is breached (#687)**
- **fix: aws parameter bugs (#688)**
- **Fix: core agentic bug fixes before release**
- **Fix: Prompt fs_write tool to prefer creating shorter files**
- **fix: update timeout to align with server**
- **fix: break up tool uses into multiple parts if stream ends unexpectedly**
- **fix: telemetry events in q chat, other refactoring and cleanup (#693)**
- **pops 2 messages at a time when truncating history (#695)**
- **Fix test (#697)**
- **Fix: Update fs_read tool so that it is used more often (#699)**
- **fix: assigns user input id to distinguish retry tool use event (#694)**
- **refactor: agentic chat code cleanup, fixes for appropriately handling history trimming (#708)**
- **Feat: Add bang syntax in chat, remove context modifiers, and add help command**
- **Feat: Support streaming of execute bash commands**
- **Fix: correct history truncation, tool interruption on ctrl c (#718)**
- **Feat: Update welcome msg for chat (#719)**
- **fix: tool results missing in certain edge cases (#721)**
- **jdhajhfgsd**
