### PR TITLE
fix(chat ux): Default `/context` to `/context help`

### DIFF
--- a/crates/q_cli/src/cli/chat/command.rs
+++ b/crates/q_cli/src/cli/chat/command.rs
@@ -326,7 +326,9 @@ impl Command {
                 },
                 "context" => {
                     if parts.len() < 2 {
-                        return Err(ContextSubcommand::usage_msg("Missing subcommand for /context."));
+                        return Ok(Self::Context {
+                            subcommand: ContextSubcommand::Help,
+                        });
                     }
 
                     macro_rules! usage_err {


### PR DESCRIPTION
#1132 