### PR TITLE
fix: stream timeout handling

### DIFF
--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -648,6 +648,34 @@ where
                         },
                     }
                 },
+                Err(RecvError::StreamTimeout { source, duration }) => {
+                    error!(
+                        ?source,
+                        "Encountered a stream timeout after waiting for {}s",
+                        duration.as_secs()
+                    );
+                    if self.interactive {
+                        execute!(self.output, cursor::Hide)?;
+                        self.spinner = Some(Spinner::new(Spinners::Dots, "Dividing up the work...".to_string()));
+                    }
+                    // For stream timeouts, we'll tell the model to try and split its response into
+                    // smaller chunks.
+                    self.conversation_state
+                        .push_assistant_message(AssistantResponseMessage {
+                            message_id: None,
+                            content: "Fake message - actual message took too long to generate".to_string(),
+                            tool_uses: None,
+                        });
+                    self.conversation_state.append_new_user_message(
+                        "You took too long to respond - try to split up the work into smaller steps.".to_string(),
+                    );
+                    self.send_tool_use_telemetry().await;
+                    return Ok(ChatState::HandleResponseStream(
+                        self.client
+                            .send_message(self.conversation_state.as_sendable_conversation_state())
+                            .await?,
+                    ));
+                },
                 Err(RecvError::UnexpectedToolUseEos {
                     tool_use_id,
                     name,


### PR DESCRIPTION
*Description of changes:*
- Handling errors when trying to receive the next event in the response stream. If we encounter an error after 59 seconds have passed, then we consider this a timeout and send back a message to the model telling it to break up its response into smaller chunks.
- We are seeing timeouts happen at 100 seconds but I set the timeout to 59 seconds just to be safe, since we had encountered 60 second timeouts previously as well.

<img width="1176" alt="Screenshot 2025-03-04 at 5 21 15 PM" src="https://github.com/user-attachments/assets/e38c2aff-f007-4cea-bb55-6421d2e9aa69" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
