### PR TITLE
feat: improve file diff for fs write

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6557,6 +6557,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "shell-color",
  "shlex",
  "similar",
  "spinners",

--- a/crates/q_cli/Cargo.toml
+++ b/crates/q_cli/Cargo.toml
@@ -86,6 +86,7 @@ walkdir.workspace = true
 which.workspace = true
 whoami.workspace = true
 winnow.workspace = true
+shell-color.workspace = true
 syntect = { version = "5.2.0", features = [ "default-syntaxes", "default-themes" ]}
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
*Description of changes:*
- Adding a file diff visualization for `fs_write` that displays line numbers. This implementation needs to be improved for truecolor support - currently, we don't highlight the entire document which can result in lines being highlighted incorrectly, consequently impacting the diff.
- Removing the `clean_file_content` function since it was resulting in a lot of errors with the model trying to use str_replace. Essentially, we were writing different content than the model was generating, which thus required it to constantly reread the file to see what we actually wrote.
- Moving the logic for appending a newline to a separate function shared by all `fs_write` commands.
- Fixed bug with append not including a newline at the end of the file.

<img width="695" alt="Screenshot 2025-03-11 at 2 55 08 PM" src="https://github.com/user-attachments/assets/1f7ff66d-afbf-4476-bfeb-cd5da1dc5926" />
<img width="695" alt="Screenshot 2025-03-11 at 2 56 20 PM" src="https://github.com/user-attachments/assets/96c3b657-e1c4-492e-8d9c-cfe6e81a9798" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
