### PR TITLE
refactor(chat): Update prompt validator for multi-line input

### DIFF
--- a/crates/q_cli/src/cli/chat/input_source.rs
+++ b/crates/q_cli/src/cli/chat/input_source.rs
@@ -36,32 +36,12 @@ impl InputSource {
     pub fn read_line(&mut self, prompt: Option<&str>) -> Result<Option<String>, ReadlineError> {
         match &mut self.0 {
             inner::Inner::Readline(rl) => {
-                let mut prompt = prompt.unwrap_or_default();
-                let mut line = String::new();
-                loop {
-                    let curr_line = rl.readline(prompt);
-                    match curr_line {
-                        Ok(l) => {
-                            if l.trim().is_empty() {
-                                continue;
-                            } else if l.ends_with("\\") {
-                                line.push_str(&l);
-                                line.pop();
-                                prompt = ">> ";
-                                continue;
-                            } else {
-                                line.push_str(&l);
-                                let _ = rl.add_history_entry(line.as_str());
-                                return Ok(Some(line));
-                            }
-                        },
-                        Err(ReadlineError::Interrupted | ReadlineError::Eof) => {
-                            return Ok(None);
-                        },
-                        Err(err) => {
-                            return Err(err);
-                        },
-                    }
+                let prompt = prompt.unwrap_or_default();
+                let curr_line = rl.readline(prompt);
+                match curr_line {
+                    Ok(line) => Ok(Some(line)),
+                    Err(ReadlineError::Interrupted | ReadlineError::Eof) => Ok(None),
+                    Err(err) => Err(err),
                 }
             },
             inner::Inner::Mock { index, lines } => {

--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -102,6 +102,7 @@ const WELCOME_TEXT: &str = color_print::cstr! {"
 <em>/help</em>         <black!>Show the help dialogue</black!>
 <em>/quit</em>         <black!>Quit the application</black!>
 
+<cyan!>Use Alt+Enter to provide multi-line prompts.</cyan!>
 
 "};
 
@@ -109,6 +110,7 @@ const HELP_TEXT: &str = color_print::cstr! {"
 
 <magenta,em>q</magenta,em> (Amazon Q Chat)
 
+<cyan,em>Commands:</cyan,em>
 <em>/clear</em>        <black!>Clear the conversation history</black!>
 <em>/acceptall</em>    <black!>Toggles acceptance prompting for the session.</black!>
 <em>/issue</em>        <black!>Report an issue or make a feature request.</black!>
@@ -128,7 +130,9 @@ const HELP_TEXT: &str = color_print::cstr! {"
   <em>rm</em>          <black!>Remove file(s) from context [--global]</black!>
   <em>clear</em>       <black!>Clear all files from current context [--global]</black!>
 
+<cyan,em>Tips:</cyan,em>
 <em>!{command}</em>    <black!>Quickly execute a command in your current session</black!>
+<em>Alt+Enter</em>     <black!>Insert new-line to provide multi-line prompt. Alternatively, [Ctrl+j]</black!>
 
 "};
 

--- a/crates/q_cli/src/cli/chat/prompt.rs
+++ b/crates/q_cli/src/cli/chat/prompt.rs
@@ -13,16 +13,25 @@ use rustyline::highlight::{
     Highlighter,
 };
 use rustyline::history::DefaultHistory;
+use rustyline::validate::{
+    ValidationContext,
+    ValidationResult,
+    Validator,
+};
 use rustyline::{
+    Cmd,
     Completer,
     CompletionType,
     Config,
     Context,
     EditMode,
     Editor,
+    EventHandler,
     Helper,
     Hinter,
-    Validator,
+    KeyCode,
+    KeyEvent,
+    Modifiers,
 };
 use winnow::stream::AsChar;
 
@@ -151,14 +160,44 @@ impl Completer for ChatCompleter {
     }
 }
 
-#[derive(Helper, Completer, Hinter, Validator)]
+/// Custom validator for multi-line input
+pub struct MultiLineValidator;
+
+impl Validator for MultiLineValidator {
+    fn validate(&self, ctx: &mut ValidationContext<'_>) -> rustyline::Result<ValidationResult> {
+        let input = ctx.input();
+
+        if input.trim().is_empty() {
+            return Ok(ValidationResult::Incomplete);
+        }
+
+        // Check for explicit multi-line markers
+        if input.starts_with("```") && !input.ends_with("```") {
+            return Ok(ValidationResult::Incomplete);
+        }
+
+        // Check for backslash continuation
+        if input.ends_with('\\') {
+            return Ok(ValidationResult::Incomplete);
+        }
+
+        Ok(ValidationResult::Valid(None))
+    }
+}
+
+#[derive(Helper, Completer, Hinter)]
 pub struct ChatHelper {
     #[rustyline(Completer)]
     completer: ChatCompleter,
-    #[rustyline(Validator)]
-    validator: (),
     #[rustyline(Hinter)]
     hinter: (),
+    validator: MultiLineValidator,
+}
+
+impl Validator for ChatHelper {
+    fn validate(&self, ctx: &mut ValidationContext<'_>) -> rustyline::Result<ValidationResult> {
+        self.validator.validate(ctx)
+    }
 }
 
 impl Highlighter for ChatHelper {
@@ -203,10 +242,23 @@ pub fn rl() -> Result<Editor<ChatHelper, DefaultHistory>> {
     let h = ChatHelper {
         completer: ChatCompleter::new(),
         hinter: (),
-        validator: (),
+        validator: MultiLineValidator,
     };
     let mut rl = Editor::with_config(config)?;
     rl.set_helper(Some(h));
+
+    // Add custom keybinding for Alt+Enter to insert a newline
+    rl.bind_sequence(
+        KeyEvent(KeyCode::Enter, Modifiers::ALT),
+        EventHandler::Simple(Cmd::Insert(1, "\n".to_string())),
+    );
+
+    // Add custom keybinding for Ctrl+J to insert a newline
+    rl.bind_sequence(
+        KeyEvent(KeyCode::Char('j'), Modifiers::CTRL),
+        EventHandler::Simple(Cmd::Insert(1, "\n".to_string())),
+    );
+
     Ok(rl)
 }
 


### PR DESCRIPTION
Add the MultiLineValidator implementation in prompt.rs to support multi-line editing in the q chat terminal

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

https://github.com/user-attachments/assets/14d20fad-a668-4b4e-b572-cf3f640c062a


https://github.com/user-attachments/assets/9398ab84-3da6-498a-afc3-7c7845125439

