### PR TITLE
fix: update fs_write tool to try to accomodate hallucinations, other UX changes for fs_read

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6826,6 +6826,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shlex",
+ "similar",
  "spinners",
  "syntect",
  "sysinfo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,7 @@ serde = { version = "1.0.216", features = ["derive", "rc"] }
 serde_json = "1.0.115"
 sha2 = "0.10.6"
 shlex = "1.3.0"
+similar = "2.6.0"
 strum = { version = "0.26.3", features = ["derive"] }
 sysinfo = "0.32.0"
 thiserror = "2.0.3"

--- a/crates/q_cli/Cargo.toml
+++ b/crates/q_cli/Cargo.toml
@@ -68,6 +68,7 @@ semver.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 shlex.workspace = true
+similar.workspace = true
 spinners = "4.1.0"
 sysinfo.workspace = true
 tempfile.workspace = true

--- a/crates/q_cli/src/cli/chat/tools/mod.rs
+++ b/crates/q_cli/src/cli/chat/tools/mod.rs
@@ -224,7 +224,9 @@ fn sanitize_path_tool_arg(ctx: &Context, path: impl AsRef<Path>) -> PathBuf {
         Some(p) => res.push(p),
         None => return res,
     }
-    res.push(path);
+    for p in path {
+        res.push(p);
+    }
     // For testing scenarios, we need to make sure paths are appropriately handled in chroot test
     // file systems since they are passed directly from the model.
     ctx.fs().chroot_path(res)


### PR DESCRIPTION
*Description of changes:*
- try to accommodate hallucinations with `fs_write`
- don't print file content on `fs_read`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
