### PR TITLE
feat(tools): increase transcript length, record all user input

### DIFF
--- a/crates/q_cli/src/cli/chat/conversation_state.rs
+++ b/crates/q_cli/src/cli/chat/conversation_state.rs
@@ -157,9 +157,6 @@ impl ConversationState {
             None
         };
 
-        // Record message before adding context.
-        self.append_user_transcript(&input);
-
         // Combine context files with user input if available
         let content = if let Some(context) = context_files {
             format!("{}\n{}", context, input)

--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -576,6 +576,7 @@ where
             }
         };
 
+        self.conversation_state.append_user_transcript(&user_input);
         Ok(ChatState::HandleInput {
             input: user_input,
             tool_uses: Some(tool_uses),

--- a/crates/q_cli/src/cli/chat/tools/gh_issue.rs
+++ b/crates/q_cli/src/cli/chat/tools/gh_issue.rs
@@ -30,7 +30,7 @@ pub struct GhIssueContext<'a> {
 }
 
 /// Max amount of user chat + assistant recent chat messages to include in the issue.
-const MAX_TRANSCRIPT_LEN: usize = 5;
+const MAX_TRANSCRIPT_LEN: usize = 10;
 
 impl GhIssue {
     pub async fn invoke(&self, _updates: impl Write, context: GhIssueContext<'_>) -> Result<InvokeOutput> {


### PR DESCRIPTION
- Take last 10 chats instead of last 5
- Also accept any user input, like commands (/acceptall, /clear).

*Issue #, if available:*
https://github.com/aws/amazon-q-developer-cli/issues/981

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
