### PR TITLE
feat: Introduce /compact command

### DIFF
--- a/crates/q_cli/src/cli/chat/chat_state.rs
+++ b/crates/q_cli/src/cli/chat/chat_state.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+
 use fig_api_client::model::ChatMessage;
 
 /// Character count warning levels for conversation size
@@ -33,7 +34,7 @@ impl SummarizationState {
             show_summary: false,
         }
     }
-    
+
     pub fn with_prompt(prompt: Option<String>) -> Self {
         Self {
             original_history: None,

--- a/crates/q_cli/src/cli/chat/chat_state.rs
+++ b/crates/q_cli/src/cli/chat/chat_state.rs
@@ -1,0 +1,44 @@
+use std::collections::VecDeque;
+use fig_api_client::model::ChatMessage;
+
+/// Character count warning levels for conversation size
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TokenWarningLevel {
+    /// No warning, conversation is within normal limits
+    None,
+    /// Critical level - at single warning threshold (500K characters)
+    Critical,
+}
+
+/// Constants for character-based warning threshold
+pub const MAX_CHARS: usize = 500000; // Character-based warning threshold
+
+/// State for tracking summarization process
+#[derive(Debug, Clone)]
+pub struct SummarizationState {
+    /// The saved original history
+    pub original_history: Option<VecDeque<ChatMessage>>,
+    /// Optional custom prompt used for summarization
+    pub custom_prompt: Option<String>,
+    /// Whether to show the summary after compacting
+    pub show_summary: bool,
+}
+
+impl SummarizationState {
+    #[allow(dead_code)]
+    pub fn new() -> Self {
+        Self {
+            original_history: None,
+            custom_prompt: None,
+            show_summary: false,
+        }
+    }
+    
+    pub fn with_prompt(prompt: Option<String>) -> Self {
+        Self {
+            original_history: None,
+            custom_prompt: prompt,
+            show_summary: false,
+        }
+    }
+}

--- a/crates/q_cli/src/cli/chat/command.rs
+++ b/crates/q_cli/src/cli/chat/command.rs
@@ -9,17 +9,35 @@ use eyre::Result;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Command {
-    Ask { prompt: String },
-    Execute { command: String },
+    Ask {
+        prompt: String,
+    },
+    Execute {
+        command: String,
+    },
     Clear,
     Help,
-    Issue { prompt: Option<String> },
+    Issue {
+        prompt: Option<String>,
+    },
     Quit,
-    Profile { subcommand: ProfileSubcommand },
-    Context { subcommand: ContextSubcommand },
-    PromptEditor { initial_text: Option<String> },
-    Compact { prompt: Option<String>, show_summary: bool, help: bool },
-    Tools { subcommand: Option<ToolsSubcommand> },
+    Profile {
+        subcommand: ProfileSubcommand,
+    },
+    Context {
+        subcommand: ContextSubcommand,
+    },
+    PromptEditor {
+        initial_text: Option<String>,
+    },
+    Compact {
+        prompt: Option<String>,
+        show_summary: bool,
+        help: bool,
+    },
+    Tools {
+        subcommand: Option<ToolsSubcommand>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -229,13 +247,13 @@ impl Command {
                     let mut prompt = None;
                     let mut show_summary = false;
                     let mut help = false;
-                    
+
                     // Check if "help" is the first subcommand
                     if parts.len() > 1 && parts[1].to_lowercase() == "help" {
                         help = true;
                     } else {
                         let mut remaining_parts = Vec::new();
-                        
+
                         // Parse the parts to handle both prompt and flags
                         for part in &parts[1..] {
                             if *part == "--summary" {
@@ -244,7 +262,7 @@ impl Command {
                                 remaining_parts.push(*part);
                             }
                         }
-                        
+
                         // Check if the last word is "--summary" (which would have been captured as part of the prompt)
                         if !remaining_parts.is_empty() {
                             let last_idx = remaining_parts.len() - 1;
@@ -253,14 +271,14 @@ impl Command {
                                 show_summary = true;
                             }
                         }
-                        
+
                         // If we have remaining parts after parsing flags, join them as the prompt
                         if !remaining_parts.is_empty() {
                             prompt = Some(remaining_parts.join(" "));
                         }
                     }
-                    
-                    Self::Compact { 
+
+                    Self::Compact {
                         prompt,
                         show_summary,
                         help,
@@ -573,9 +591,18 @@ mod tests {
         let tests = &[
             ("/compact", compact!(None, false)),
             ("/compact --summary", compact!(None, true)),
-            ("/compact custom prompt", compact!(Some("custom prompt".to_string()), false)),
-            ("/compact --summary custom prompt", compact!(Some("custom prompt".to_string()), true)),
-            ("/compact custom prompt --summary", compact!(Some("custom prompt".to_string()), true)),
+            (
+                "/compact custom prompt",
+                compact!(Some("custom prompt".to_string()), false),
+            ),
+            (
+                "/compact --summary custom prompt",
+                compact!(Some("custom prompt".to_string()), true),
+            ),
+            (
+                "/compact custom prompt --summary",
+                compact!(Some("custom prompt".to_string()), true),
+            ),
             ("/profile list", profile!(ProfileSubcommand::List)),
             (
                 "/profile create new_profile",


### PR DESCRIPTION
*Description of changes:*
- Add functionality to summarize and clear conversation history
- Allow presenting the summary with --summary flag
- Let /compact take an optional prompt to modify summary request
- Ensure the model acknowledges the summary in future responses
- Modify clear() method to optionally preserve summary
- Warn users about context limit based on number of characters

[see issue : 1067](https://github.com/aws/amazon-q-developer-cli/issues/1067)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
