### PR TITLE
fix(chat): Fix display of square brackets in chat output

### DIFF
--- a/crates/q_cli/src/cli/chat/parse.rs
+++ b/crates/q_cli/src/cli/chat/parse.rs
@@ -753,6 +753,10 @@ mod tests {
     )]);
     validate!(square_bracket_empty, "[]", [style::Print("[]")]);
     validate!(square_bracket_array, "a[i]", [style::Print("a[i]")]);
-    validate!(square_bracket_url_like_1, "[text] without url part", [style::Print("[text] without url part")]);
-    validate!(square_bracket_url_like_2, "[text](without url part", [style::Print("[text](without url part")]);
+    validate!(square_bracket_url_like_1, "[text] without url part", [style::Print(
+        "[text] without url part"
+    )]);
+    validate!(square_bracket_url_like_2, "[text](without url part", [style::Print(
+        "[text](without url part"
+    )]);
 }

--- a/crates/q_cli/src/cli/chat/parse.rs
+++ b/crates/q_cli/src/cli/chat/parse.rs
@@ -753,6 +753,6 @@ mod tests {
     )]);
     validate!(square_bracket_empty, "[]", [style::Print("[]")]);
     validate!(square_bracket_array, "a[i]", [style::Print("a[i]")]);
-    validate!(square_bracket_url_like, "[text] without url part", [style::Print("[text] without url part")]);
+    validate!(square_bracket_url_like_1, "[text] without url part", [style::Print("[text] without url part")]);
     validate!(square_bracket_url_like_2, "[text](without url part", [style::Print("[text](without url part")]);
 }

--- a/crates/q_cli/src/cli/chat/parse.rs
+++ b/crates/q_cli/src/cli/chat/parse.rs
@@ -404,9 +404,30 @@ fn url<'a, 'b>(
     state: &'b mut ParseState,
 ) -> impl FnMut(&mut Partial<&'a str>) -> PResult<(), Error<'a>> + 'b {
     move |i| {
-        let display = delimited("[", take_until(1.., "]("), "]").parse_next(i)?;
-        let link = delimited("(", take_till(0.., ')'), ")").parse_next(i)?;
-
+        // Save the current input position
+        let start = i.checkpoint();
+        
+        // Try to match the first part of URL pattern "[text]"
+        let display = match delimited::<_, _, _, _, Error<'a>, _, _, _>("[", take_until(1.., "]("), "]").parse_next(i) {
+            Ok(display) => display,
+            Err(_) => {
+                // If it doesn't match, reset position and fail
+                i.reset(&start);
+                return Err(ErrMode::from_error_kind(i, ErrorKind::Fail));
+            }
+        };
+        
+        // Try to match the second part of URL pattern "(url)"
+        let link = match delimited::<_, _, _, _, Error<'a>, _, _, _>("(", take_till(0.., ')'), ")").parse_next(i) {
+            Ok(link) => link,
+            Err(_) => {
+                // If it doesn't match, reset position and fail
+                i.reset(&start);
+                return Err(ErrMode::from_error_kind(i, ErrorKind::Fail));
+            }
+        };
+        
+        // Only generate output if the complete URL pattern matches
         queue_newline_or_advance(&mut o, state, display.width() + 1)?;
         queue(&mut o, style::SetForegroundColor(URL_TEXT_COLOR))?;
         queue(&mut o, style::Print(format!("{display} ")))?;
@@ -726,4 +747,8 @@ mod tests {
         style::SetForegroundColor(BLOCKQUOTE_COLOR),
         style::Print("│ hello"),
     ]);
+    validate!(square_bracket_1, "[test]", [style::Print("[test]")]);
+    validate!(square_bracket_2, "Text with [brackets]", [style::Print("Text with [brackets]")]);
+    validate!(square_bracket_empty, "[]", [style::Print("[]")]);
+    validate!(square_bracket_array, "a[i]", [style::Print("a[i]")]);
 }

--- a/crates/q_cli/src/cli/chat/parse.rs
+++ b/crates/q_cli/src/cli/chat/parse.rs
@@ -754,4 +754,5 @@ mod tests {
     validate!(square_bracket_empty, "[]", [style::Print("[]")]);
     validate!(square_bracket_array, "a[i]", [style::Print("a[i]")]);
     validate!(square_bracket_url_like, "[text] without url part", [style::Print("[text] without url part")]);
+    validate!(square_bracket_url_like_2, "[text](without url part", [style::Print("[text](without url part")]);
 }

--- a/crates/q_cli/src/cli/chat/parse.rs
+++ b/crates/q_cli/src/cli/chat/parse.rs
@@ -406,7 +406,7 @@ fn url<'a, 'b>(
     move |i| {
         // Save the current input position
         let start = i.checkpoint();
-        
+
         // Try to match the first part of URL pattern "[text]"
         let display = match delimited::<_, _, _, _, Error<'a>, _, _, _>("[", take_until(1.., "]("), "]").parse_next(i) {
             Ok(display) => display,
@@ -414,9 +414,9 @@ fn url<'a, 'b>(
                 // If it doesn't match, reset position and fail
                 i.reset(&start);
                 return Err(ErrMode::from_error_kind(i, ErrorKind::Fail));
-            }
+            },
         };
-        
+
         // Try to match the second part of URL pattern "(url)"
         let link = match delimited::<_, _, _, _, Error<'a>, _, _, _>("(", take_till(0.., ')'), ")").parse_next(i) {
             Ok(link) => link,
@@ -424,9 +424,9 @@ fn url<'a, 'b>(
                 // If it doesn't match, reset position and fail
                 i.reset(&start);
                 return Err(ErrMode::from_error_kind(i, ErrorKind::Fail));
-            }
+            },
         };
-        
+
         // Only generate output if the complete URL pattern matches
         queue_newline_or_advance(&mut o, state, display.width() + 1)?;
         queue(&mut o, style::SetForegroundColor(URL_TEXT_COLOR))?;
@@ -748,7 +748,10 @@ mod tests {
         style::Print("│ hello"),
     ]);
     validate!(square_bracket_1, "[test]", [style::Print("[test]")]);
-    validate!(square_bracket_2, "Text with [brackets]", [style::Print("Text with [brackets]")]);
+    validate!(square_bracket_2, "Text with [brackets]", [style::Print(
+        "Text with [brackets]"
+    )]);
     validate!(square_bracket_empty, "[]", [style::Print("[]")]);
     validate!(square_bracket_array, "a[i]", [style::Print("a[i]")]);
+    validate!(square_bracket_url_like, "[text] without url part", [style::Print("[text] without url part")]);
 }


### PR DESCRIPTION
*Issue #, if available:* #889 

*Description of changes:*

Modify URL parser to properly handle square brackets in text by saving the input position and resetting it when the complete URL pattern does not match. This ensures square brackets are correctly displayed in chat output when they are not part of a markdown link.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
