### PR TITLE
refactor: use map for filename completion

### DIFF
--- a/crates/q_chat/src/prompt.rs
+++ b/crates/q_chat/src/prompt.rs
@@ -120,16 +120,12 @@ impl PathCompleter {
         ctx: &Context<'_>,
     ) -> Result<(usize, Vec<String>), ReadlineError> {
         // Use the filename completer to get path completions
-        match self.filename_completer.complete(line, pos, ctx) {
-            Ok((pos, completions)) => {
-                // Convert the filename completer's pairs to strings
-                let file_completions: Vec<String> = completions.iter().map(|pair| pair.replacement.clone()).collect();
-
-                // Return the completions if we have any
-                Ok((pos, file_completions))
-            },
-            Err(err) => Err(err),
-        }
+        self.filename_completer
+            .complete(line, pos, ctx)
+            .map(|(pos, completions)| {
+                let file_completions = completions.iter().map(|pair| pair.replacement.clone()).collect();
+                (pos, file_completions)
+            })
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:* `NA`

*Description of changes:*

This PR refactors the path completion logic by replacing the match expression with a more concise and functional style using iterator combinators.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
