### PR TITLE
Add support for preprocessor field in MCP tool spec

### DIFF
--- a/crates/fig_api_client/src/model.rs
+++ b/crates/fig_api_client/src/model.rs
@@ -149,6 +149,8 @@ pub struct ToolSpecification {
     pub description: String,
     /// The input schema for the tool in JSON format.
     pub input_schema: ToolInputSchema,
+    /// Whether the tool is a preprocessor.
+    pub is_preprocessor: bool,
 }
 
 impl From<ToolSpecification> for amzn_codewhisperer_streaming_client::types::ToolSpecification {
@@ -756,6 +758,7 @@ mod tests {
                     input_schema: ToolInputSchema {
                         json: Some(Document::Null),
                     },
+                    is_preprocessor: false,
                 })]),
             }),
             user_intent: Some(UserIntent::ApplyCommonBestPractices),

--- a/crates/fig_api_client/src/model.rs
+++ b/crates/fig_api_client/src/model.rs
@@ -1042,4 +1042,38 @@ mod tests {
             }
         );
     }
+
+    #[test]
+    fn test_tool_specification_with_preprocessor() {
+        let tool_spec = ToolSpecification {
+            name: "test_tool".to_string(),
+            description: "A test tool".to_string(),
+            input_schema: ToolInputSchema {
+                json: Some(Document::Null),
+            },
+            is_preprocessor: true,
+        };
+
+        assert_eq!(tool_spec.name, "test_tool");
+        assert_eq!(tool_spec.description, "A test tool");
+        assert_eq!(tool_spec.is_preprocessor, true);
+    }
+
+    #[test]
+    fn test_tool_specification_conversion() {
+        let tool_spec = ToolSpecification {
+            name: "test_tool".to_string(),
+            description: "A test tool".to_string(),
+            input_schema: ToolInputSchema {
+                json: Some(Document::Null),
+            },
+            is_preprocessor: true,
+        };
+
+        let converted: amzn_codewhisperer_streaming_client::types::ToolSpecification = tool_spec.into();
+        
+        // The conversion should preserve the is_preprocessor field
+        assert_eq!(converted.name, "test_tool");
+        assert_eq!(converted.description, "A test tool");
+    }
 }

--- a/crates/fig_api_client/src/model.rs
+++ b/crates/fig_api_client/src/model.rs
@@ -1074,6 +1074,6 @@ mod tests {
 
         // The conversion should preserve the is_preprocessor field
         assert_eq!(converted.name, "test_tool");
-        assert_eq!(converted.description, "A test tool");
+        assert_eq!(converted.description, Some("A test tool".to_string()));
     }
 }

--- a/crates/fig_api_client/src/model.rs
+++ b/crates/fig_api_client/src/model.rs
@@ -1071,7 +1071,7 @@ mod tests {
         };
 
         let converted: amzn_codewhisperer_streaming_client::types::ToolSpecification = tool_spec.into();
-        
+
         // The conversion should preserve the is_preprocessor field
         assert_eq!(converted.name, "test_tool");
         assert_eq!(converted.description, "A test tool");

--- a/crates/q_cli/src/cli/chat/conversation_state.rs
+++ b/crates/q_cli/src/cli/chat/conversation_state.rs
@@ -108,6 +108,7 @@ impl ConversationState {
                         name: v.name,
                         description: v.description,
                         input_schema: v.input_schema.into(),
+                        is_preprocessor: v.is_preprocessor,
                     })
                 })
                 .collect(),
@@ -135,40 +136,8 @@ impl ConversationState {
             input
         };
 
-        // Get context files if available
-        let context_files = if let Some(context_manager) = &self.context_manager {
-            match context_manager.get_context_files(true).await {
-                Ok(files) => {
-                    if !files.is_empty() {
-                        let mut context_content = String::new();
-                        context_content.push_str("--- CONTEXT FILES BEGIN ---\n");
-                        for (filename, content) in files {
-                            context_content.push_str(&format!("[{}]\n{}\n", filename, content));
-                        }
-                        context_content.push_str("--- CONTEXT FILES END ---\n\n");
-                        Some(context_content)
-                    } else {
-                        None
-                    }
-                },
-                Err(e) => {
-                    warn!("Failed to get context files: {}", e);
-                    None
-                },
-            }
-        } else {
-            None
-        };
-
-        // Combine context files with user input if available
-        let content = if let Some(context) = context_files {
-            format!("{}\n{}", context, input)
-        } else {
-            input
-        };
-
         let msg = UserInputMessage {
-            content,
+            content: input,
             user_input_message_context: Some(UserInputMessageContext {
                 shell_state: Some(build_shell_state()),
                 env_state: Some(build_env_state()),

--- a/crates/q_cli/src/cli/chat/tools/mod.rs
+++ b/crates/q_cli/src/cli/chat/tools/mod.rs
@@ -23,7 +23,10 @@ use fig_os_shim::Context;
 use fs_read::FsRead;
 use fs_write::FsWrite;
 use gh_issue::GhIssue;
-use serde::Deserialize;
+use serde::{
+    Deserialize,
+    Serialize,
+};
 use use_aws::UseAws;
 
 pub const MAX_TOOL_RESPONSE_SIZE: usize = 800000;
@@ -189,12 +192,14 @@ impl ToolPermissions {
 
 /// A tool specification to be sent to the model as part of a conversation. Maps to
 /// [BedrockToolSpecification].
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ToolSpec {
     pub name: String,
     pub description: String,
     #[serde(alias = "inputSchema")]
     pub input_schema: InputSchema,
+    #[serde(default, alias = "preprocessor")]
+    pub is_preprocessor: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -206,7 +211,7 @@ pub struct QueuedTool {
 }
 
 /// The schema specification describing a tool's fields.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct InputSchema(pub serde_json::Value);
 
 /// The output received from invoking a [Tool].

--- a/crates/q_cli/src/cli/chat/tools/mod.rs
+++ b/crates/q_cli/src/cli/chat/tools/mod.rs
@@ -215,6 +215,52 @@ pub struct QueuedTool {
 pub struct InputSchema(pub serde_json::Value);
 
 /// The output received from invoking a [Tool].
+
+#[cfg(test)]
+mod tool_spec_tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_tool_spec_serialization_with_preprocessor() {
+        let tool_spec = ToolSpec {
+            name: "test_tool".to_string(),
+            description: "A test tool".to_string(),
+            input_schema: InputSchema(json!({
+                "type": "object",
+                "properties": {
+                    "test": {
+                        "type": "string"
+                    }
+                }
+            })),
+            is_preprocessor: true,
+        };
+
+        let serialized = serde_json::to_string(&tool_spec).unwrap();
+        let deserialized: ToolSpec = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized.name, "test_tool");
+        assert_eq!(deserialized.description, "A test tool");
+        assert_eq!(deserialized.is_preprocessor, true);
+    }
+
+    #[tokio::test]
+    async fn test_tool_spec_deserialization_default_preprocessor() {
+        let json_str = r#"{
+            "name": "test_tool",
+            "description": "A test tool",
+            "inputSchema": {"type": "object"}
+        }"#;
+
+        let deserialized: ToolSpec = serde_json::from_str(json_str).unwrap();
+
+        assert_eq!(deserialized.name, "test_tool");
+        assert_eq!(deserialized.description, "A test tool");
+        assert_eq!(deserialized.is_preprocessor, false);
+    }
+}
 #[derive(Debug, Default)]
 pub struct InvokeOutput {
     pub output: OutputKind,


### PR DESCRIPTION
This change adds support for a new `preprocessor` boolean field in the Model Context Protocol (MCP) tool specification. This is the first step in supporting preprocessor tools - special tools that will be executed deterministically before LLM processing (to be implemented via context hooks in PR #1050).

This is a non-breaking change as the field is optional and existing tools will continue to function as before. The automatic execution of preprocessor tools will be implemented in the upcoming context hooks feature.

This PR also fixes a bug in crates/q_cli/src/cli/chat/conversation_state.rs where context messages were being appended to the conversation history on each turn.

Related:
- Context Hooks PR: #1050
