### PR TITLE
chore: add feed entry for /compact, update /tools messaging

### DIFF
--- a/feed.json
+++ b/feed.json
@@ -18,7 +18,11 @@
       "changes": [
         {
           "type": "added",
-          "description": "Granular tool permissioning in `q chat` with a new command `/tools` - [#1054](https://github.com/aws/amazon-q-developer-cli/pull/1054)"
+          "description": "A new command `/tools` in `q chat` for granular tool permissioning - [#1054](https://github.com/aws/amazon-q-developer-cli/pull/1054)"
+        },
+        {
+          "type": "added",
+          "description": "A new command `/compact` in `q chat` for summarizing the conversation history - [#1128](https://github.com/aws/amazon-q-developer-cli/pull/1128)"
         },
         {
           "type": "added",


### PR DESCRIPTION
*Description of changes:*
- Adding an entry for the `/compact` command from #1128 and for terminal notifications from #1135
- Update the `/tools` copy to be consistent with the others for new commands

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
