### PR TITLE
✨ feat(cli): Add append functionality to fs_write tool

### DIFF
--- a/crates/q_cli/src/cli/chat/tools/tool_index.json
+++ b/crates/q_cli/src/cli/chat/tools/tool_index.json
@@ -36,14 +36,14 @@
   },
   "fs_write": {
     "name": "fs_write",
-    "description": "A tool for creating and editing files\n * The `create` command will override the file at `path` if it already exists as a file, and otherwise create a new file\n * Please prefer creating smaller files even when asked otherwise as large file creations are likely to fail.\n Notes for using the `str_replace` command:\n * The `old_str` parameter should match EXACTLY one or more consecutive lines from the original file. Be mindful of whitespaces!\n * If the `old_str` parameter is not unique in the file, the replacement will not be performed. Make sure to include enough context in `old_str` to make it unique\n * The `new_str` parameter should contain the edited lines that should replace the `old_str`.",
+    "description": "A tool for creating and editing files\n * The `create` command will override the file at `path` if it already exists as a file, and otherwise create a new file\n * The `append` command will add content to the end of an existing file, or create a new file if it doesn't exist\n * Please prefer creating smaller files even when asked otherwise as large file creations are likely to fail.\n Notes for using the `str_replace` command:\n * The `old_str` parameter should match EXACTLY one or more consecutive lines from the original file. Be mindful of whitespaces!\n * If the `old_str` parameter is not unique in the file, the replacement will not be performed. Make sure to include enough context in `old_str` to make it unique\n * The `new_str` parameter should contain the edited lines that should replace the `old_str`.",
     "input_schema": {
       "type": "object",
       "properties": {
         "command": {
           "type": "string",
-          "enum": ["create", "str_replace", "insert"],
-          "description": "The commands to run. Allowed options are: `create`, `str_replace`, `insert`."
+          "enum": ["create", "str_replace", "insert", "append"],
+          "description": "The commands to run. Allowed options are: `create`, `str_replace`, `insert`, `append`."
         },
         "file_text": {
           "description": "Required parameter of `create` command, with the content of the file to be created.",
@@ -59,6 +59,10 @@
         },
         "old_str": {
           "description": "Required parameter of `str_replace` command containing the string in `path` to replace.",
+          "type": "string"
+        },
+        "content": {
+          "description": "Required parameter of `append` command containing the content to append to the file.",
           "type": "string"
         },
         "path": {


### PR DESCRIPTION
***Description of changes:***

This commit enhances the fs_write tool by adding a new "append" command that allows users to append content to the end of files without having to read and rewrite the entire file.

## Features
- 📝 Add new `Append` variant to the `FsWrite` enum
- 🔄 Implement functionality to append content to existing files
- 🆕 Auto-create files when appending to non-existent files
- 📁 Auto-create parent directories when needed
- 🧪 Add comprehensive test coverage for the new functionality

## Implementation Details
- Added validation to ensure path and content are not empty
- Enhanced user feedback during append operations
- Implemented syntax highlighting for appended content
- Maintained consistent code patterns with existing commands
- Added proper newline handling to ensure clean appends
- Updated tool_index.json schema to expose the new command

## Use Cases
- Adding new lines to configuration files
- Appending log entries
- Adding new content to the end of text files
- Creating files incrementally

This enhancement improves the user experience by providing a more convenient way to add content to files without having to read the entire file first and then use the "create" command to overwrite it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
