### PR TITLE
feat(tools): display chat settings in report_issue

### DIFF
--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -1412,6 +1412,8 @@ where
                     context_manager: self.conversation_state.context_manager.clone(),
                     transcript: self.conversation_state.transcript.clone(),
                     failed_request_ids: self.failed_request_ids.clone(),
+                    accept_all: self.accept_all,
+                    interactive: self.interactive,
                 });
             },
             _ => (),


### PR DESCRIPTION
- record if `accept_all` or `interactive` is true/false
- display list of all available profiles

Related: https://github.com/aws/amazon-q-developer-cli/issues/873


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
