### PR TITLE
fix: update ssh integration config to remove '=' in exec condition

### DIFF
--- a/crates/fig_integrations/src/ssh/mod.rs
+++ b/crates/fig_integrations/src/ssh/mod.rs
@@ -55,7 +55,7 @@ impl SshIntegration {
         Ok(FileIntegration {
             path: self.get_integration_path()?,
             contents: indoc::formatdoc! {"
-                Match exec=\"command -v {bin_name} && {bin_name} internal generate-ssh --remote-host %h --remote-port %p --remote-username %r\"
+                Match exec \"command -v {bin_name} && {bin_name} internal generate-ssh --remote-host %h --remote-port %p --remote-username %r\"
                     Include \"{include_path}\"
             "},
             #[cfg(unix)]


### PR DESCRIPTION
*Description of changes:*
- Removing the `=` sign in the ssh Match condition since a recent update to OpenSSH 9.9 seems to have broken this. See the related issue #1026 
- Users with the broken config will have it corrected upon installing the ssh integration again.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
