### PR TITLE
chore: add beta notice to /profile and /context help text

### DIFF
--- a/crates/q_cli/src/cli/chat/command.rs
+++ b/crates/q_cli/src/cli/chat/command.rs
@@ -42,7 +42,7 @@ impl ProfileSubcommand {
     pub fn help_text() -> String {
         color_print::cformat!(
             r#"
-<magenta,em>Profile Management</magenta,em>
+<magenta,em>(Beta) Profile Management</magenta,em>
 
 Profiles allow you to organize and manage different sets of context files for different projects or tasks.
 
@@ -107,7 +107,7 @@ impl ContextSubcommand {
     pub fn help_text() -> String {
         color_print::cformat!(
             r#"
-<magenta,em>Context Management</magenta,em>
+<magenta,em>(Beta) Context Management</magenta,em>
 
 Context files provide Amazon Q with additional information about your project or environment.
 Adding relevant files to your context helps Amazon Q provide more accurate and helpful responses.

--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -95,8 +95,8 @@ const WELCOME_TEXT: &str = color_print::cstr! {"
 • Help me understand my git status
 
 <em>/acceptall</em>    <black!>Toggles acceptance prompting for the session.</black!>
-<em>/profile</em>      <black!>Manage profiles for the chat session</black!>
-<em>/context</em>      <black!>Manage context files for a profile</black!>
+<em>/profile</em>      <black!>(Beta) Manage profiles for the chat session</black!>
+<em>/context</em>      <black!>(Beta) Manage context files for a profile</black!>
 <em>/help</em>         <black!>Show the help dialogue</black!>
 <em>/quit</em>         <black!>Quit the application</black!>
 


### PR DESCRIPTION
*Description of changes:*
- Adding a "beta" notice in the `/profile` and `/context` help text to signify that they are subject to change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
