### PR TITLE
feat: add Compact command for compressing conversation history

### DIFF
--- a/crates/q_cli/src/cli/chat/command.rs
+++ b/crates/q_cli/src/cli/chat/command.rs
@@ -7,6 +7,7 @@ pub enum Command {
     Help,
     AcceptAll,
     Quit,
+    Compact,
 }
 
 impl Command {
@@ -19,6 +20,7 @@ impl Command {
                 "help" => Self::Help,
                 "acceptall" => Self::AcceptAll,
                 "q" | "exit" | "quit" => Self::Quit,
+                "compact" => Self::Compact,
                 _ => return Err(format!("Unknown command: {}", input)),
             });
         }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
## Overview
The Compact command (/compact) is a new feature for Amazon Q Developer CLI that intelligently compresses conversation history while preserving context. This feature addresses the challenge of managing long-running conversations that can become unwieldy 
and hit system limits.

## Problem Statement
As conversations with Amazon Q grow longer, they can:
• Reach token limits that degrade response quality
• Slow down response times due to processing large context windows
• Make it difficult to focus on current tasks when earlier parts of the conversation are no longer relevant

## Solution
The Compact command provides a streamlined way to compress conversation history while maintaining essential context through an intelligent summarization process.

## How It Works
1. When a user types /compact, the CLI initiates a conversation compression workflow
2. The system automatically generates a prompt requesting a concise summary of the conversation
3. This summary follows a structured format:
   • **Original User Ask**: Preserves the initial request that started the conversation
   • **Completed Items**: Documents what has been accomplished, including modified resources and important context
   • **Todo Items**: Lists remaining tasks with required details and next steps
4. After receiving the summary, the system:
   • Retains only the last two messages in the conversation history
   • Replaces the extensive conversation history with the concise summary
   • Maintains continuity for ongoing tasks

## Technical Implementation
• Added a new Compact variant to the Command enum
• Implemented the compact_conversation_history() method in ConversationState that intelligently prunes the conversation history
• Added comprehensive test coverage to ensure reliability
• Integrated with the existing conversation state management system


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
