### PR TITLE
feat: add Compact command for compressing conversation history

### DIFF
--- a/crates/q_cli/src/cli/chat/command.rs
+++ b/crates/q_cli/src/cli/chat/command.rs
@@ -1,5 +1,6 @@
 use eyre::Result;
 
+#[derive(Debug, Clone)]
 pub enum Command {
     Ask { prompt: String },
     Execute { command: String },
@@ -7,6 +8,7 @@ pub enum Command {
     Help,
     AcceptAll,
     Quit,
+    Compact,
 }
 
 impl Command {
@@ -19,6 +21,7 @@ impl Command {
                 "help" => Self::Help,
                 "acceptall" => Self::AcceptAll,
                 "q" | "exit" | "quit" => Self::Quit,
+                "compact" => Self::Compact,
                 _ => return Err(format!("Unknown command: {}", input)),
             });
         }


### PR DESCRIPTION
# Add Compact command for compressing conversation history

## Feature Description
Added a new "Compact" command to the Amazon Q CLI that enables users to compress their conversation history into a summary format, making it more manageable while preserving important context.

## Change Description
- Added command registration in `command.rs` (3 lines)
- Implemented conversation compression logic in `conversation_state.rs` with significant refactoring (111 lines changed)
- Updated the chat module in `mod.rs` to handle the new command and integrate with existing conversation flow (117 lines changed)
- Overall: 142 insertions and 89 deletions across 3 files

## Testing Description
The feature is covered by unit tests:
- `test_compact_conversation_history` - Tests the core functionality of compacting conversation history
- `test_conversation_state_history_handling_truncation` - Tests related history truncation functionality
- `test_conversation_state_history_handling_with_tool_results` - Tests history handling with tool results

Tests are passing.

## User Experience
Users can now type `/compact` during a chat session to compress the conversation history into a summary format. This helps manage long conversations while preserving context for the model.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
