### PR TITLE
feat(commands): granular permissions with /tools

### DIFF
--- a/crates/q_cli/src/cli/chat/command.rs
+++ b/crates/q_cli/src/cli/chat/command.rs
@@ -1,3 +1,10 @@
+use std::io::Write;
+
+use crossterm::style::Color;
+use crossterm::{
+    queue,
+    style,
+};
 use eyre::Result;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -6,11 +13,11 @@ pub enum Command {
     Execute { command: String },
     Clear,
     Help,
-    AcceptAll,
     Issue { prompt: Option<String> },
     Quit,
     Profile { subcommand: ProfileSubcommand },
     Context { subcommand: ContextSubcommand },
+    Tools { subcommand: Option<ToolsSubcommand> },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -126,6 +133,56 @@ Adding relevant files to your context helps Amazon Q provide more accurate and h
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolsSubcommand {
+    Trust { tool_name: String },
+    Untrust { tool_name: String },
+    TrustAll,
+    Reset,
+    Help,
+}
+
+impl ToolsSubcommand {
+    const AVAILABLE_COMMANDS: &str = color_print::cstr! {"<cyan!>Available subcommands</cyan!>
+  <em>help</em>                           <black!>Show an explanation for the trust command</black!>
+  <em>trust <<tool name>></em>              <black!>Trust a specific tool for the session</black!>
+  <em>untrust <<tool name>></em>            <black!>Revert a tool to per-request confirmation</black!>
+  <em>trustall</em>                       <black!>Trust all tools (equivalent to deprecated /acceptall)</black!>
+  <em>reset</em>                          <black!>Reset all tools to default permission levels</black!>"};
+    const BASE_COMMAND: &str = color_print::cstr! {"<cyan!>Usage: /tools [SUBCOMMAND]</cyan!>
+
+<cyan!>Description</cyan!>
+  Show the current set of tools and their permission settings. 
+  Alternatively, specify a subcommand to modify the tool permissions."};
+    const TRUST_USAGE: &str = "/tools trust <tool name>";
+    const UNTRUST_USAGE: &str = "/tools untrust <tool name>";
+
+    fn usage_msg(header: impl AsRef<str>) -> String {
+        format!(
+            "{}\n\n{}\n\n{}",
+            header.as_ref(),
+            Self::BASE_COMMAND,
+            Self::AVAILABLE_COMMANDS
+        )
+    }
+
+    pub fn help_text() -> String {
+        color_print::cformat!(
+            r#"
+<magenta,em>Tool Permissions</magenta,em>
+
+By default, Amazon Q will ask for your permission to certain tools. You can control which tools you
+trust so that no confirmation is required. These settings will last only for this session.
+
+{}
+
+{}"#,
+            Self::BASE_COMMAND,
+            Self::AVAILABLE_COMMANDS
+        )
+    }
+}
+
 impl Command {
     // Check if input is a common single-word command that should use slash prefix
     fn check_common_command(input: &str) -> Option<String> {
@@ -145,7 +202,7 @@ impl Command {
         }
     }
 
-    pub fn parse(input: &str) -> Result<Self, String> {
+    pub fn parse(input: &str, output: &mut impl Write) -> Result<Self, String> {
         let input = input.trim();
 
         // Check for common single-word commands without slash prefix
@@ -163,7 +220,18 @@ impl Command {
             return Ok(match parts[0].to_lowercase().as_str() {
                 "clear" => Self::Clear,
                 "help" => Self::Help,
-                "acceptall" => Self::AcceptAll,
+                "acceptall" => {
+                    let _ = queue!(
+                        output,
+                        style::SetForegroundColor(Color::Yellow),
+                        style::Print("\n/acceptall is deprecated. Use /tools instead.\n\n"),
+                        style::SetForegroundColor(Color::Reset)
+                    );
+
+                    Self::Tools {
+                        subcommand: Some(ToolsSubcommand::TrustAll),
+                    }
+                },
                 "issue" => {
                     if parts.len() > 1 {
                         Self::Issue {
@@ -346,6 +414,57 @@ impl Command {
                         },
                     }
                 },
+                "tools" => {
+                    if parts.len() < 2 {
+                        return Ok(Self::Tools { subcommand: None });
+                    }
+
+                    macro_rules! usage_err {
+                        ($subcommand:expr, $usage_str:expr) => {
+                            return Err(format!(
+                                "Invalid /tools {} arguments.\n\nUsage:\n  {}",
+                                $subcommand, $usage_str
+                            ))
+                        };
+                    }
+
+                    match parts[1].to_lowercase().as_str() {
+                        "trust" => {
+                            let tool_name = parts.get(2);
+                            match tool_name {
+                                Some(tool_name) => Self::Tools {
+                                    subcommand: Some(ToolsSubcommand::Trust {
+                                        tool_name: (*tool_name).to_string(),
+                                    }),
+                                },
+                                None => usage_err!("trust", ToolsSubcommand::TRUST_USAGE),
+                            }
+                        },
+                        "untrust" => {
+                            let tool_name = parts.get(2);
+                            match tool_name {
+                                Some(tool_name) => Self::Tools {
+                                    subcommand: Some(ToolsSubcommand::Untrust {
+                                        tool_name: (*tool_name).to_string(),
+                                    }),
+                                },
+                                None => usage_err!("untrust", ToolsSubcommand::UNTRUST_USAGE),
+                            }
+                        },
+                        "trustall" => Self::Tools {
+                            subcommand: Some(ToolsSubcommand::TrustAll),
+                        },
+                        "reset" => Self::Tools {
+                            subcommand: Some(ToolsSubcommand::Reset),
+                        },
+                        "help" => Self::Tools {
+                            subcommand: Some(ToolsSubcommand::Help),
+                        },
+                        other => {
+                            return Err(ToolsSubcommand::usage_msg(format!("Unknown subcommand '{}'.", other)));
+                        },
+                    }
+                },
                 _ => {
                     return Ok(Self::Ask {
                         prompt: input.to_string(),
@@ -372,6 +491,8 @@ mod tests {
 
     #[test]
     fn test_command_parse() {
+        let mut stdout = std::io::stdout();
+
         macro_rules! profile {
             ($subcommand:expr) => {
                 Command::Profile {
@@ -463,12 +584,13 @@ mod tests {
         ];
 
         for (input, parsed) in tests {
-            assert_eq!(&Command::parse(input).unwrap(), parsed, "{}", input);
+            assert_eq!(&Command::parse(input, &mut stdout).unwrap(), parsed, "{}", input);
         }
     }
 
     #[test]
     fn test_common_command_suggestions() {
+        let mut stdout = std::io::stdout();
         let test_cases = vec![
             (
                 "exit",
@@ -501,7 +623,7 @@ mod tests {
         ];
 
         for (input, expected_message) in test_cases {
-            let result = Command::parse(input);
+            let result = Command::parse(input, &mut stdout);
             assert!(result.is_err(), "Expected error for input: {}", input);
             assert_eq!(result.unwrap_err(), expected_message);
         }

--- a/crates/q_cli/src/cli/chat/command.rs
+++ b/crates/q_cli/src/cli/chat/command.rs
@@ -144,7 +144,7 @@ pub enum ToolsSubcommand {
 
 impl ToolsSubcommand {
     const AVAILABLE_COMMANDS: &str = color_print::cstr! {"<cyan!>Available subcommands</cyan!>
-  <em>help</em>                           <black!>Show an explanation for the trust command</black!>
+  <em>help</em>                           <black!>Show an explanation for the tools command</black!>
   <em>trust <<tool name>></em>              <black!>Trust a specific tool for the session</black!>
   <em>untrust <<tool name>></em>            <black!>Revert a tool to per-request confirmation</black!>
   <em>trustall</em>                       <black!>Trust all tools (equivalent to deprecated /acceptall)</black!>

--- a/crates/q_cli/src/cli/chat/command.rs
+++ b/crates/q_cli/src/cli/chat/command.rs
@@ -171,7 +171,7 @@ impl ToolsSubcommand {
             r#"
 <magenta,em>Tool Permissions</magenta,em>
 
-By default, Amazon Q will ask for your permission to certain tools. You can control which tools you
+By default, Amazon Q will ask for your permission to use certain tools. You can control which tools you
 trust so that no confirmation is required. These settings will last only for this session.
 
 {}

--- a/crates/q_cli/src/cli/chat/conversation_state.rs
+++ b/crates/q_cli/src/cli/chat/conversation_state.rs
@@ -33,7 +33,10 @@ use tracing::{
 };
 
 use super::context::ContextManager;
-use super::tools::ToolSpec;
+use super::tools::{
+    QueuedTool,
+    ToolSpec,
+};
 use super::truncate_safe;
 use crate::cli::chat::tools::{
     InputSchema,
@@ -64,7 +67,7 @@ pub struct ConversationState {
     /// e.g user messages prefixed with '> '. Should also be used to store errors posted in the
     /// chat.
     pub transcript: VecDeque<String>,
-    tools: Vec<Tool>,
+    pub tools: Vec<Tool>,
     /// Context manager for handling sticky context files
     pub context_manager: Option<ContextManager>,
     /// Cached value representing the length of the user context message.
@@ -350,12 +353,12 @@ impl ConversationState {
     }
 
     /// Sets the next user message with "cancelled" tool results.
-    pub fn abandon_tool_use(&mut self, tools_to_be_abandoned: Vec<(String, super::tools::Tool)>, deny_input: String) {
+    pub fn abandon_tool_use(&mut self, tools_to_be_abandoned: Vec<QueuedTool>, deny_input: String) {
         debug_assert!(self.next_message.is_none());
         let tool_results = tools_to_be_abandoned
             .into_iter()
-            .map(|(tool_use_id, _)| ToolResult {
-                tool_use_id,
+            .map(|tool| ToolResult {
+                tool_use_id: tool.id,
                 content: vec![ToolResultContentBlock::Text(
                     "Tool use was cancelled by the user".to_string(),
                 )],

--- a/crates/q_cli/src/cli/chat/prompt.rs
+++ b/crates/q_cli/src/cli/chat/prompt.rs
@@ -38,9 +38,14 @@ use winnow::stream::AsChar;
 const COMMANDS: &[&str] = &[
     "/clear",
     "/help",
-    "/acceptall",
     "/issue",
+    // "/acceptall", /// Functional, but deprecated in favor of /tools trustall
     "/quit",
+    "/tools",
+    "/tools trust",
+    "/tools untrust",
+    "/tools trustall",
+    "/tools reset",
     "/profile",
     "/profile help",
     "/profile list",

--- a/crates/q_cli/src/cli/chat/tools/gh_issue.rs
+++ b/crates/q_cli/src/cli/chat/tools/gh_issue.rs
@@ -1,4 +1,7 @@
-use std::collections::VecDeque;
+use std::collections::{
+    HashMap,
+    VecDeque,
+};
 use std::io::Write;
 
 use crossterm::style::Color;
@@ -14,7 +17,10 @@ use eyre::{
 use fig_os_shim::Context;
 use serde::Deserialize;
 
-use super::InvokeOutput;
+use super::{
+    InvokeOutput,
+    ToolPermission,
+};
 use crate::cli::chat::context::ContextManager;
 use crate::cli::issue::IssueCreator;
 
@@ -34,7 +40,7 @@ pub struct GhIssueContext {
     pub context_manager: Option<ContextManager>,
     pub transcript: VecDeque<String>,
     pub failed_request_ids: Vec<String>,
-    pub accept_all: bool,
+    pub tool_permissions: HashMap<String, ToolPermission>,
     pub interactive: bool,
 }
 
@@ -180,8 +186,12 @@ impl GhIssue {
 
     fn get_chat_settings(context: &GhIssueContext) -> String {
         let mut result_str = "[chat-settings]\n".to_string();
-        result_str.push_str(&format!("accept_all={}\n", context.accept_all));
         result_str.push_str(&format!("interactive={}", context.interactive));
+
+        result_str.push_str("\n\n[chat-trusted_tools]");
+        for (tool, permission) in context.tool_permissions.iter() {
+            result_str.push_str(&format!("\n{tool}={}", permission.trusted));
+        }
 
         result_str
     }

--- a/crates/q_cli/src/cli/mod.rs
+++ b/crates/q_cli/src/cli/mod.rs
@@ -182,8 +182,8 @@ pub enum CliRootCommands {
     /// AI assistant in your terminal
     #[command(alias("q"))]
     Chat {
-        /// Enabling this flag allows the model to execute all commands without first accepting
-        /// them.
+        /// (Deprecated, use --trust-all-tools) Enabling this flag allows the model to execute
+        /// all commands without first accepting them.
         #[arg(short, long)]
         accept_all: bool,
         /// Print the first response to STDOUT without interactive mode. This will fail if the
@@ -195,13 +195,12 @@ pub enum CliRootCommands {
         /// Context profile to use
         #[arg(long = "profile")]
         profile: Option<String>,
-        /// Trust all tools to perform actions without confirmation (equivalent to deprecated
-        /// accept_all)
+        /// Allows the model to use any tool to run commands without asking for confirmation.
         #[arg(long)]
         trust_all_tools: bool,
-        /// Trust only this set of tools. Example: '--trust-tools=fs_read,fs_write' OR
-        /// to trust no tools, use '--trust-tools='
-        #[arg(long, value_delimiter = ',')]
+        /// Trust only this set of tools. Example: trust some tools: '--trust-tools=fs_read,fs_write',
+        /// trust no tools: '--trust-tools='
+        #[arg(long, value_delimiter = ',', value_name="TOOL_NAMES")]
         trust_tools: Option<Vec<String>>,
     },
     /// Inline shell completions

--- a/crates/q_cli/src/cli/mod.rs
+++ b/crates/q_cli/src/cli/mod.rs
@@ -198,9 +198,9 @@ pub enum CliRootCommands {
         /// Allows the model to use any tool to run commands without asking for confirmation.
         #[arg(long)]
         trust_all_tools: bool,
-        /// Trust only this set of tools. Example: trust some tools: '--trust-tools=fs_read,fs_write',
-        /// trust no tools: '--trust-tools='
-        #[arg(long, value_delimiter = ',', value_name="TOOL_NAMES")]
+        /// Trust only this set of tools. Example: trust some tools:
+        /// '--trust-tools=fs_read,fs_write', trust no tools: '--trust-tools='
+        #[arg(long, value_delimiter = ',', value_name = "TOOL_NAMES")]
         trust_tools: Option<Vec<String>>,
     },
     /// Inline shell completions


### PR DESCRIPTION
Implements https://github.com/aws/amazon-q-developer-cli/pull/921 which describes trusting and untrusting specific tools for the current session.

- Start with default permissions. Users can change them from command line or within chat via /tools
- `/acceptall` and `--accept-all` were deprecated in favor of `--trust-all-tools` and `/tools trustall`. They will continue to work, but display a notice and activation functionality of the new commands.
  - Command::AcceptAll no longer exists
- UI has been reword a little, see screenshots.
- `report_issue` will include trust override settings in the report.
- Chat supports multiple tool use requests from Q at once. I have refactored the tool flow to allow asking permissions for individual tool requests at a time
  - Now, ExecuteTools (checks for acceptance one tool at a time) -> PromptUser (ask for acceptance) -> HandleInput (handle acceptance) -> ExecuteTools (find next tool that needs acceptance OR trigger execution if none remaining).
  - I was not able to find a prompt that made Q send multiple tool_uses in a single request coming from Q. It seems to do them iteratively even when asked to do them in parallel.
  - In any case, that original logic to support parallel requests is preserved with this new structure.

Risks: Likely conflicts with https://github.com/aws/amazon-q-developer-cli/pull/999

<img width="1202" alt="image" src="https://github.com/user-attachments/assets/86ebbfac-e1eb-4038-acfa-b220b446f318" />

<img width="934" alt="image" src="https://github.com/user-attachments/assets/62a940ad-eb7c-4fa1-b4a8-f130d4a5c901" />

![image](https://github.com/user-attachments/assets/0504e69c-9a11-41af-a4da-26e222d647d0)
![image](https://github.com/user-attachments/assets/b82791e8-575a-4507-8616-a7b6d21cb545)
![image](https://github.com/user-attachments/assets/41fdaefa-96da-4de4-9ac0-e703820b853a)
![image](https://github.com/user-attachments/assets/82b8c27f-1810-42dc-ba07-0e923354c9cd)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
