### PR TITLE
Fix history-support with multi-line

### DIFF
--- a/crates/q_cli/src/cli/chat/input_source.rs
+++ b/crates/q_cli/src/cli/chat/input_source.rs
@@ -39,7 +39,10 @@ impl InputSource {
                 let prompt = prompt.unwrap_or_default();
                 let curr_line = rl.readline(prompt);
                 match curr_line {
-                    Ok(line) => Ok(Some(line)),
+                    Ok(line) => {
+                        let _ = rl.add_history_entry(line.as_str());
+                        Ok(Some(line))
+                    },
                     Err(ReadlineError::Interrupted | ReadlineError::Eof) => Ok(None),
                     Err(err) => Err(err),
                 }


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/amazon-q-developer-cli/pull/1044#discussion_r2025311601

*Description of changes:*

Add lines to history to allow navigation using up/down arrow keys
