### PR TITLE
feat(tools): add gh_issue

### DIFF
--- a/crates/q_cli/src/cli/chat/conversation_state.rs
+++ b/crates/q_cli/src/cli/chat/conversation_state.rs
@@ -59,9 +59,10 @@ pub struct ConversationState {
     /// calling [Self::as_sendable_conversation_state].
     pub next_message: Option<UserInputMessage>,
     history: VecDeque<ChatMessage>,
-    /// Similar to history in that stores user and assistant responses, except that it is not used in message requests. 
-    /// Instead, the responses are expected to be in human-readable format, e.g user messages prefixed with '> '.
-    /// Should also be used to store errors posted in the chat.
+    /// Similar to history in that stores user and assistant responses, except that it is not used
+    /// in message requests. Instead, the responses are expected to be in human-readable format,
+    /// e.g user messages prefixed with '> '. Should also be used to store errors posted in the
+    /// chat.
     pub transcript: VecDeque<String>,
     tools: Vec<Tool>,
     /// Context manager for handling sticky context files
@@ -158,7 +159,7 @@ impl ConversationState {
 
         // Record message before adding context.
         self.append_user_transcript(&input);
-        
+
         // Combine context files with user input if available
         let content = if let Some(context) = context_files {
             format!("{}\n{}", context, input)
@@ -472,18 +473,14 @@ impl ConversationState {
         self.context_message_length
     }
 
-    pub fn append_user_transcript(&mut self, message: &String) {
+    pub fn append_user_transcript(&mut self, message: &str) {
         self.append_transcript(format!("> {}", message.replace("\n", "> \n")));
     }
 
     pub fn append_assistant_transcript(&mut self, message: &AssistantResponseMessage) {
-        let tool_uses = message.tool_uses.as_deref()
-            .map_or("none".to_string(), |tools| {
-                tools.iter()
-                    .map(|tool| tool.name.clone())
-                    .collect::<Vec<_>>()
-                    .join(",")
-            });
+        let tool_uses = message.tool_uses.as_deref().map_or("none".to_string(), |tools| {
+            tools.iter().map(|tool| tool.name.clone()).collect::<Vec<_>>().join(",")
+        });
         self.append_transcript(format!("{}\n[Tool uses: {tool_uses}]", message.content.clone()));
     }
 

--- a/crates/q_cli/src/cli/chat/conversation_state.rs
+++ b/crates/q_cli/src/cli/chat/conversation_state.rs
@@ -182,7 +182,6 @@ impl ConversationState {
             }),
             user_intent: None,
         };
-
         self.next_message = Some(msg);
     }
 

--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -431,7 +431,10 @@ where
             match result {
                 Ok(state) => next_state = Some(state),
                 Err(e) => {
-                    let mut print_error = |output: &mut W, prepend_msg: &str,report: Option<eyre::Report>,| -> Result<(), std::io::Error> {
+                    let mut print_error = |output: &mut W,
+                                           prepend_msg: &str,
+                                           report: Option<eyre::Report>|
+                     -> Result<(), std::io::Error> {
                         queue!(
                             output,
                             style::SetAttribute(Attribute::Bold),
@@ -993,14 +996,13 @@ where
                 style::Print(format!("{}\n", "▔".repeat(terminal_width))),
                 style::SetForegroundColor(Color::Reset),
             )?;
-            let invoke_result = tool.1.invoke(
-                &self.ctx, 
-                &mut self.output,
-                GhIssueContext {
+            let invoke_result = tool
+                .1
+                .invoke(&self.ctx, &mut self.output, GhIssueContext {
                     conversation_state: &self.conversation_state,
                     failed_request_ids: &self.failed_request_ids,
-                },
-            ).await;
+                })
+                .await;
 
             if self.interactive && self.spinner.is_some() {
                 queue!(
@@ -1133,7 +1135,8 @@ where
                             );
                             if self.interactive {
                                 execute!(self.output, cursor::Hide)?;
-                                self.spinner = Some(Spinner::new(Spinners::Dots, "Dividing up the work...".to_string()));
+                                self.spinner =
+                                    Some(Spinner::new(Spinners::Dots, "Dividing up the work...".to_string()));
                             }
                             // For stream timeouts, we'll tell the model to try and split its response into
                             // smaller chunks.
@@ -1145,7 +1148,8 @@ where
                                 });
                             self.conversation_state
                                 .append_new_user_message(
-                                    "You took too long to respond - try to split up the work into smaller steps.".to_string(),
+                                    "You took too long to respond - try to split up the work into smaller steps."
+                                        .to_string(),
                                 )
                                 .await;
                             self.send_tool_use_telemetry().await;
@@ -1171,7 +1175,7 @@ where
                                     "The generated tool use was too large, trying to divide up the work...".to_string(),
                                 ));
                             }
-        
+
                             self.conversation_state.push_assistant_message(*message);
                             let tool_results = vec![ToolResult {
                                     tool_use_id,
@@ -1190,7 +1194,7 @@ where
                         },
                         _ => return Err(recv_error.into()),
                     }
-                }
+                },
             }
 
             // Fix for the markdown parser copied over from q chat:

--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -432,7 +432,6 @@ where
                 Ok(state) => next_state = Some(state),
                 Err(e) => {
                     let mut print_error = |output: &mut W, prepend_msg: &str,report: Option<eyre::Report>,| -> Result<(), std::io::Error> {
-                        let transcript = &mut self.conversation_state.transcript;
                         queue!(
                             output,
                             style::SetAttribute(Attribute::Bold),
@@ -442,12 +441,12 @@ where
                         match report {
                             Some(report) => {
                                 let text = format!("{}: {:?}\n", prepend_msg, report);
-                                transcript.push(text.clone());
-                                queue!(output, style::Print(text),)?
+                                queue!(output, style::Print(&text),)?;
+                                self.conversation_state.append_transcript(text);
                             },
                             None => {
-                                transcript.push(prepend_msg.to_string());
-                                queue!(output, style::Print(prepend_msg), style::Print("\n"))?
+                                queue!(output, style::Print(prepend_msg), style::Print("\n"))?;
+                                self.conversation_state.append_transcript(prepend_msg.to_string());
                             },
                         }
 

--- a/crates/q_cli/src/cli/chat/tools/gh_issue.rs
+++ b/crates/q_cli/src/cli/chat/tools/gh_issue.rs
@@ -1,0 +1,143 @@
+use std::io::Write;
+
+use crossterm::{
+    queue,
+    style,
+};
+use crossterm::style::Color;
+use eyre::{
+    Result,
+    WrapErr,
+};
+use fig_os_shim::Context;
+use serde::Deserialize;
+
+use crate::cli::chat::conversation_state::ConversationState;
+use crate::cli::issue::IssueCreator;
+
+use super::InvokeOutput;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct GhIssue {
+    pub title: String,
+    pub expected_behavior: Option<String>,
+    pub actual_behavior: Option<String>,
+    pub steps_to_reproduce: Option<String>,
+}
+
+pub struct GhIssueContext<'a> {
+    pub conversation_state: &'a ConversationState,
+    pub failed_request_ids: &'a Vec<String>,
+}
+
+/// Max amount of user chat + assistant recent chat messages to include in the issue.
+const MAX_TRANSCRIPT_LEN: usize = 5;
+
+impl GhIssue {
+    pub async fn invoke(&self, _updates: impl Write, context: GhIssueContext<'_>) -> Result<InvokeOutput> {
+        // Prepare additional details from the chat session
+        let additional_environment = [
+            Self::get_request_ids(&context),
+            Self::get_context(&context).await,
+        ]
+        .join("\n\n");
+
+        // Add chat history to the actual behavior text.
+        let actual_behavior = self.actual_behavior
+            .as_ref()
+            .map(|behavior| format!("{behavior}\n{}\n\n", Self::get_transcript(&context)))
+            .unwrap_or_else(|| Self::get_transcript(&context));
+
+        let _ = IssueCreator {
+            title: Some(self.title.clone()),
+            expected_behavior: self.expected_behavior.clone(),
+            actual_behavior: Some(actual_behavior),
+            steps_to_reproduce: self.steps_to_reproduce.clone(),
+            additional_environment: Some(additional_environment),
+        }
+        .create_url()
+        .await
+        .wrap_err("failed to invoke gh issue tool");
+
+        Ok(Default::default())
+    }
+
+    fn get_transcript(context: &GhIssueContext<'_>) -> String {
+        let mut transcript_str = String::from("```\n[chat-transcript]\n");
+        let transcript = context.conversation_state.transcript(MAX_TRANSCRIPT_LEN);
+        if !transcript.is_empty() {
+            transcript_str.push_str(&transcript.join("\n\n"));
+        } else {
+            transcript_str.push_str("No chat history found.")
+        }
+
+        transcript_str.push_str("\n```");
+        transcript_str
+    }
+
+    fn get_request_ids(context: &GhIssueContext<'_>) -> String {
+        format!("[chat-failed_request_ids]\n{}", 
+            if context.failed_request_ids.is_empty() { 
+                "none".to_string() 
+            } else { 
+                context.failed_request_ids.join("\n") 
+            }
+        )
+    }
+
+    async fn get_context(context: &GhIssueContext<'_>) -> String {
+        let mut ctx_str = "[chat-context]\n".to_string();
+        let Some(ctx_manager) = &context.conversation_state.context_manager else {
+            ctx_str.push_str("No context available.");
+            return ctx_str;
+        };
+    
+        ctx_str.push_str(&format!("current_profile={}\n\n", ctx_manager.current_profile));
+        
+        // Context file categories
+        if ctx_manager.global_config.paths.is_empty() {
+            ctx_str.push_str("global=none\n\n");
+        } else {
+            ctx_str.push_str(&format!("global=\n{}\n\n", &ctx_manager.global_config.paths.join("\n")));
+        }
+
+        if ctx_manager.profile_config.paths.is_empty() {
+            ctx_str.push_str("profile=none\n\n");
+        } else {
+            ctx_str.push_str(&format!("profile=\n{}\n\n", &ctx_manager.profile_config.paths.join("\n")));
+        }
+
+        // Handle context files
+        match ctx_manager.get_context_files(false).await {
+            Ok(context_files) if !context_files.is_empty() => {
+                ctx_str.push_str("files=\n");
+                let total_size: usize = context_files
+                    .iter()
+                    .map(|(file, content)| {
+                        let size = content.as_bytes().len();
+                        ctx_str.push_str(&format!("{}, {} B\n", file, size));
+                        size
+                    })
+                    .sum();
+                ctx_str.push_str(&format!("total context size={total_size} B"));
+            }
+            _ => ctx_str.push_str("files=none"),
+        }
+
+        ctx_str
+    }
+
+    pub fn queue_description(&self, updates: &mut impl Write) -> Result<()> {
+        Ok(queue!(
+            updates, 
+            style::Print("I will prepare a github issue with our conversation history.\n"),
+            style::SetForegroundColor(Color::Green),
+            style::Print(format!("Title: {}\n", &self.title)), 
+            style::ResetColor
+        )?)
+    }
+
+    pub async fn validate(&mut self, _ctx: &Context) -> Result<()> {
+        Ok(())
+    }
+}

--- a/crates/q_cli/src/cli/chat/tools/gh_issue.rs
+++ b/crates/q_cli/src/cli/chat/tools/gh_issue.rs
@@ -40,7 +40,7 @@ impl GhIssue {
         // Add chat history to the actual behavior text.
         let actual_behavior = self.actual_behavior.as_ref().map_or_else(
             || Self::get_transcript(&context),
-            |behavior| format!("{behavior}\n{}\n\n", Self::get_transcript(&context)),
+            |behavior| format!("{behavior}\n\n{}\n", Self::get_transcript(&context)),
         );
 
         let _ = IssueCreator {

--- a/crates/q_cli/src/cli/chat/tools/mod.rs
+++ b/crates/q_cli/src/cli/chat/tools/mod.rs
@@ -1,8 +1,8 @@
 pub mod execute_bash;
 pub mod fs_read;
 pub mod fs_write;
-pub mod use_aws;
 pub mod gh_issue;
+pub mod use_aws;
 
 use std::io::Write;
 use std::path::{
@@ -24,9 +24,12 @@ use fig_api_client::model::{
 use fig_os_shim::Context;
 use fs_read::FsRead;
 use fs_write::FsWrite;
+use gh_issue::{
+    GhIssue,
+    GhIssueContext,
+};
 use serde::Deserialize;
 use use_aws::UseAws;
-use gh_issue::{GhIssue, GhIssueContext};
 
 use super::parser::ToolUse;
 
@@ -79,7 +82,12 @@ impl Tool {
 
     /// Invokes the tool asynchronously
     // TODO: Need to rework this to avoid passing in args meant for a single tool.
-    pub async fn invoke(&self, context: &Context, updates: &mut impl Write, gh_issue_context: GhIssueContext<'_>) -> Result<InvokeOutput> {
+    pub async fn invoke(
+        &self,
+        context: &Context,
+        updates: &mut impl Write,
+        gh_issue_context: GhIssueContext<'_>,
+    ) -> Result<InvokeOutput> {
         match self {
             Tool::FsRead(fs_read) => fs_read.invoke(context, updates).await,
             Tool::FsWrite(fs_write) => fs_write.invoke(context, updates).await,

--- a/crates/q_cli/src/cli/chat/tools/mod.rs
+++ b/crates/q_cli/src/cli/chat/tools/mod.rs
@@ -2,6 +2,7 @@ pub mod execute_bash;
 pub mod fs_read;
 pub mod fs_write;
 pub mod use_aws;
+pub mod gh_issue;
 
 use std::io::Write;
 use std::path::{
@@ -25,6 +26,7 @@ use fs_read::FsRead;
 use fs_write::FsWrite;
 use serde::Deserialize;
 use use_aws::UseAws;
+use gh_issue::{GhIssue, GhIssueContext};
 
 use super::parser::ToolUse;
 
@@ -37,6 +39,7 @@ pub enum Tool {
     FsWrite(FsWrite),
     ExecuteBash(ExecuteBash),
     UseAws(UseAws),
+    GhIssue(GhIssue),
 }
 
 impl Tool {
@@ -47,6 +50,7 @@ impl Tool {
             Tool::FsWrite(_) => "Write to filesystem",
             Tool::ExecuteBash(_) => "Execute shell command",
             Tool::UseAws(_) => "Use AWS CLI",
+            Tool::GhIssue(_) => "Prepare GitHub issue",
         }
     }
 
@@ -57,6 +61,7 @@ impl Tool {
             Tool::FsWrite(_) => "Writing to filesystem",
             Tool::ExecuteBash(execute_bash) => return format!("Executing `{}`", execute_bash.command),
             Tool::UseAws(_) => "Using AWS CLI",
+            Tool::GhIssue(_) => "Preparing GitHub issue",
         }
         .to_owned()
     }
@@ -68,16 +73,19 @@ impl Tool {
             Tool::FsWrite(_) => true,
             Tool::ExecuteBash(execute_bash) => execute_bash.requires_acceptance(),
             Tool::UseAws(use_aws) => use_aws.requires_acceptance(),
+            Tool::GhIssue(_) => false,
         }
     }
 
     /// Invokes the tool asynchronously
-    pub async fn invoke(&self, context: &Context, updates: &mut impl Write) -> Result<InvokeOutput> {
+    // TODO: Need to rework this to avoid passing in args meant for a single tool.
+    pub async fn invoke(&self, context: &Context, updates: &mut impl Write, gh_issue_context: GhIssueContext<'_>) -> Result<InvokeOutput> {
         match self {
             Tool::FsRead(fs_read) => fs_read.invoke(context, updates).await,
             Tool::FsWrite(fs_write) => fs_write.invoke(context, updates).await,
             Tool::ExecuteBash(execute_bash) => execute_bash.invoke(updates).await,
             Tool::UseAws(use_aws) => use_aws.invoke(context, updates).await,
+            Tool::GhIssue(gh_issue) => gh_issue.invoke(updates, gh_issue_context).await,
         }
     }
 
@@ -88,6 +96,7 @@ impl Tool {
             Tool::FsWrite(fs_write) => fs_write.queue_description(ctx, updates),
             Tool::ExecuteBash(execute_bash) => execute_bash.queue_description(updates),
             Tool::UseAws(use_aws) => use_aws.queue_description(updates),
+            Tool::GhIssue(gh_issue) => gh_issue.queue_description(updates),
         }
     }
 
@@ -98,6 +107,7 @@ impl Tool {
             Tool::FsWrite(fs_write) => fs_write.validate(ctx).await,
             Tool::ExecuteBash(execute_bash) => execute_bash.validate(ctx).await,
             Tool::UseAws(use_aws) => use_aws.validate(ctx).await,
+            Tool::GhIssue(gh_issue) => gh_issue.validate(ctx).await,
         }
     }
 }
@@ -119,6 +129,7 @@ impl TryFrom<ToolUse> for Tool {
             "fs_write" => Self::FsWrite(serde_json::from_value::<FsWrite>(value.args).map_err(map_err)?),
             "execute_bash" => Self::ExecuteBash(serde_json::from_value::<ExecuteBash>(value.args).map_err(map_err)?),
             "use_aws" => Self::UseAws(serde_json::from_value::<UseAws>(value.args).map_err(map_err)?),
+            "gh_issue" => Self::GhIssue(serde_json::from_value::<GhIssue>(value.args).map_err(map_err)?),
             unknown => {
                 return Err(ToolResult {
                     tool_use_id: value.id,

--- a/crates/q_cli/src/cli/chat/tools/mod.rs
+++ b/crates/q_cli/src/cli/chat/tools/mod.rs
@@ -137,7 +137,7 @@ impl TryFrom<ToolUse> for Tool {
             "fs_write" => Self::FsWrite(serde_json::from_value::<FsWrite>(value.args).map_err(map_err)?),
             "execute_bash" => Self::ExecuteBash(serde_json::from_value::<ExecuteBash>(value.args).map_err(map_err)?),
             "use_aws" => Self::UseAws(serde_json::from_value::<UseAws>(value.args).map_err(map_err)?),
-            "gh_issue" => Self::GhIssue(serde_json::from_value::<GhIssue>(value.args).map_err(map_err)?),
+            "report_issue" => Self::GhIssue(serde_json::from_value::<GhIssue>(value.args).map_err(map_err)?),
             unknown => {
                 return Err(ToolResult {
                     tool_use_id: value.id,

--- a/crates/q_cli/src/cli/chat/tools/tool_index.json
+++ b/crates/q_cli/src/cli/chat/tools/tool_index.json
@@ -148,8 +148,8 @@
     }
   },
   "gh_issue": {
-    "name": "gh_issue",
-    "description": "Opens the browser to a pre-filled GitHub issue template to report chat issues, bugs, or feature requests. Pre-filled information includes the conversation transcript, chat context, and chat request IDs from the service.",
+    "name": "report_issue",
+    "description": "Opens the browser to a pre-filled gh (GitHub) issue template to report chat issues, bugs, or feature requests. Pre-filled information includes the conversation transcript, chat context, and chat request IDs from the service.",
     "input_schema": {
       "type": "object",
       "properties": {

--- a/crates/q_cli/src/cli/chat/tools/tool_index.json
+++ b/crates/q_cli/src/cli/chat/tools/tool_index.json
@@ -163,7 +163,7 @@
         },
         "actual_behavior": {
           "type": "string",
-          "description": "Optional: The actual chat behavior that happpened and demonstrates the issue or lack of a feature."
+          "description": "Optional: The actual chat behavior that happened and demonstrates the issue or lack of a feature."
         },
         "steps_to_reproduce": {
           "type": "string",

--- a/crates/q_cli/src/cli/chat/tools/tool_index.json
+++ b/crates/q_cli/src/cli/chat/tools/tool_index.json
@@ -146,5 +146,31 @@
         "label"
       ]
     }
+  },
+  "gh_issue": {
+    "name": "gh_issue",
+    "description": "Opens the browser to a pre-filled GitHub issue template to report chat issues, bugs, or feature requests. Pre-filled information includes the conversation transcript, chat context, and chat request IDs from the service.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "The title of the GitHub issue."
+        },
+        "expected_behavior": {
+          "type": "string",
+          "description": "Optional: The expected chat behavior or action that did not happen."
+        },
+        "actual_behavior": {
+          "type": "string",
+          "description": "Optional: The actual chat behavior that happpened and demonstrates the issue or lack of a feature."
+        },
+        "steps_to_reproduce": {
+          "type": "string",
+          "description": "Optional: Previous user chat requests or steps that were taken that may have resulted in the issue or error response."
+        }
+      },
+      "required": ["title"]
+    }
   }
 }

--- a/crates/q_cli/src/cli/issue.rs
+++ b/crates/q_cli/src/cli/issue.rs
@@ -47,9 +47,9 @@ impl IssueCreator {
             },
         };
 
-        let environment =  match &self.additional_environment {
+        let environment = match &self.additional_environment {
             Some(ctx) => format!("{diagnostic_info}\n{ctx}"),
-            None => diagnostic_info
+            None => diagnostic_info,
         };
 
         let mut params = Vec::new();
@@ -57,12 +57,23 @@ impl IssueCreator {
         params.push(("os", &os));
         params.push(("environment", &environment));
 
-        self.title.as_deref().map(|t| params.push(("title", t)));
-        self.expected_behavior.as_deref().map(|e| params.push(("expected", e)));
-        self.actual_behavior.as_deref().map(|a| params.push(("actual", a)));
-        self.steps_to_reproduce.as_deref().map(|s| params.push(("reproduce", s)));
+        if let Some(t) = self.title.as_deref() {
+            params.push(("title", t));
+        }
+        if let Some(t) = self.expected_behavior.as_deref() {
+            params.push(("expected", t));
+        }
+        if let Some(t) = self.actual_behavior.as_deref() {
+            params.push(("actual", t));
+        }
+        if let Some(t) = self.steps_to_reproduce.as_deref() {
+            params.push(("reproduce", t));
+        }
 
-        let url = url::Url::parse_with_params(&format!("https://github.com/{GITHUB_REPO_NAME}/issues/new"), params.iter())?;
+        let url = url::Url::parse_with_params(
+            &format!("https://github.com/{GITHUB_REPO_NAME}/issues/new"),
+            params.iter(),
+        )?;
 
         println!("Heading over to GitHub...");
         if is_remote() || fig_util::open_url_async(url.as_str()).await.is_err() {

--- a/crates/q_cli/src/cli/issue.rs
+++ b/crates/q_cli/src/cli/issue.rs
@@ -32,6 +32,9 @@ pub struct IssueCreator {
 
 impl IssueCreator {
     pub async fn create_url(&self) -> Result<url::Url> {
+        let warning = |text: &String| {
+            format!("<This will be visible to anyone. Do not include personal or sensitive information>\n\n{text}")
+        };
         let diagnostics = Diagnostics::new().await;
 
         let os = match &diagnostics.system_info.os {
@@ -53,21 +56,21 @@ impl IssueCreator {
         };
 
         let mut params = Vec::new();
-        params.push(("template", TEMPLATE_NAME));
-        params.push(("os", &os));
-        params.push(("environment", &environment));
+        params.push(("template", TEMPLATE_NAME.to_string()));
+        params.push(("os", os));
+        params.push(("environment", warning(&environment)));
 
-        if let Some(t) = self.title.as_deref() {
+        if let Some(t) = self.title.clone() {
             params.push(("title", t));
         }
-        if let Some(t) = self.expected_behavior.as_deref() {
-            params.push(("expected", t));
+        if let Some(t) = self.expected_behavior.as_ref() {
+            params.push(("expected", warning(t)));
         }
-        if let Some(t) = self.actual_behavior.as_deref() {
-            params.push(("actual", t));
+        if let Some(t) = self.actual_behavior.as_ref() {
+            params.push(("actual", warning(t)));
         }
-        if let Some(t) = self.steps_to_reproduce.as_deref() {
-            params.push(("reproduce", t));
+        if let Some(t) = self.steps_to_reproduce.as_ref() {
+            params.push(("reproduce", warning(t)));
         }
 
         let url = url::Url::parse_with_params(


### PR DESCRIPTION
**To be squashed**

*Issue #, if available:*
https://github.com/aws/amazon-q-developer-cli/issues/873

*Description of changes:*
Add the `gh_issue` tool that allows Q to open pre-filled issue templates with additional information. Similar to `q issue`, when asked to report an issue, a browser will open to the template (or URL if the browser cannot be opened).

Features:
- Triggers when asked to create or report an issue, or to open a feature request.
- Adds additional chat information automatically.
- Q could fill in expected/actual behavior, steps to reproduce, title.
- Includes any request IDs that resulted in an error.
- Includes chat context (from `/context show --expand`). This also includes their sizes.
- Includes the last **5** user-assistant requests from the chat transcript. This also includes any tool uses or errors that were displayed.


https://github.com/user-attachments/assets/b3f70548-bba2-490d-86eb-6e514f299157


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
