### PR TITLE
feat(chat): all-tools-trusted indicator

### DIFF
--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -677,8 +677,12 @@ where
         // Require two consecutive sigint's to exit.
         let mut ctrl_c = false;
         let user_input = loop {
-            // Generate prompt based on active context profile
-            let prompt = prompt::generate_prompt(self.conversation_state.current_profile());
+            let all_tools_trusted = self.conversation_state.tools.iter().all(|t| match t {
+                FigTool::ToolSpecification(t) => self.tool_permissions.is_trusted(&t.name),
+            });
+
+            // Generate prompt based on active context profile and trusted tools
+            let prompt = prompt::generate_prompt(self.conversation_state.current_profile(), all_tools_trusted);
 
             match (self.input_source.read_line(Some(&prompt))?, ctrl_c) {
                 (Some(line), _) => {

--- a/crates/q_cli/src/cli/chat/prompt.rs
+++ b/crates/q_cli/src/cli/chat/prompt.rs
@@ -66,16 +66,14 @@ const COMMANDS: &[&str] = &[
     "/context clear --global",
 ];
 
-pub fn generate_prompt(current_profile: Option<&str>) -> String {
-    if let Some(profile_name) = &current_profile {
-        if *profile_name != "default" {
-            // Format with profile name for non-default profiles
-            return format!("[{}] > ", profile_name);
-        }
-    }
+pub fn generate_prompt(current_profile: Option<&str>, warning: bool) -> String {
+    let warning_symbol = if warning { "!".red().to_string() } else { "".to_string() };
+    let profile_part = current_profile
+        .filter(|&p| p != "default")
+        .map(|p| format!("[{p}] ").cyan().to_string())
+        .unwrap_or_default();
 
-    // Default prompt
-    "> ".to_string()
+    format!("{profile_part}{warning_symbol}{}", "> ".magenta())
 }
 
 /// Complete commands that start with a slash
@@ -203,21 +201,6 @@ impl Validator for ChatHelper {
 }
 
 impl Highlighter for ChatHelper {
-    fn highlight_prompt<'b, 's: 'b, 'p: 'b>(&'s self, prompt: &'p str, _default: bool) -> Cow<'b, str> {
-        // Check if the prompt contains a context profile indicator
-        if let Some(profile_end) = prompt.find("] ") {
-            // Split the prompt into context part and the rest
-            let context_part = &prompt[..=profile_end];
-            let rest = &prompt[(profile_end + 1)..];
-
-            // Color the context part cyan and the rest magenta
-            Cow::Owned(format!("{}{}", context_part.cyan(), rest.magenta()))
-        } else {
-            // Default prompt with magenta color
-            Cow::Owned(prompt.magenta().to_string())
-        }
-    }
-
     fn highlight_hint<'h>(&self, hint: &'h str) -> Cow<'h, str> {
         Cow::Owned(format!("\x1b[1m{hint}\x1b[m"))
     }
@@ -271,13 +254,21 @@ mod tests {
     #[test]
     fn test_generate_prompt() {
         // Test default prompt (no profile)
-        assert_eq!(generate_prompt(None), "> ");
+        assert_eq!(generate_prompt(None, false), "> ".magenta().to_string());
+        // Test default prompt with warning
+        assert_eq!(generate_prompt(None, true), format!("{}{}", "!".red(), "> ".magenta()));
         // Test default profile (should be same as no profile)
-        assert_eq!(generate_prompt(Some("default")), "> ");
+        assert_eq!(generate_prompt(Some("default"), false), "> ".magenta().to_string());
         // Test custom profile
-        assert_eq!(generate_prompt(Some("test-profile")), "[test-profile] > ");
-        // Test another custom profile
-        assert_eq!(generate_prompt(Some("dev")), "[dev] > ");
+        assert_eq!(
+            generate_prompt(Some("test-profile"), false),
+            format!("{}{}", "[test-profile] ".cyan(), "> ".magenta())
+        );
+        // Test another custom profile with warning
+        assert_eq!(
+            generate_prompt(Some("dev"), true),
+            format!("{}{}{}", "[dev] ".cyan(), "!".red(), "> ".magenta())
+        );
     }
 
     #[test]


### PR DESCRIPTION
Issue: https://github.com/aws/amazon-q-developer-cli/issues/1042

Attaches a red ! to ">" prompt indicator if **all** available tools are trusted.


<img width="680" alt="image" src="https://github.com/user-attachments/assets/faafee84-eee4-4653-9ddb-2fc8f62cb384" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
