### PR TITLE
docs(vscode): Update extension links and documentation

### DIFF
--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -2,8 +2,8 @@
 
 This is the Amazon Q for command line IDE extension. It only supports completions in your IDEs' terminal emulator.
 
-If you would like completions in your editor, please download the [AWS Toolkit extension](https://marketplace.visualstudio.com/items?itemName=AmazonWebServices.aws-toolkit-vscode) and set up Amazon Q.
+If you would like completions in your editor, please download the [Amazon Q extension](https://marketplace.visualstudio.com/items?itemName=AmazonWebServices.amazon-q-vscode) and set up Amazon Q.
 
-For support, please see [github.com/aws/q-command-line-discussions](https://github.com/aws/q-command-line-discussions).
+For support, please see [github.com/aws/amazon-q-developer-cli](https://github.com/aws/amazon-q-developer-cli).
 
-![CLI Compleations Demo](https://raw.githubusercontent.com/aws/q-command-line-discussions/main/assets/cli-completions.gif)
+![CLI Completions Demo](https://raw.githubusercontent.com/aws/q-command-line-discussions/main/assets/cli-completions.gif)


### PR DESCRIPTION
Point to new Amazon Q VSCode IDE extension and amazon-q-developer-cli github repo for better discoverability and support.

🤖 Assisted by [Amazon Q Developer](https://aws.amazon.com/q/developer)

*Issue #, if available:* 

The [README.md](https://github.com/aws/amazon-q-developer-cli/tree/main/extensions/vscode#readme) under extensions/vscode was pointing to the AWS Toolkit VS Code extension instead of the Amazon Q VS Code extension.

*Description of changes:*
- Updated link to point to Amazon Q VS Code extension
- Updated link to this github repo instead of previous https://github.com/aws/q-command-line-discussions link

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
