### PR TITLE
feat: dont exit on first ctrl c when at the prompt

### DIFF
--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -456,10 +456,26 @@ where
                 style::SetForegroundColor(Color::Reset),
             )?;
         }
-        let user_input = match self.input_source.read_line(Some("> "))? {
-            Some(line) => line,
-            None => return Ok(ChatState::Exit),
+
+        // Require two consecutive sigint's to exit.
+        let mut ctrl_c = false;
+        let user_input = loop {
+            match (self.input_source.read_line(Some("> "))?, ctrl_c) {
+                (Some(line), _) => break line,
+                (None, false) => {
+                    execute!(
+                        self.output,
+                        style::Print(format!(
+                            "\n(To exit, press Ctrl+C or Ctrl+D again or type {})\n\n",
+                            "/quit".green()
+                        ))
+                    )?;
+                    ctrl_c = true;
+                },
+                (None, true) => return Ok(ChatState::Exit),
+            }
         };
+
         Ok(ChatState::HandleInput {
             input: user_input,
             tool_uses: Some(tool_uses),


### PR DESCRIPTION
*Description of changes:*
- Replicate the behavior of the `node` repl by requiring two consecutive sigint's in order to exit. This is intended to prevent accidental exits when the user spams Ctrl+C.

<img width="680" alt="Screenshot 2025-03-14 at 10 13 54 AM" src="https://github.com/user-attachments/assets/c80447ba-e5ec-4223-9e93-80eac6f4fa77" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
