### PR TITLE
chore: bump version to 1.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty_terminal"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "bitflags 2.9.0",
  "camino",
@@ -283,7 +283,7 @@ checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "appkit-nsworkspace-bindings"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "bindgen 0.71.1",
  "objc",
@@ -2028,7 +2028,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "dbus"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "async_zip",
  "fig_os_shim",
@@ -2461,7 +2461,7 @@ dependencies = [
 
 [[package]]
 name = "fig-api-mock"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "async-trait",
  "clap",
@@ -2474,7 +2474,7 @@ dependencies = [
 
 [[package]]
 name = "fig_api_client"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "amzn-codewhisperer-client",
  "amzn-codewhisperer-streaming-client",
@@ -2510,7 +2510,7 @@ dependencies = [
 
 [[package]]
 name = "fig_auth"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "async-trait",
  "aws-credential-types",
@@ -2544,7 +2544,7 @@ dependencies = [
 
 [[package]]
 name = "fig_aws_common"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "aws-runtime",
  "aws-smithy-runtime",
@@ -2557,7 +2557,7 @@ dependencies = [
 
 [[package]]
 name = "fig_desktop"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -2649,7 +2649,7 @@ dependencies = [
 
 [[package]]
 name = "fig_desktop_api"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anstream",
  "async-trait",
@@ -2685,7 +2685,7 @@ dependencies = [
 
 [[package]]
 name = "fig_diagnostic"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "cfg-if",
  "clap",
@@ -2705,7 +2705,7 @@ dependencies = [
 
 [[package]]
 name = "fig_input_method"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "apple-bundle",
  "fig_ipc",
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "fig_install"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "bitflags 2.9.0",
  "bytes",
@@ -2765,7 +2765,7 @@ dependencies = [
 
 [[package]]
 name = "fig_integrations"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "accessibility-sys",
  "async-trait",
@@ -2798,7 +2798,7 @@ dependencies = [
 
 [[package]]
 name = "fig_ipc"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2821,7 +2821,7 @@ dependencies = [
 
 [[package]]
 name = "fig_log"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "fig_util",
  "parking_lot",
@@ -2834,7 +2834,7 @@ dependencies = [
 
 [[package]]
 name = "fig_os_shim"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "cfg-if",
  "dirs",
@@ -2847,7 +2847,7 @@ dependencies = [
 
 [[package]]
 name = "fig_proto"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -2870,7 +2870,7 @@ dependencies = [
 
 [[package]]
 name = "fig_remote_ipc"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2888,7 +2888,7 @@ dependencies = [
 
 [[package]]
 name = "fig_request"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -2913,7 +2913,7 @@ dependencies = [
 
 [[package]]
 name = "fig_settings"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "fd-lock",
  "fig_test",
@@ -2934,7 +2934,7 @@ dependencies = [
 
 [[package]]
 name = "fig_telemetry"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "amzn-codewhisperer-client",
  "amzn-toolkit-telemetry",
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "fig_telemetry_core"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "amzn-codewhisperer-client",
  "amzn-toolkit-telemetry",
@@ -2982,7 +2982,7 @@ dependencies = [
 
 [[package]]
 name = "fig_test"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "fig_test_macro",
  "tokio",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "fig_test_macro"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -2998,7 +2998,7 @@ dependencies = [
 
 [[package]]
 name = "fig_test_utils"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "bytes",
  "fig_os_shim",
@@ -3016,7 +3016,7 @@ dependencies = [
 
 [[package]]
 name = "fig_util"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "appkit-nsworkspace-bindings",
  "bstr",
@@ -3056,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "figterm"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -3120,7 +3120,7 @@ dependencies = [
 
 [[package]]
 name = "figterm2"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4799,7 +4799,7 @@ dependencies = [
 
 [[package]]
 name = "macos-utils"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "q_cli"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "amzn-codewhisperer-client",
  "amzn-codewhisperer-streaming-client",
@@ -7670,7 +7670,7 @@ dependencies = [
 
 [[package]]
 name = "shell-color"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "bitflags 2.9.0",
  "fig_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ authors = [
 edition = "2021"
 homepage = "https://aws.amazon.com/q/"
 publish = false
-version = "1.7.0"
+version = "1.7.1"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]

--- a/feed.json
+++ b/feed.json
@@ -12,6 +12,30 @@
     },
     {
       "type": "release",
+      "date": "2025-03-14",
+      "version": "1.7.1",
+      "title": "Version 1.7.1",
+      "changes": [
+        {
+          "type": "added",
+          "description": "`q chat` improvements: better file diff [#799](https://github.com/aws/amazon-q-developer-cli/pull/799), append functionality with fs_write [#764](https://github.com/aws/amazon-q-developer-cli/pull/764), multi-line input support [#831](https://github.com/aws/amazon-q-developer-cli/pull/831)"
+        },
+        {
+          "type": "added",
+          "description": "Support for WindSurf Next [#814](https://github.com/aws/amazon-q-developer-cli/pull/814)"
+        },
+        {
+          "type": "changed",
+          "description": "Ctrl+C no longer exits `q chat` on first attempt [#830](https://github.com/aws/amazon-q-developer-cli/pull/830)"
+        },
+        {
+          "type": "fixed",
+          "description": "Minor issues in `q chat`"
+        }
+      ]
+    },
+    {
+      "type": "release",
       "date": "2025-03-05",
       "version": "1.7.0",
       "title": "Version 1.7.0",


### PR DESCRIPTION
*Description of changes:*
- Bumping the version to `1.7.1`
- Adding a `feed.json` entry

<img width="688" alt="Screenshot 2025-03-14 at 2 17 44 PM" src="https://github.com/user-attachments/assets/42cd751c-f387-46ff-8b31-eab27ad7a690" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
