### PR TITLE
fix(cli): Improve chat input handling and keyboard shortcut display

### DIFF
--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -102,7 +102,7 @@ const WELCOME_TEXT: &str = color_print::cstr! {"
 <em>/help</em>         <black!>Show the help dialogue</black!>
 <em>/quit</em>         <black!>Quit the application</black!>
 
-<cyan!>Use Alt+Enter to provide multi-line prompts.</cyan!>
+<cyan!>Use Alt(⌥) + Enter(⏎) to provide multi-line prompts.</cyan!>
 
 "};
 
@@ -131,8 +131,8 @@ const HELP_TEXT: &str = color_print::cstr! {"
   <em>clear</em>       <black!>Clear all files from current context [--global]</black!>
 
 <cyan,em>Tips:</cyan,em>
-<em>!{command}</em>    <black!>Quickly execute a command in your current session</black!>
-<em>Alt+Enter</em>     <black!>Insert new-line to provide multi-line prompt. Alternatively, [Ctrl+j]</black!>
+<em>!{command}</em>            <black!>Quickly execute a command in your current session</black!>
+<em>Alt(⌥) + Enter(⏎)</em>     <black!>Insert new-line to provide multi-line prompt. Alternatively, [Ctrl+j]</black!>
 
 "};
 
@@ -567,7 +567,13 @@ where
             let prompt = prompt::generate_prompt(self.conversation_state.current_profile());
 
             match (self.input_source.read_line(Some(&prompt))?, ctrl_c) {
-                (Some(line), _) => break line,
+                (Some(line), _) => {
+                    // Handle empty line case - reprompt the user
+                    if line.trim().is_empty() {
+                        continue;
+                    }
+                    break line;
+                },
                 (None, false) => {
                     execute!(
                         self.output,

--- a/crates/q_cli/src/cli/chat/prompt.rs
+++ b/crates/q_cli/src/cli/chat/prompt.rs
@@ -167,10 +167,6 @@ impl Validator for MultiLineValidator {
     fn validate(&self, ctx: &mut ValidationContext<'_>) -> rustyline::Result<ValidationResult> {
         let input = ctx.input();
 
-        if input.trim().is_empty() {
-            return Ok(ValidationResult::Incomplete);
-        }
-
         // Check for explicit multi-line markers
         if input.starts_with("```") && !input.ends_with("```") {
             return Ok(ValidationResult::Incomplete);


### PR DESCRIPTION

*Issue #, if available:*
- Empty Line was considered as incomplete prompt instead of re-prompting the user

*Description of changes:*

- Add keyboard symbols (⌥, ⏎) to make shortcuts more recognizable
- Handle empty line inputs by reprompting the user instead of processing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<img width="997" alt="Screenshot 2025-04-03 at 7 32 56 PM" src="https://github.com/user-attachments/assets/d70b710b-4fa9-447f-a67d-3fee67a13a53" />
