### PR TITLE
feat(cli): improve context file display

### DIFF
--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -834,40 +834,49 @@ where
                                 execute!(self.output, style::Print("\n"))?;
                             }
 
-                            // If expand flag is set, show the expanded files
-                            if expand {
-                                match context_manager.get_context_files(false).await {
-                                    Ok(context_files) => {
-                                        if context_files.is_empty() {
-                                            execute!(
-                                                self.output,
-                                                style::SetForegroundColor(Color::DarkGrey),
-                                                style::Print("No files matched the patterns.\n\n"),
-                                                style::SetForegroundColor(Color::Reset)
-                                            )?;
-                                        } else {
-                                            execute!(
-                                                self.output,
-                                                style::SetForegroundColor(Color::Green),
-                                                style::Print(format!("Expanded files ({}):\n", context_files.len())),
-                                                style::SetForegroundColor(Color::Reset)
-                                            )?;
-
-                                            for (filename, _) in context_files {
-                                                execute!(self.output, style::Print(format!("    {}\n", filename)))?;
-                                            }
-                                            execute!(self.output, style::Print("\n"))?;
-                                        }
-                                    },
-                                    Err(e) => {
+                            match context_manager.get_context_files(false).await {
+                                Ok(context_files) => {
+                                    if context_files.is_empty() {
                                         execute!(
                                             self.output,
-                                            style::SetForegroundColor(Color::Red),
-                                            style::Print(format!("Error expanding files: {}\n\n", e)),
+                                            style::SetForegroundColor(Color::DarkGrey),
+                                            style::Print("No files matched the configured context paths.\n\n"),
                                             style::SetForegroundColor(Color::Reset)
                                         )?;
-                                    },
-                                }
+                                    } else if expand {
+                                        // Show expanded file list when expand flag is set
+                                        execute!(
+                                            self.output,
+                                            style::SetForegroundColor(Color::Green),
+                                            style::Print(format!("Expanded files ({}):\n", context_files.len())),
+                                            style::SetForegroundColor(Color::Reset)
+                                        )?;
+
+                                        for (filename, _) in context_files {
+                                            execute!(self.output, style::Print(format!("    {}\n", filename)))?;
+                                        }
+                                        execute!(self.output, style::Print("\n"))?;
+                                    } else {
+                                        // Just show the count when expand flag is not set
+                                        execute!(
+                                            self.output,
+                                            style::SetForegroundColor(Color::Green),
+                                            style::Print(format!(
+                                                "Number of context files in use: {}\n",
+                                                context_files.len()
+                                            )),
+                                            style::SetForegroundColor(Color::Reset)
+                                        )?;
+                                    }
+                                },
+                                Err(e) => {
+                                    execute!(
+                                        self.output,
+                                        style::SetForegroundColor(Color::Red),
+                                        style::Print(format!("Error retrieving context files: {}\n\n", e)),
+                                        style::SetForegroundColor(Color::Reset)
+                                    )?;
+                                },
                             }
                         },
                         command::ContextSubcommand::Add { global, force, paths } => {


### PR DESCRIPTION
*Issue #, if available:*

Currently, running `/context show` doesn't tell users if there are/aren't any files being tracked in the context.
This can be confusing as we show the path-rules, but not the expanded paths by default.

*Description of changes:*

improve context file display by doing the following - 
- Always show context file count regardless of expand flag
- Let users know when no files are currently being added to context

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

![Screenshot 2025-03-27 at 10 33 22 PM](https://github.com/user-attachments/assets/a3234f24-e12c-4b87-9d33-9e2573a47ea1)

