### PR TITLE
chore: add allowed license ncsa to deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -49,6 +49,7 @@ allow = [
   "ISC",
   "MIT",
   "MPL-2.0",
+  "NCSA",
   "OpenSSL",
   "Unicode-3.0",
   "Zlib",


### PR DESCRIPTION
*Description of changes:*
- Adding NCSA as an allowed license, since it is approved for use by Amazon


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
