### PR TITLE
refactor(chat): update the /tools permission copy to be more consistent

### DIFF
--- a/crates/q_cli/src/cli/chat/command.rs
+++ b/crates/q_cli/src/cli/chat/command.rs
@@ -156,7 +156,8 @@ impl ToolsSubcommand {
     const BASE_COMMAND: &str = color_print::cstr! {"<cyan!>Usage: /tools [SUBCOMMAND]</cyan!>
 
 <cyan!>Description</cyan!>
-  Show the current set of tools and their permission settings. 
+  Show the current set of tools and their permission setting.
+  The permission setting states when user confirmation is required. Trusted tools never require confirmation.
   Alternatively, specify a subcommand to modify the tool permissions."};
     const TRUST_USAGE: &str = "/tools trust <tool name>";
     const UNTRUST_USAGE: &str = "/tools untrust <tool name>";

--- a/crates/q_cli/src/cli/chat/tools/mod.rs
+++ b/crates/q_cli/src/cli/chat/tools/mod.rs
@@ -205,8 +205,8 @@ impl ToolPermissions {
         let label = match tool_name {
             "fs_read" => "Trusted",
             "fs_write" => "Per-request",
-            "execute_bash" => "Read-only commands",
-            "use_aws" => "Read-only commands",
+            "execute_bash" => "Write-only commands",
+            "use_aws" => "Write-only commands",
             "report_issue" => "Trusted",
             _ => "Per-request",
         };


### PR DESCRIPTION
*Description of changes:*
- Updating the `/tools` permission display to be more consistent. Currently, stating "readonly commands" is a bit confusing and inconsistent with "per-request" messaging. Now, we will display when to ask for permission, outside of the "Trusted" messaging.

Some example screenshots:

<img width="1064" alt="Screenshot 2025-04-09 at 4 40 46 PM" src="https://github.com/user-attachments/assets/daa59346-f4e1-428b-9d0e-2ed1a4371388" />
<img width="499" alt="Screenshot 2025-04-09 at 4 41 03 PM" src="https://github.com/user-attachments/assets/7fec9fa7-90e7-4325-9c23-9ae51569351b" />
<img width="499" alt="Screenshot 2025-04-09 at 4 45 22 PM" src="https://github.com/user-attachments/assets/f6afa975-c3fd-47b6-af63-70f0ab94e425" />
<img width="387" alt="Screenshot 2025-04-09 at 4 45 50 PM" src="https://github.com/user-attachments/assets/d3ef0e0b-d45d-4c78-81f7-12c85315f98e" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
