### PR TITLE
feat: enhance tools reset

### DIFF
--- a/crates/q_cli/src/cli/chat/command.rs
+++ b/crates/q_cli/src/cli/chat/command.rs
@@ -140,6 +140,7 @@ pub enum ToolsSubcommand {
     Untrust { tool_name: String },
     TrustAll,
     Reset,
+    ResetSingle { tool_name: String },
     Help,
 }
 
@@ -149,7 +150,8 @@ impl ToolsSubcommand {
   <em>trust <<tool name>></em>              <black!>Trust a specific tool for the session</black!>
   <em>untrust <<tool name>></em>            <black!>Revert a tool to per-request confirmation</black!>
   <em>trustall</em>                       <black!>Trust all tools (equivalent to deprecated /acceptall)</black!>
-  <em>reset</em>                          <black!>Reset all tools to default permission levels</black!>"};
+  <em>reset</em>                          <black!>Reset all tools to default permission levels</black!>
+  <em>reset <<tool name>></em>              <black!>Reset a single tool to default permission level</black!>"};
     const BASE_COMMAND: &str = color_print::cstr! {"<cyan!>Usage: /tools [SUBCOMMAND]</cyan!>
 
 <cyan!>Description</cyan!>
@@ -464,8 +466,18 @@ impl Command {
                         "trustall" => Self::Tools {
                             subcommand: Some(ToolsSubcommand::TrustAll),
                         },
-                        "reset" => Self::Tools {
-                            subcommand: Some(ToolsSubcommand::Reset),
+                        "reset" => {
+                            let tool_name = parts.get(2);
+                            match tool_name {
+                                Some(tool_name) => Self::Tools {
+                                    subcommand: Some(ToolsSubcommand::ResetSingle {
+                                        tool_name: (*tool_name).to_string(),
+                                    }),
+                                },
+                                None => Self::Tools {
+                                    subcommand: Some(ToolsSubcommand::Reset),
+                                },
+                            }
                         },
                         "help" => Self::Tools {
                             subcommand: Some(ToolsSubcommand::Help),

--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -1244,6 +1244,15 @@ where
                             style::SetForegroundColor(Color::Reset),
                         )?;
                     },
+                    Some(ToolsSubcommand::ResetSingle { tool_name }) => {
+                        self.tool_permissions.reset_tool(&tool_name);
+                        queue!(
+                            self.output,
+                            style::SetForegroundColor(Color::Green),
+                            style::Print(format!("\nReset tool '{}' to the default permission level.", tool_name)),
+                            style::SetForegroundColor(Color::Reset),
+                        )?;
+                    },
                     Some(ToolsSubcommand::Help) => {
                         queue!(
                             self.output,

--- a/crates/q_cli/src/cli/chat/tools/mod.rs
+++ b/crates/q_cli/src/cli/chat/tools/mod.rs
@@ -27,6 +27,7 @@ use fs_read::FsRead;
 use fs_write::FsWrite;
 use gh_issue::GhIssue;
 use serde::Deserialize;
+use tracing::warn;
 use use_aws::UseAws;
 
 use super::parser::ToolUse;
@@ -195,6 +196,10 @@ impl ToolPermissions {
     }
 
     pub fn reset_tool(&mut self, tool_name: &str) {
+        if !self.permissions.contains_key(tool_name) {
+            warn!("No custom permissions set for tool '{tool_name}' to reset");
+            return;
+        }
         self.permissions.remove(tool_name);
     }
 

--- a/crates/q_cli/src/cli/chat/tools/mod.rs
+++ b/crates/q_cli/src/cli/chat/tools/mod.rs
@@ -194,6 +194,10 @@ impl ToolPermissions {
         self.permissions.clear();
     }
 
+    pub fn reset_tool(&mut self, tool_name: &str) {
+        self.permissions.remove(tool_name);
+    }
+
     pub fn has(&self, tool_name: &str) -> bool {
         self.permissions.contains_key(tool_name)
     }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/amazon-q-developer-cli/issues/1086

*Description of changes:* 

1. Added a new `ResetSingle` variant to the `ToolsSubcommand` enum in `crates/q_cli/src/cli/chat/command.rs`
2. Updated the `AVAILABLE_COMMANDS` constant to include documentation for the new reset single tool command
Added handling in the command parser to support both `/tools reset (reset all)` and `/tools reset <tool_name>` (reset single)
Added a new `reset_tool` method to the `ToolPermissions` struct in `crates/q_cli/src/cli/chat/tools/mod.rs`
5. Added command handling for the `ResetSingle` variant in the Chat state machine in `crates/q_cli/src/cli/chat/mod.rs`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
