### PR TITLE
chore: bump version to 1.7.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty_terminal"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "bitflags 2.9.0",
  "camino",
@@ -283,7 +283,7 @@ checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "appkit-nsworkspace-bindings"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "bindgen 0.71.1",
  "objc",
@@ -2028,7 +2028,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "dbus"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "async_zip",
  "fig_os_shim",
@@ -2461,7 +2461,7 @@ dependencies = [
 
 [[package]]
 name = "fig-api-mock"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "async-trait",
  "clap",
@@ -2474,7 +2474,7 @@ dependencies = [
 
 [[package]]
 name = "fig_api_client"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "amzn-codewhisperer-client",
  "amzn-codewhisperer-streaming-client",
@@ -2510,7 +2510,7 @@ dependencies = [
 
 [[package]]
 name = "fig_auth"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "async-trait",
  "aws-credential-types",
@@ -2544,7 +2544,7 @@ dependencies = [
 
 [[package]]
 name = "fig_aws_common"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "aws-runtime",
  "aws-smithy-runtime",
@@ -2557,7 +2557,7 @@ dependencies = [
 
 [[package]]
 name = "fig_desktop"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -2649,7 +2649,7 @@ dependencies = [
 
 [[package]]
 name = "fig_desktop_api"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "anstream",
  "async-trait",
@@ -2685,7 +2685,7 @@ dependencies = [
 
 [[package]]
 name = "fig_diagnostic"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "cfg-if",
  "clap",
@@ -2705,7 +2705,7 @@ dependencies = [
 
 [[package]]
 name = "fig_input_method"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "apple-bundle",
  "fig_ipc",
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "fig_install"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "bitflags 2.9.0",
  "bytes",
@@ -2765,7 +2765,7 @@ dependencies = [
 
 [[package]]
 name = "fig_integrations"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "accessibility-sys",
  "async-trait",
@@ -2798,7 +2798,7 @@ dependencies = [
 
 [[package]]
 name = "fig_ipc"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2821,7 +2821,7 @@ dependencies = [
 
 [[package]]
 name = "fig_log"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "fig_util",
  "parking_lot",
@@ -2834,7 +2834,7 @@ dependencies = [
 
 [[package]]
 name = "fig_os_shim"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "cfg-if",
  "dirs",
@@ -2847,7 +2847,7 @@ dependencies = [
 
 [[package]]
 name = "fig_proto"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -2870,7 +2870,7 @@ dependencies = [
 
 [[package]]
 name = "fig_remote_ipc"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2888,7 +2888,7 @@ dependencies = [
 
 [[package]]
 name = "fig_request"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -2913,7 +2913,7 @@ dependencies = [
 
 [[package]]
 name = "fig_settings"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "fd-lock",
  "fig_test",
@@ -2934,7 +2934,7 @@ dependencies = [
 
 [[package]]
 name = "fig_telemetry"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "amzn-codewhisperer-client",
  "amzn-toolkit-telemetry",
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "fig_telemetry_core"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "amzn-codewhisperer-client",
  "amzn-toolkit-telemetry",
@@ -2982,7 +2982,7 @@ dependencies = [
 
 [[package]]
 name = "fig_test"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "fig_test_macro",
  "tokio",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "fig_test_macro"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -2998,7 +2998,7 @@ dependencies = [
 
 [[package]]
 name = "fig_test_utils"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "bytes",
  "fig_os_shim",
@@ -3016,7 +3016,7 @@ dependencies = [
 
 [[package]]
 name = "fig_util"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "appkit-nsworkspace-bindings",
  "bstr",
@@ -3056,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "figterm"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -3120,7 +3120,7 @@ dependencies = [
 
 [[package]]
 name = "figterm2"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4800,7 +4800,7 @@ dependencies = [
 
 [[package]]
 name = "macos-utils"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -6493,7 +6493,7 @@ dependencies = [
 
 [[package]]
 name = "q_cli"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "amzn-codewhisperer-client",
  "amzn-codewhisperer-streaming-client",
@@ -7672,7 +7672,7 @@ dependencies = [
 
 [[package]]
 name = "shell-color"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "bitflags 2.9.0",
  "fig_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ authors = [
 edition = "2021"
 homepage = "https://aws.amazon.com/q/"
 publish = false
-version = "1.7.2"
+version = "1.7.3"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]

--- a/feed.json
+++ b/feed.json
@@ -54,6 +54,10 @@
         },
         {
           "type": "fixed",
+          "description": "A missing Match criteria error in the ssh integration - [#1134](https://github.com/aws/amazon-q-developer-cli/pull/1134)"
+        },
+        {
+          "type": "fixed",
           "description": "Various issues in `q chat`"
         }
       ]

--- a/feed.json
+++ b/feed.json
@@ -12,6 +12,50 @@
     },
     {
       "type": "release",
+      "date": "2025-04-08",
+      "version": "1.7.3",
+      "title": "Version 1.7.3",
+      "changes": [
+        {
+          "type": "added",
+          "description": "Granular tool permissioning in `q chat` with a new command `/tools` - [#1054](https://github.com/aws/amazon-q-developer-cli/pull/1054)"
+        },
+        {
+          "type": "added",
+          "description": "A new command `/ed` in `q chat` for composing prompts using the configured editor - [#1035](https://github.com/aws/amazon-q-developer-cli/pull/1035)"
+        },
+        {
+          "type": "added",
+          "description": "A new command `/issue` in `q chat` for creating new GitHub issues - [#990](https://github.com/aws/amazon-q-developer-cli/pull/990)"
+        },
+        {
+          "type": "added",
+          "description": "A new tool `report_issue` in `q chat` for creating new GitHub issues - [#974](https://github.com/aws/amazon-q-developer-cli/pull/974)"
+        },
+        {
+          "type": "added",
+          "description": "An improved context file display in `q chat` - [#983](https://github.com/aws/amazon-q-developer-cli/pull/983)"
+        },
+        {
+          "type": "added",
+          "description": "An option `--no-interactive` to invoke `q chat` in a non-interactive mode - [#878](https://github.com/aws/amazon-q-developer-cli/pull/878)"
+        },
+        {
+          "type": "added",
+          "description": "File name autocompletion in `q chat` - [#930](https://github.com/aws/amazon-q-developer-cli/pull/930)"
+        },
+        {
+          "type": "added",
+          "description": "Improved `execute_bash` pipe safety checking in `q chat` - [#927](https://github.com/aws/amazon-q-developer-cli/pull/927)"
+        },
+        {
+          "type": "fixed",
+          "description": "Various issues in `q chat`"
+        }
+      ]
+    },
+    {
+      "type": "release",
       "date": "2025-03-20",
       "version": "1.7.2",
       "title": "Version 1.7.2",

--- a/feed.json
+++ b/feed.json
@@ -22,7 +22,7 @@
         },
         {
           "type": "added",
-          "description": "A new command `/ed` in `q chat` for composing prompts using the configured editor - [#1035](https://github.com/aws/amazon-q-developer-cli/pull/1035)"
+          "description": "A new command `/editor` in `q chat` for composing prompts using the configured editor - [#1035](https://github.com/aws/amazon-q-developer-cli/pull/1035)"
         },
         {
           "type": "added",
@@ -47,6 +47,10 @@
         {
           "type": "added",
           "description": "Improved `execute_bash` pipe safety checking in `q chat` - [#927](https://github.com/aws/amazon-q-developer-cli/pull/927)"
+        },
+        {
+          "type": "changed",
+          "description": "Executing `q` now enters `q chat` instead of opening the dashboard - [#987](https://github.com/aws/amazon-q-developer-cli/pull/987)"
         },
         {
           "type": "fixed",


### PR DESCRIPTION
*Description of changes:*
- Bumping the version to `1.7.3`

<img width="712" alt="Screenshot 2025-04-07 at 8 24 59 PM" src="https://github.com/user-attachments/assets/7e4b2950-92f4-4d1b-8eb8-dbda7d5fc3fb" />




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
