### PR TITLE
feat(chat): no-interactive mode

### DIFF
--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -129,7 +129,12 @@ const HELP_TEXT: &str = color_print::cstr! {"
 
 "};
 
-pub async fn chat(input: Option<String>, no_interactive: bool, accept_all: bool, profile: Option<String>) -> Result<ExitCode> {
+pub async fn chat(
+    input: Option<String>,
+    no_interactive: bool,
+    accept_all: bool,
+    profile: Option<String>,
+) -> Result<ExitCode> {
     if !fig_util::system_info::in_cloudshell() && !fig_auth::is_logged_in().await {
         bail!(
             "You are not logged in, please log in with {}",
@@ -229,7 +234,9 @@ pub enum ChatError {
     Custom(Cow<'static, str>),
     #[error("interrupted")]
     Interrupted { tool_uses: Option<Vec<QueuedTool>> },
-    #[error("Tool approval required but --no-interactive was specified. Use --accept-all to automatically approve tools.")]
+    #[error(
+        "Tool approval required but --no-interactive was specified. Use --accept-all to automatically approve tools."
+    )]
     NonInteractiveToolApproval,
 }
 
@@ -393,7 +400,7 @@ where
                 } => {
                     // Cannot prompt in non-interactive mode no matter what.
                     if !self.interactive {
-                        return Ok(())
+                        return Ok(());
                     }
                     self.prompt_user(tool_uses, skip_printing_tools).await
                 },
@@ -1354,7 +1361,7 @@ where
                 tool_uses: Some(queued_tools),
                 skip_printing_tools: false,
             }),
-            (false, false) => Err(ChatError::NonInteractiveToolApproval)
+            (false, false) => Err(ChatError::NonInteractiveToolApproval),
         }
     }
 

--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -129,7 +129,7 @@ const HELP_TEXT: &str = color_print::cstr! {"
 
 "};
 
-pub async fn chat(input: Option<String>, accept_all: bool, profile: Option<String>) -> Result<ExitCode> {
+pub async fn chat(input: Option<String>, no_interactive: bool, accept_all: bool, profile: Option<String>) -> Result<ExitCode> {
     if !fig_util::system_info::in_cloudshell() && !fig_auth::is_logged_in().await {
         bail!(
             "You are not logged in, please log in with {}",
@@ -140,17 +140,22 @@ pub async fn chat(input: Option<String>, accept_all: bool, profile: Option<Strin
     region_check("chat")?;
 
     let ctx = Context::new();
-    let output = std::io::stderr();
 
     let stdin = std::io::stdin();
-    let interactive = stdin.is_terminal();
-    let input = if !interactive {
-        // append to input string any extra info that was provided.
+    // no_interactive flag or part of a pipe
+    let interactive = !no_interactive && stdin.is_terminal();
+    let input = if !interactive && !stdin.is_terminal() {
+        // append to input string any extra info that was provided, e.g. via pipe
         let mut input = input.unwrap_or_default();
         stdin.lock().read_to_string(&mut input)?;
         Some(input)
     } else {
         input
+    };
+
+    let output: Box<dyn Write> = match interactive {
+        true => Box::new(std::io::stderr()),
+        false => Box::new(std::io::stdout()),
     };
 
     let client = match ctx.env().get("Q_MOCK_CHAT_RESPONSE") {
@@ -224,6 +229,8 @@ pub enum ChatError {
     Custom(Cow<'static, str>),
     #[error("interrupted")]
     Interrupted { tool_uses: Option<Vec<QueuedTool>> },
+    #[error("Tool approval required but --no-interactive was specified. Use --accept-all to automatically approve tools.")]
+    NonInteractiveToolApproval,
 }
 
 pub struct ChatContext<W: Write> {
@@ -358,14 +365,16 @@ where
         });
 
         if let Some(user_input) = self.initial_input.take() {
-            execute!(
-                self.output,
-                style::SetForegroundColor(Color::Magenta),
-                style::Print("> "),
-                style::SetAttribute(Attribute::Reset),
-                style::Print(&user_input),
-                style::Print("\n")
-            )?;
+            if self.interactive {
+                execute!(
+                    self.output,
+                    style::SetForegroundColor(Color::Magenta),
+                    style::Print("> "),
+                    style::SetAttribute(Attribute::Reset),
+                    style::Print(&user_input),
+                    style::Print("\n")
+                )?;
+            }
             next_state = Some(ChatState::HandleInput {
                 input: user_input,
                 tool_uses: None,
@@ -381,7 +390,13 @@ where
                 ChatState::PromptUser {
                     tool_uses,
                     skip_printing_tools,
-                } => self.prompt_user(tool_uses, skip_printing_tools).await,
+                } => {
+                    // Cannot prompt in non-interactive mode no matter what.
+                    if !self.interactive {
+                        return Ok(())
+                    }
+                    self.prompt_user(tool_uses, skip_printing_tools).await
+                },
                 ChatState::HandleInput { input, tool_uses } => self.handle_input(input, tool_uses).await,
                 ChatState::ExecuteTools(tool_uses) => {
                     let tool_uses_clone = tool_uses.clone();
@@ -493,9 +508,7 @@ where
         mut tool_uses: Option<Vec<QueuedTool>>,
         skip_printing_tools: bool,
     ) -> Result<ChatState, ChatError> {
-        if self.interactive {
-            execute!(self.output, cursor::Show)?;
-        }
+        execute!(self.output, cursor::Show)?;
         let tool_uses = tool_uses.take().unwrap_or_default();
         if !tool_uses.is_empty() && !skip_printing_tools {
             self.print_tool_descriptions(&tool_uses).await?;
@@ -1332,15 +1345,16 @@ where
 
         let skip_acceptance = self.accept_all || queued_tools.iter().all(|tool| !tool.1.requires_acceptance(&self.ctx));
 
-        match skip_acceptance {
-            true => {
+        match (skip_acceptance, self.interactive) {
+            (true, _) => {
                 self.print_tool_descriptions(&queued_tools).await?;
                 Ok(ChatState::ExecuteTools(queued_tools))
             },
-            false => Ok(ChatState::PromptUser {
+            (false, true) => Ok(ChatState::PromptUser {
                 tool_uses: Some(queued_tools),
                 skip_printing_tools: false,
             }),
+            (false, false) => Err(ChatError::NonInteractiveToolApproval)
         }
     }
 

--- a/crates/q_cli/src/cli/mod.rs
+++ b/crates/q_cli/src/cli/mod.rs
@@ -186,6 +186,10 @@ pub enum CliRootCommands {
         /// them.
         #[arg(short, long)]
         accept_all: bool,
+        /// Print the first response to STDOUT without interactive mode. This will fail if the
+        /// prompt requests permissions to use a tool, unless --accept-all is also used.
+        #[arg(long)]
+        no_interactive: bool,
         /// The first question to ask
         input: Option<String>,
         /// Context profile to use
@@ -337,9 +341,10 @@ impl Cli {
                 CliRootCommands::Dashboard => launch_dashboard(false).await,
                 CliRootCommands::Chat {
                     accept_all,
+                    no_interactive,
                     input,
                     profile,
-                } => chat::chat(input, accept_all, profile).await,
+                } => chat::chat(input, no_interactive, accept_all, profile).await,
                 CliRootCommands::Inline(subcommand) => subcommand.execute(&cli_context).await,
             },
             // Root command
@@ -460,6 +465,7 @@ mod test {
         assert_eq!(Cli::parse_from([CLI_BINARY_NAME, "chat", "-vv"]), Cli {
             subcommand: Some(CliRootCommands::Chat {
                 accept_all: false,
+                no_interactive: false,
                 input: None,
                 profile: None,
             },),
@@ -589,6 +595,7 @@ mod test {
     fn test_chat_with_context_profile() {
         assert_parse!(["chat", "--profile", "my-profile"], CliRootCommands::Chat {
             accept_all: false,
+            no_interactive: false,
             input: None,
             profile: Some("my-profile".to_string()),
         });
@@ -598,6 +605,7 @@ mod test {
     fn test_chat_with_context_profile_and_input() {
         assert_parse!(["chat", "--profile", "my-profile", "Hello"], CliRootCommands::Chat {
             accept_all: false,
+            no_interactive: false,
             input: Some("Hello".to_string()),
             profile: Some("my-profile".to_string()),
         });
@@ -609,8 +617,22 @@ mod test {
             ["chat", "--profile", "my-profile", "--accept-all"],
             CliRootCommands::Chat {
                 accept_all: true,
+                no_interactive: false,
                 input: None,
                 profile: Some("my-profile".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn test_chat_with_no_interactive() {
+        assert_parse!(
+            ["chat", "--no_interactive"],
+            CliRootCommands::Chat {
+                accept_all: false,
+                no_interactive: true,
+                input: None,
+                profile: None,
             }
         );
     }

--- a/crates/q_cli/src/cli/mod.rs
+++ b/crates/q_cli/src/cli/mod.rs
@@ -626,14 +626,11 @@ mod test {
 
     #[test]
     fn test_chat_with_no_interactive() {
-        assert_parse!(
-            ["chat", "--no-interactive"],
-            CliRootCommands::Chat {
-                accept_all: false,
-                no_interactive: true,
-                input: None,
-                profile: None,
-            }
-        );
+        assert_parse!(["chat", "--no-interactive"], CliRootCommands::Chat {
+            accept_all: false,
+            no_interactive: true,
+            input: None,
+            profile: None,
+        });
     }
 }

--- a/crates/q_cli/src/cli/mod.rs
+++ b/crates/q_cli/src/cli/mod.rs
@@ -627,7 +627,7 @@ mod test {
     #[test]
     fn test_chat_with_no_interactive() {
         assert_parse!(
-            ["chat", "--no_interactive"],
+            ["chat", "--no-interactive"],
             CliRootCommands::Chat {
                 accept_all: false,
                 no_interactive: true,


### PR DESCRIPTION
Related: https://github.com/aws/amazon-q-developer-cli/issues/808

- Prints to STDOUT instead.
- Does not print non-response text, e.g. user input prompt, welcome message.
- Runs tools as long as --accept-all is also provided. Otherwise it will error. You can bypass this by asking to not run tools in the prompt.
- Continues to work with pipes, e.g.
  - echo "give a cool tip" | q chat --no-interactive -> outputs a cool tip
  - echo "give a cool tip" | q chat --no-interactive "write hello world." -> outputs hello world code and a cool tip
  - q chat --no-interactive -> does nothing and immediately returns

Does NOT print without any formatting/styling codes or labels. That will require a larger refactor in a separate PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
