### PR TITLE
chore: update max tool response size to match the backend limit

### DIFF
--- a/crates/q_cli/src/cli/chat/tools/mod.rs
+++ b/crates/q_cli/src/cli/chat/tools/mod.rs
@@ -28,7 +28,7 @@ use use_aws::UseAws;
 
 use super::parser::ToolUse;
 
-pub const MAX_TOOL_RESPONSE_SIZE: usize = 30720;
+pub const MAX_TOOL_RESPONSE_SIZE: usize = 800000;
 
 /// Represents an executable tool use.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
*Description of changes:*
- Updating the max tool response size to the same value as the backend limit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
