### PR TITLE
fix: show request id on errors encountered during the response stream

### DIFF
--- a/crates/fig_api_client/src/clients/streaming_client.rs
+++ b/crates/fig_api_client/src/clients/streaming_client.rs
@@ -176,6 +176,14 @@ pub enum SendMessageOutput {
 }
 
 impl SendMessageOutput {
+    pub fn request_id(&self) -> Option<&str> {
+        match self {
+            SendMessageOutput::Codewhisperer(output) => output.request_id(),
+            SendMessageOutput::QDeveloper(output) => output.request_id(),
+            SendMessageOutput::Mock(_) => None,
+        }
+    }
+
     pub async fn recv(&mut self) -> Result<Option<ChatResponseStream>, Error> {
         match self {
             SendMessageOutput::Codewhisperer(output) => Ok(output


### PR DESCRIPTION
*Description of changes:*
- We currently do not show the request id for non-InternalServiceError errors. This change will always show the request id for errors encountered during the response stream, even if the client is the one responsible. This is intended to help debug issues with the backend producing a bad response that *looks* like a client error, but is in actuality a backend error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
