### PR TITLE
fix(chat): remove unneeded . characters from welcome message

### DIFF
--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -104,8 +104,8 @@ const WELCOME_TEXT: &str = color_print::cstr! {"
 • Write unit tests for my application.
 • Help me understand my git status
 
-<em>/tools</em>        <black!>View and manage tools and permissions.</black!>
-<em>/issue</em>        <black!>Report an issue or make a feature request.</black!>
+<em>/tools</em>        <black!>View and manage tools and permissions</black!>
+<em>/issue</em>        <black!>Report an issue or make a feature request</black!>
 <em>/profile</em>      <black!>(Beta) Manage profiles for the chat session</black!>
 <em>/context</em>      <black!>(Beta) Manage context files for a profile</black!>
 <em>/help</em>         <black!>Show the help dialogue</black!>
@@ -121,10 +121,10 @@ const HELP_TEXT: &str = color_print::cstr! {"
 
 <cyan,em>Commands:</cyan,em>
 <em>/clear</em>        <black!>Clear the conversation history</black!>
-<em>/issue</em>        <black!>Report an issue or make a feature request.</black!>
+<em>/issue</em>        <black!>Report an issue or make a feature request</black!>
 <em>/help</em>         <black!>Show this help dialogue</black!>
 <em>/quit</em>         <black!>Quit the application</black!>
-<em>/tools</em>        <black!>View and manage tools and permissions.</black!>
+<em>/tools</em>        <black!>View and manage tools and permissions</black!>
   <em>help</em>        <black!>Show an explanation for the trust command</black!>
   <em>trust</em>       <black!>Trust a specific tool for the session</black!>
   <em>untrust</em>     <black!>Revert a tool to per-request confirmation</black!>


### PR DESCRIPTION
Align with other help text.

Before:
<img width="470" alt="image" src="https://github.com/user-attachments/assets/546d3e99-83a4-4681-89de-5ec0263b8bb1" />

After:
<img width="476" alt="image" src="https://github.com/user-attachments/assets/0dc31ed7-b728-41ab-ab91-77978d444c55" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
