### PR TITLE
fix (q chat): ensure generated files end with newline character, and no trailing whitespaces

### DIFF
--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -1140,6 +1140,6 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(ctx.fs().read_to_string("/file.txt").await.unwrap(), "Hello, world!");
+        assert_eq!(ctx.fs().read_to_string("/file.txt").await.unwrap(), "Hello, world!\n");
     }
 }

--- a/crates/q_cli/src/cli/chat/tools/fs_write.rs
+++ b/crates/q_cli/src/cli/chat/tools/fs_write.rs
@@ -70,6 +70,12 @@ impl FsWrite {
                     style::ResetColor,
                     style::Print("\n"),
                 )?;
+                // Ensure file ends with a newline if it doesn't already
+                let file_text = if !file_text.ends_with('\n') {
+                    format!("{}\n", file_text)
+                } else {
+                    file_text
+                };
                 fs.write(&path, file_text.as_bytes()).await?;
                 Ok(Default::default())
             },
@@ -89,6 +95,12 @@ impl FsWrite {
                     0 => Err(eyre!("no occurrences of \"{old_str}\" were found")),
                     1 => {
                         let file = file.replacen(old_str, new_str, 1);
+                        // Ensure file ends with a newline if it doesn't already
+                        let file = if !file.ends_with('\n') {
+                            format!("{}\n", file)
+                        } else {
+                            file
+                        };
                         fs.write(path, file).await?;
                         Ok(Default::default())
                     },
@@ -120,6 +132,12 @@ impl FsWrite {
                     i += line_len;
                 }
                 file.insert_str(i, new_str);
+                // Ensure file ends with a newline if it doesn't already
+                let file = if !file.ends_with('\n') {
+                    format!("{}\n", file)
+                } else {
+                    file
+                };
                 fs.write(&path, &file).await?;
                 Ok(Default::default())
             },
@@ -435,7 +453,10 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(ctx.fs().read_to_string("/my-file").await.unwrap(), file_text);
+        assert_eq!(
+            ctx.fs().read_to_string("/my-file").await.unwrap(),
+            format!("{}\n", file_text)
+        );
 
         let file_text = "Goodbye, world!\nSee you later";
         let v = serde_json::json!({
@@ -449,7 +470,11 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(ctx.fs().read_to_string("/my-file").await.unwrap(), file_text);
+        // File should end with a newline
+        assert_eq!(
+            ctx.fs().read_to_string("/my-file").await.unwrap(),
+            format!("{}\n", file_text)
+        );
 
         let file_text = "This is a new string";
         let v = serde_json::json!({
@@ -463,7 +488,10 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(ctx.fs().read_to_string("/my-file").await.unwrap(), file_text);
+        assert_eq!(
+            ctx.fs().read_to_string("/my-file").await.unwrap(),
+            format!("{}\n", file_text)
+        );
     }
 
     #[tokio::test]
@@ -613,7 +641,7 @@ mod tests {
             .await
             .unwrap();
         let actual = ctx.fs().read_to_string(test_file_path).await.unwrap();
-        assert_eq!(actual, format!("{}{}", test_file_contents, new_str),);
+        assert_eq!(actual, format!("{}{}\n", test_file_contents, new_str));
 
         // Then, test prepending
         let v = serde_json::json!({
@@ -628,7 +656,7 @@ mod tests {
             .await
             .unwrap();
         let actual = ctx.fs().read_to_string(test_file_path).await.unwrap();
-        assert_eq!(actual, format!("{}{}{}", new_str, test_file_contents, new_str),);
+        assert_eq!(actual, format!("{}{}{}\n", new_str, test_file_contents, new_str));
     }
 
     #[tokio::test]

--- a/crates/q_cli/src/cli/chat/tools/fs_write.rs
+++ b/crates/q_cli/src/cli/chat/tools/fs_write.rs
@@ -50,6 +50,19 @@ pub enum FsWrite {
 }
 
 impl FsWrite {
+    /// Helper function to clean file content:
+    /// 1. Ensures the file ends with a newline
+    /// 2. Removes trailing whitespace from each line
+    fn clean_file_content(content: String) -> String {
+        let mut cleaned = content
+            .lines()
+            .map(|line| line.trim_end())
+            .collect::<Vec<_>>()
+            .join("\n");
+        cleaned.push('\n');
+        cleaned
+    }
+
     pub async fn invoke(&self, ctx: &Context, updates: &mut impl Write) -> Result<InvokeOutput> {
         let fs = ctx.fs();
         let cwd = ctx.env().current_dir()?;
@@ -70,13 +83,9 @@ impl FsWrite {
                     style::ResetColor,
                     style::Print("\n"),
                 )?;
-                // Ensure file ends with a newline if it doesn't already
-                let file_text = if !file_text.ends_with('\n') {
-                    format!("{}\n", file_text)
-                } else {
-                    file_text
-                };
-                fs.write(&path, file_text.as_bytes()).await?;
+
+                let cleaned_text = Self::clean_file_content(file_text);
+                fs.write(&path, cleaned_text.as_bytes()).await?;
                 Ok(Default::default())
             },
             FsWrite::StrReplace { path, old_str, new_str } => {
@@ -95,13 +104,8 @@ impl FsWrite {
                     0 => Err(eyre!("no occurrences of \"{old_str}\" were found")),
                     1 => {
                         let file = file.replacen(old_str, new_str, 1);
-                        // Ensure file ends with a newline if it doesn't already
-                        let file = if !file.ends_with('\n') {
-                            format!("{}\n", file)
-                        } else {
-                            file
-                        };
-                        fs.write(path, file).await?;
+                        let cleaned_file = Self::clean_file_content(file);
+                        fs.write(path, cleaned_file).await?;
                         Ok(Default::default())
                     },
                     x => Err(eyre!("{x} occurrences of old_str were found when only 1 is expected")),
@@ -132,13 +136,8 @@ impl FsWrite {
                     i += line_len;
                 }
                 file.insert_str(i, new_str);
-                // Ensure file ends with a newline if it doesn't already
-                let file = if !file.ends_with('\n') {
-                    format!("{}\n", file)
-                } else {
-                    file
-                };
-                fs.write(&path, &file).await?;
+                let cleaned_file = Self::clean_file_content(file);
+                fs.write(&path, &cleaned_file).await?;
                 Ok(Default::default())
             },
             FsWrite::Append { path, new_str } => {
@@ -710,5 +709,28 @@ mod tests {
         assert_eq!(truncate_str(s, 13), s);
         let s = "Hello, world!";
         assert_eq!(truncate_str(s, 0), "<...Truncated>");
+    }
+
+    #[test]
+    fn test_clean_file_content() {
+        // Test removing trailing whitespace
+        let content = "Hello world!  \nThis is a test   \nWith trailing spaces    ";
+        let expected = "Hello world!\nThis is a test\nWith trailing spaces\n";
+        assert_eq!(FsWrite::clean_file_content(content.to_string()), expected);
+
+        // Test ensuring ending newline
+        let content = "Hello world!\nNo ending newline";
+        let expected = "Hello world!\nNo ending newline\n";
+        assert_eq!(FsWrite::clean_file_content(content.to_string()), expected);
+
+        // Test with content already having ending newline
+        let content = "Hello world!\nWith ending newline\n";
+        let expected = "Hello world!\nWith ending newline\n";
+        assert_eq!(FsWrite::clean_file_content(content.to_string()), expected);
+
+        // Test with empty string
+        let content = "";
+        let expected = "\n";
+        assert_eq!(FsWrite::clean_file_content(content.to_string()), expected);
     }
 }


### PR DESCRIPTION
Fixes #768

This commit adds functionality to ensure all files created or modified by the fs_write tool end with a newline character, following Unix text file conventions. The change:

- Adds newline handling to create, str_replace, and insert operations
- Updates test cases to verify the new behavior
- Maintains backward compatibility with existing functionality
- Avoids common Checkstyle and Lint failures due to missing new line or trailing whitespace at the end of a line.

This improves compatibility with other tools and follows standard text file best practices.

*Issue #, if available:*
#768

*Description of changes:*

This PR addresses issue #768 by ensuring that all files created or modified by the fs_write tool end with a newline character, following Unix text file conventions.

* Added newline handling to all fs_write operations in Q CLI:
  * create command now ensures the file content ends with a newline
  * str_replace command preserves the trailing newline during replacements
  * insert command maintains the trailing newline after insertions
* Updated test cases to verify the new behavior
* Maintained backward compatibility with existing functionality

### Testing

I've verified this change by:
• Running the existing test suite which now checks for trailing newlines
• Manually testing with local Java and Python files to ensure proper newline handling
• Confirming that files created through the CLI properly end with newlines when viewed in various editors

### Why this matters

Many Unix tools expect text files to end with a newline character. Without a trailing newline, some tools might:
• Display warnings
• Concatenate files incorrectly
• Have issues with diffs and patches

This change improves compatibility with standard Unix tools and follows best practices for text file handling.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
