### PR TITLE
refactor(context): Simplify 'show' command by removing --expand option

### DIFF
--- a/crates/q_cli/src/cli/chat/command.rs
+++ b/crates/q_cli/src/cli/chat/command.rs
@@ -70,9 +70,7 @@ Profiles allow you to organize and manage different sets of context files for di
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ContextSubcommand {
-    Show {
-        expand: bool,
-    },
+    Show,
     Add {
         global: bool,
         force: bool,
@@ -92,8 +90,8 @@ impl ContextSubcommand {
     const ADD_USAGE: &str = "/context add [--global] [--force] <path1> [path2...]";
     const AVAILABLE_COMMANDS: &str = color_print::cstr! {"<cyan!>Available commands</cyan!>
   <em>help</em>                           <black!>Show an explanation for the context command</black!>
-  <em>show [--expand]</em>                <black!>Display current context configuration</black!>
-                                 <black!>Use --expand to list all matched files</black!>
+
+  <em>show</em>                           <black!>Display current context configuration</black!>
 
   <em>add [--global] [--force] <<paths...>></em>
                                  <black!>Add file(s) to context</black!>
@@ -107,7 +105,6 @@ impl ContextSubcommand {
                                  <black!>--global: Clear global context</black!>"};
     const CLEAR_USAGE: &str = "/context clear [--global]";
     const REMOVE_USAGE: &str = "/context rm [--global] <path1> [path2...]";
-    const SHOW_USAGE: &str = "/context show [--expand]";
 
     fn usage_msg(header: impl AsRef<str>) -> String {
         format!("{}\n\n{}", header.as_ref(), Self::AVAILABLE_COMMANDS)
@@ -339,21 +336,8 @@ impl Command {
                     }
 
                     match parts[1].to_lowercase().as_str() {
-                        "show" => {
-                            // Parse show command with optional --expand flag
-                            let mut expand = false;
-
-                            for part in &parts[2..] {
-                                if *part == "--expand" {
-                                    expand = true;
-                                } else {
-                                    usage_err!(ContextSubcommand::SHOW_USAGE);
-                                }
-                            }
-
-                            Self::Context {
-                                subcommand: ContextSubcommand::Show { expand },
-                            }
+                        "show" => Self::Context {
+                            subcommand: ContextSubcommand::Show,
                         },
                         "add" => {
                             // Parse add command with paths and flags
@@ -544,11 +528,7 @@ mod tests {
                 "/profile set p",
                 profile!(ProfileSubcommand::Set { name: "p".to_string() }),
             ),
-            ("/context show", context!(ContextSubcommand::Show { expand: false })),
-            (
-                "/context show --expand",
-                context!(ContextSubcommand::Show { expand: true }),
-            ),
+            ("/context show", context!(ContextSubcommand::Show)),
             (
                 "/context add p1 p2",
                 context!(ContextSubcommand::Add {

--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -148,7 +148,7 @@ const HELP_TEXT: &str = color_print::cstr! {"
   <em>rename</em>      <black!>Rename a profile</black!>
 <em>/context</em>      <black!>Manage context files for the chat session</black!>
   <em>help</em>        <black!>Show context help</black!>
-  <em>show</em>        <black!>Display current context configuration [--expand]</black!>
+  <em>show</em>        <black!>Display current context configuration</black!>
   <em>add</em>         <black!>Add file(s) to context [--global] [--force]</black!>
   <em>rm</em>          <black!>Remove file(s) from context [--global]</black!>
   <em>clear</em>       <black!>Clear all files from current context [--global]</black!>
@@ -1007,7 +1007,7 @@ where
             Command::Context { subcommand } => {
                 if let Some(context_manager) = &mut self.conversation_state.context_manager {
                     match subcommand {
-                        command::ContextSubcommand::Show { expand } => {
+                        command::ContextSubcommand::Show => {
                             execute!(
                                 self.output,
                                 style::SetForegroundColor(Color::Green),
@@ -1057,12 +1057,12 @@ where
                                             style::Print("No files matched the configured context paths.\n\n"),
                                             style::SetForegroundColor(Color::Reset)
                                         )?;
-                                    } else if expand {
+                                    } else {
                                         // Show expanded file list when expand flag is set
                                         execute!(
                                             self.output,
                                             style::SetForegroundColor(Color::Green),
-                                            style::Print(format!("Expanded files ({}):\n", context_files.len())),
+                                            style::Print(format!("Files in use ({}):\n", context_files.len())),
                                             style::SetForegroundColor(Color::Reset)
                                         )?;
 
@@ -1070,17 +1070,6 @@ where
                                             execute!(self.output, style::Print(format!("    {}\n", filename)))?;
                                         }
                                         execute!(self.output, style::Print("\n"))?;
-                                    } else {
-                                        // Just show the count when expand flag is not set
-                                        execute!(
-                                            self.output,
-                                            style::SetForegroundColor(Color::Green),
-                                            style::Print(format!(
-                                                "Number of context files in use: {}\n",
-                                                context_files.len()
-                                            )),
-                                            style::SetForegroundColor(Color::Reset)
-                                        )?;
                                     }
                                 },
                                 Err(e) => {

--- a/crates/q_cli/src/cli/chat/prompt.rs
+++ b/crates/q_cli/src/cli/chat/prompt.rs
@@ -57,7 +57,6 @@ const COMMANDS: &[&str] = &[
     "/profile set",
     "/context help",
     "/context show",
-    "/context show --expand",
     "/context add",
     "/context add --global",
     "/context rm",


### PR DESCRIPTION
* Removed `--expand` flag
* Show what `--expand` used to show in `/context show`
<img width="547" alt="Screenshot 2025-04-07 at 2 54 08 PM" src="https://github.com/user-attachments/assets/a0396e6d-8c08-4c88-959f-2a3195586bcb" />
