### PR TITLE
fix(chat): Improve command parsing to handle paths starting with slash

### DIFF
--- a/crates/q_cli/src/cli/chat/command.rs
+++ b/crates/q_cli/src/cli/chat/command.rs
@@ -313,7 +313,11 @@ impl Command {
                         },
                     }
                 },
-                _ => return Err(format!("Unknown command: {}", input)),
+                _ => {
+                    return Ok(Self::Ask {
+                        prompt: input.to_string(),
+                    });
+                },
             });
         }
 


### PR DESCRIPTION


*Issue #, if available:* https://github.com/aws/amazon-q-developer-cli/issues/894

*Description of changes:*

Fixes an issue where pasting error messages or file paths that start with a slash (/) would be incorrectly interpreted as commands. This change improves the command parser to better distinguish between actual commands and text that happens to start with a slash character.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


![Screenshot 2025-03-26 at 1 12 09 AM](https://github.com/user-attachments/assets/b6b75225-78e6-4473-ba47-44f8c99c9223)
