### PR TITLE
feat(commands): add /issue command to chat

### DIFF
--- a/crates/q_cli/src/cli/chat/command.rs
+++ b/crates/q_cli/src/cli/chat/command.rs
@@ -7,6 +7,7 @@ pub enum Command {
     Clear,
     Help,
     AcceptAll,
+    Issue { prompt: Option<String> },
     Quit,
     Profile { subcommand: ProfileSubcommand },
     Context { subcommand: ContextSubcommand },
@@ -163,6 +164,15 @@ impl Command {
                 "clear" => Self::Clear,
                 "help" => Self::Help,
                 "acceptall" => Self::AcceptAll,
+                "issue" => {
+                    if parts.len() > 1 {
+                        Self::Issue {
+                            prompt: Some(parts[1..].join(" ")),
+                        }
+                    } else {
+                        Self::Issue { prompt: None }
+                    }
+                },
                 "q" | "exit" | "quit" => Self::Quit,
                 "profile" => {
                     if parts.len() < 2 {
@@ -443,6 +453,13 @@ mod tests {
                 "/context clear --global",
                 context!(ContextSubcommand::Clear { global: true }),
             ),
+            ("/issue", Command::Issue { prompt: None }),
+            ("/issue there was an error in the chat", Command::Issue {
+                prompt: Some("there was an error in the chat".to_string()),
+            }),
+            ("/issue \"there was an error in the chat\"", Command::Issue {
+                prompt: Some("\"there was an error in the chat\"".to_string()),
+            }),
         ];
 
         for (input, parsed) in tests {

--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -96,6 +96,7 @@ const WELCOME_TEXT: &str = color_print::cstr! {"
 • Help me understand my git status
 
 <em>/acceptall</em>    <black!>Toggles acceptance prompting for the session.</black!>
+<em>/issue</em>        <black!>Report an issue or make a feature request.</black!>
 <em>/profile</em>      <black!>(Beta) Manage profiles for the chat session</black!>
 <em>/context</em>      <black!>(Beta) Manage context files for a profile</black!>
 <em>/help</em>         <black!>Show the help dialogue</black!>
@@ -110,6 +111,7 @@ const HELP_TEXT: &str = color_print::cstr! {"
 
 <em>/clear</em>        <black!>Clear the conversation history</black!>
 <em>/acceptall</em>    <black!>Toggles acceptance prompting for the session.</black!>
+<em>/issue</em>        <black!>Report an issue or make a feature request.</black!>
 <em>/help</em>         <black!>Show this help dialogue</black!>
 <em>/quit</em>         <black!>Quit the application</black!>
 <em>/profile</em>      <black!>Manage profiles</black!>
@@ -664,6 +666,17 @@ where
                 ChatState::PromptUser {
                     tool_uses: Some(tool_uses),
                     skip_printing_tools: true,
+                }
+            },
+            Command::Issue { prompt } => {
+                let input = "I would like to report an issue or make a feature request";
+                ChatState::HandleInput {
+                    input: if let Some(prompt) = prompt {
+                        format!("{input}: {prompt}")
+                    } else {
+                        input.to_string()
+                    },
+                    tool_uses: Some(tool_uses),
                 }
             },
             Command::AcceptAll => {

--- a/crates/q_cli/src/cli/chat/prompt.rs
+++ b/crates/q_cli/src/cli/chat/prompt.rs
@@ -30,6 +30,7 @@ const COMMANDS: &[&str] = &[
     "/clear",
     "/help",
     "/acceptall",
+    "/issue",
     "/quit",
     "/profile",
     "/profile help",


### PR DESCRIPTION
This command simply prompts amazon Q to use the `report_issue` tool. Any additional text beyond /issue will be provided in the prompt.

*Issue #, if available:*
https://github.com/aws/amazon-q-developer-cli/issues/972

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
