### PR TITLE
feat(cli): preprocessor tools

### DIFF
--- a/crates/fig_api_client/src/model.rs
+++ b/crates/fig_api_client/src/model.rs
@@ -149,6 +149,8 @@ pub struct ToolSpecification {
     pub description: String,
     /// The input schema for the tool in JSON format.
     pub input_schema: ToolInputSchema,
+    /// Whether the tool is a preprocessor.
+    pub is_preprocessor: bool,
 }
 
 impl From<ToolSpecification> for amzn_codewhisperer_streaming_client::types::ToolSpecification {
@@ -756,6 +758,7 @@ mod tests {
                     input_schema: ToolInputSchema {
                         json: Some(Document::Null),
                     },
+                    is_preprocessor: false,
                 })]),
             }),
             user_intent: Some(UserIntent::ApplyCommonBestPractices),

--- a/crates/q_cli/src/cli/chat/tool_manager.rs
+++ b/crates/q_cli/src/cli/chat/tool_manager.rs
@@ -302,10 +302,11 @@ impl ToolManager {
                 },
             }
         }
+
         Ok(tool_specs)
     }
 
-    pub fn get_tool_from_tool_use(&self, value: ToolUse) -> Result<Tool, ToolResult> {
+    pub async fn get_tool_from_tool_use(&self, value: ToolUse) -> Result<Tool, ToolResult> {
         let map_err = |parse_error| ToolResult {
             tool_use_id: value.id.clone(),
             content: vec![ToolResultContentBlock::Text(format!(
@@ -347,6 +348,7 @@ impl ToolManager {
                 params.insert("name".to_owned(), serde_json::Value::String(tool_name.to_owned()));
                 params.insert("arguments".to_owned(), value.args);
                 let params = serde_json::Value::Object(params);
+
                 let custom_tool = CustomTool {
                     name: tool_name.to_owned(),
                     client: client.clone(),

--- a/crates/q_cli/src/cli/chat/tools/custom_tool.rs
+++ b/crates/q_cli/src/cli/chat/tools/custom_tool.rs
@@ -21,7 +21,10 @@ use serde::{
     Deserialize,
     Serialize,
 };
-use tracing::warn;
+use tracing::{
+    debug,
+    warn,
+};
 
 use super::{
     InvokeOutput,

--- a/crates/q_cli/src/cli/chat/tools/mod.rs
+++ b/crates/q_cli/src/cli/chat/tools/mod.rs
@@ -22,7 +22,10 @@ use fig_os_shim::Context;
 use fs_read::FsRead;
 use fs_write::FsWrite;
 use gh_issue::GhIssue;
-use serde::Deserialize;
+use serde::{
+    Deserialize,
+    Serialize,
+};
 use use_aws::UseAws;
 
 pub const MAX_TOOL_RESPONSE_SIZE: usize = 800000;
@@ -116,16 +119,18 @@ impl Tool {
 
 /// A tool specification to be sent to the model as part of a conversation. Maps to
 /// [BedrockToolSpecification].
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ToolSpec {
     pub name: String,
     pub description: String,
     #[serde(alias = "inputSchema")]
     pub input_schema: InputSchema,
+    #[serde(default, alias = "preprocessor")]
+    pub is_preprocessor: bool,
 }
 
 /// The schema specification describing a tool's fields.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct InputSchema(pub serde_json::Value);
 
 /// The output received from invoking a [Tool].

--- a/rfcs/0002-preprocessor-tools.md
+++ b/rfcs/0002-preprocessor-tools.md
@@ -1,0 +1,112 @@
+- Feature Name: preprocessor_tools
+- Start Date: 2025-03-31
+
+# Summary
+
+[summary]: #summary
+
+This RFC introduces **Preprocessor Tools** in the Model Context Protocol (MCP). Preprocessor tools are executed deterministically for every prompt before the user input is processed by the language model (LLM). Their outputs are injected into the request context but do not persist in the conversation history. Preprocessor tools are not available as general tools and are excluded from the tool specifications sent to the LLM.
+
+# Motivation
+
+[motivation]: #motivation
+
+Certain tools, such as a **RetrieveMemories** function in a personalization system, must be executed before every user prompt to provide necessary context to the LLM. Since these tools serve a preparatory function rather than an interactive one, they require a distinct designation within MCP.
+
+By introducing a **preprocessor** flag in the MCP tool specification, we ensure deterministic execution of these tools while preserving the integrity of the tool interface. Additionally, this design maintains backward compatibility and provides a pathway for potential upstream adoption into the MCP project.
+
+Another key benefit of preprocessors is **control over tool execution order**. By ensuring that preprocessors execute before the LLM receives a prompt, we can guarantee that their output is able to influence subsequent standard tool calls. If RetrieveMemories were a standard tool, it might execute later in the chain, preventing earlier tool calls from benefiting from its output. This could lead to suboptimal tool selections, as key user memory entries may have altered the request or influenced which tools should be invoked.
+
+# Guide-level explanation
+
+[guide-level-explanation]: #guide-level-explanation
+
+### Introducing Preprocessor Tools
+
+A **Preprocessor Tool** is a special category of MCP tool that runs before every user prompt. Unlike standard tools:
+
+- They execute deterministically before the LLM receives the user's prompt.
+- Their output is injected into the request context but does not persist in the conversation history.
+- They are not accessible as general tools and do not appear in the LLM's toolset.
+
+Example: Suppose we have a **RetrieveMemories** tool that fetches user-specific memories. This tool must execute on every prompt to provide personalization data to the LLM. By marking it as a preprocessor, we ensure it runs every time and its output is available to the model without the user having to call it explicitly.
+
+### Example: RetrieveMemories Tool Specification
+
+```json
+{
+  "name": "RetrieveMemories",
+  "description": "Retrieves relevant user memories",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "query": {
+        "type": "string",
+        "description": "The user input to match against memories"
+      }
+    }
+  },
+  "preprocessor": true
+}
+```
+
+# Reference-level explanation
+
+[reference-level-explanation]: #reference-level-explanation
+
+### MCP Tool Specification Update
+
+A new `preprocessor` field is added to the MCP tool specification:
+
+```json
+{
+  "name": "string",          // Unique identifier for the tool
+  "description": "string",   // Optional human-readable description
+  "inputSchema": {           // JSON Schema defining tool parameters
+    "type": "object",
+    "properties": { ... }    // Tool-specific parameters
+  },
+  "preprocessor": true       // New flag indicating preprocessor tool status
+}
+```
+
+### Behavior of Preprocessor Tools
+
+- **Deterministic Execution**: Preprocessor tools run for every prompt before it reaches the LLM.
+- **Context Injection**: Their output is included in the request context but does not modify the conversation history.
+- **Restricted Availability**: Preprocessors are not available as general tools and are omitted from the tool specs sent to the LLM.
+- **Tool Execution Order Control**: Preprocessors guarantee that their output is available before the LLM decides which other tools to invoke.
+- **Non-Disruptive Addition**: The introduction of this feature does not break existing MCP tool specifications.
+
+# Drawbacks
+
+[drawbacks]: #drawbacks
+
+- **Latency**: Preprocessors introduce latency for prompts that do not require their output. However, in cases where a preprocessor would otherwise be called as a standard tool, this approach can reduce latency by eliminating an additional LLM call (if no other tools are involved).
+
+# Rationale and alternatives
+
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+- **Why this design?** The preprocessor flag ensures a clean, additive modification to MCP without disrupting existing tools.
+- **Alternatives considered:**
+  - Ensure 'always-execute' functionality by relying on the tool description: This is non-deterministic, and the reliability would depend on the wider context of the request. Also, there would be no control over the ordering of tool executions (e.g. if multiple tools have 'always-execute' tool descriptions).
+  - Custom CLI integration/built-in tool: This would not harness MCP, and would not scale outside of the CLI.
+- **Impact of not implementing:** Personalization and other pre-execution-dependent use cases would require workarounds.
+
+# Unresolved questions
+
+[unresolved-questions]: #unresolved-questions
+
+- Should we provide an API for listing registered preprocessors?
+- Should preprocessors support dependency ordering if multiple exist?
+- Should there be logging/debugging tools specific to preprocessors?
+
+# Future possibilities
+
+[future-possibilities]: #future-possibilities
+
+- **Upstream Contribution**: We may propose this feature for inclusion in the upstream MCP project.
+- **Broader Applications**: Other potential use cases include real-time security validation, compliance checks, or dynamic user context augmentation.
+
+This RFC provides a structured approach to introducing **Preprocessor Tools** in MCP, ensuring deterministic execution of essential context-providing functions while maintaining backwards compatibility.


### PR DESCRIPTION
# Preprocessor Tools

This PR implements preprocessor tools as defined in RFC-0002 https://github.com/aws/amazon-q-developer-cli/pull/1040. Preprocessor tools are executed automatically before each user prompt is sent to the LLM, allowing for deterministic context injection without requiring explicit user invocation.

## Key Changes
• Added `is_preprocessor` flag to tool specifications
• Implemented preprocessor execution flow in the chat module
• Added preprocessor outputs to the context manager
• Updated conversation state to properly handle preprocessor context

## New Context Format
The context format has been updated to be more generic so it can include files and preprocessor outputs:
• Changed from a single block with `--- CONTEXT FILES BEGIN/END ---` to individual entries with `--- CONTEXT ENTRY BEGIN/END ---`
• Each entry has a [label]\ncontent format within its own block
• Preprocessor outputs are included as named entries alongside file contents

Example context:

```
--- CONTEXT ENTRY BEGIN ---
[/path/to/README.md]
# Project Documentation

This is a sample README file that would be included in the context.
It contains information about the project structure and usage.

## Installation
Follow these steps to install the project...
--- CONTEXT ENTRY END ---

--- CONTEXT ENTRY BEGIN ---
[RetrieveMemories]
{
  "memories": [
    {
      "content": "User prefers TypeScript over JavaScript",
    },
    {
      "content": "User is working on a serverless project",
    }
  ]
}
--- CONTEXT ENTRY END ---

--- CONTEXT ENTRY BEGIN ---
[/path/to/config.json]
{
  "version": "1.0.0",
  "settings": {
    "theme": "dark",
    "autoSave": true
  }
}
--- CONTEXT ENTRY END ---
```

This PR also fixes a bug in `crates/q_cli/src/cli/chat/conversation_state.rs` where context messages were being appended to the conversation history on each turn.

