### PR TITLE
fix(chat): cli crashes when tool_uses is none

### DIFF
--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -475,10 +475,10 @@ where
                     tool_uses,
                     pending_tool_index,
                 } => {
-                    let tool_uses_clone = tool_uses.clone().unwrap();
+                    let tool_uses_clone = tool_uses.clone();
                     tokio::select! {
                         res = self.handle_input(input, tool_uses, pending_tool_index) => res,
-                        Some(_) = ctrl_c_stream.recv() => Err(ChatError::Interrupted { tool_uses: Some(tool_uses_clone) })
+                        Some(_) = ctrl_c_stream.recv() => Err(ChatError::Interrupted { tool_uses: tool_uses_clone })
                     }
                 },
                 ChatState::ExecuteTools(tool_uses) => {


### PR DESCRIPTION
*Issue #, if available:*
#1091 

*Description of changes:*
* Removed the unwrapping of tool_use_clone and passed that directly to `Interrupted`