### PR TITLE
Improved User Experience for Context Window Limit

### DIFF
--- a/crates/q_cli/src/cli/chat/conversation_state.rs
+++ b/crates/q_cli/src/cli/chat/conversation_state.rs
@@ -251,7 +251,7 @@ impl ConversationState {
                             user_input_message_context: Some(ctx),
                             ..
                         }) if ctx.tool_results.as_ref().is_some_and(|r| !r.is_empty()) => {
-                            *content = "The conversation history has overflowed, clearing state".to_string();
+                            *content = "The conversation history has overflowed, clearing state. Mention to user that invoking a larger number of tools one after the other can cause the chat to reset. Request the user to reduce the number of sequential calls if possible in the future.".to_string();
                             ctx.tool_results.take();
                         },
                         _ => {},


### PR DESCRIPTION
**IMPORTANT**: We'll need to deploy to RTS prod first, and then update to a new client minor version to get this working.

This PR addresses an issue where conversations would unexpectedly reset when the context window limit is reached, causing a negative customer experience.

## Changes

- Instead of clearing the conversation history entirely when the context window overflows, we now provide a more informative message to the user explaining what happened
- The message now explicitly mentions that invoking a large number of tools sequentially can cause the chat to reset
- The message provides actionable guidance to users, suggesting they reduce the number of sequential tool calls

## Before

<img width="915" alt="Screenshot 2025-03-28 at 2 24 31 PM" src="https://github.com/user-attachments/assets/6f0d6d7e-7fac-4909-80a2-d3573a8e3b67" />

When the conversation history overflowed, users received a generic message that didn't explain why the conversation was reset or how to avoid it in the future.

## After
<img width="1613" alt="Screenshot 2025-03-28 at 2 21 23 PM" src="https://github.com/user-attachments/assets/e090694e-741c-47c1-8f0a-38ce27e8ce49" />

## Testing

Testing was done by changing the constant `MAX_CONVERSATION_STATE_HISTORY_LEN` in `conversation_state.rs` from 100 to 10 to simulate the overflow condition more easily.


This PR enhances the user experience when a user reaches the context window limit in Amazon Q CLI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
