### PR TITLE
feat(context): load and execute context hooks

### DIFF
--- a/crates/q_cli/src/cli/chat/context.rs
+++ b/crates/q_cli/src/cli/chat/context.rs
@@ -28,6 +28,7 @@ pub const AMAZONQ_FILENAME: &str = "AmazonQ.md";
 
 /// Configuration for context files, containing paths to include in the context.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(default)]
 pub struct ContextConfig {
     /// List of file paths or glob patterns to include in the context.
     pub paths: Vec<String>,
@@ -503,11 +504,10 @@ impl ContextManager {
         self.save_config(global).await
     }
 
-    /// Sets the "disabled" field on any [`Hook`] with the given name to be true or false
+    /// Sets the "disabled" field on any [`Hook`] with the given name
     /// # Arguments
-    /// * `enable` - If true, the "disabled" field are is to false. If false, the "disabled" field
-    ///   is set to true
-    pub async fn enable_hook(&mut self, name: &str, global: bool, enable: bool) -> Result<()> {
+    /// * `disable` - Set "disabled" field to this value
+    pub async fn set_hook_disabled(&mut self, name: &str, global: bool, disable: bool) -> Result<()> {
         let config = self.get_config_mut(global);
 
         config
@@ -516,16 +516,15 @@ impl ContextManager {
             .iter_mut()
             .chain(config.hooks.per_prompt.iter_mut())
             .filter(|h| h.name == name)
-            .for_each(|h| h.disabled = !enable);
+            .for_each(|h| h.disabled = disable);
 
         self.save_config(global).await
     }
 
-    /// Sets the "disabled" field on all [`Hook`]s to be true or false
+    /// Sets the "disabled" field on all [`Hook`]s
     /// # Arguments
-    /// * `enable` - If true, all "disabled" fields are set to false. If false, all "disabled"
-    ///   fields are set to true
-    pub async fn enable_all_hooks(&mut self, global: bool, enable: bool) -> Result<()> {
+    /// * `disable` - Set all "disabled" fields to this value
+    pub async fn set_all_hooks_disabled(&mut self, global: bool, disable: bool) -> Result<()> {
         let config = self.get_config_mut(global);
 
         config
@@ -533,7 +532,7 @@ impl ContextManager {
             .conversation_start
             .iter_mut()
             .chain(config.hooks.per_prompt.iter_mut())
-            .for_each(|h| h.disabled = !enable);
+            .for_each(|h| h.disabled = disable);
 
         self.save_config(global).await
     }

--- a/crates/q_cli/src/cli/chat/context.rs
+++ b/crates/q_cli/src/cli/chat/context.rs
@@ -1,3 +1,4 @@
+use std::io::Write;
 use std::path::{
     Path,
     PathBuf,
@@ -17,6 +18,12 @@ use serde::{
     Serialize,
 };
 
+use super::hooks::{
+    Hook,
+    HookExecutor,
+};
+use crate::cli::chat::hooks::HookConfig;
+
 pub const AMAZONQ_FILENAME: &str = "AmazonQ.md";
 
 /// Configuration for context files, containing paths to include in the context.
@@ -24,6 +31,7 @@ pub const AMAZONQ_FILENAME: &str = "AmazonQ.md";
 pub struct ContextConfig {
     /// List of file paths or glob patterns to include in the context.
     pub paths: Vec<String>,
+    pub hooks: HookConfig,
 }
 
 #[allow(dead_code)]
@@ -40,6 +48,8 @@ pub struct ContextManager {
 
     /// Context configuration for the current profile.
     pub profile_config: ContextConfig,
+
+    pub hook_executor: HookExecutor,
 }
 
 #[allow(dead_code)]
@@ -67,6 +77,7 @@ impl ContextManager {
             global_config,
             current_profile,
             profile_config,
+            hook_executor: HookExecutor::new(),
         })
     }
 
@@ -157,11 +168,7 @@ impl ContextManager {
     /// A Result indicating success or an error
     pub async fn remove_paths(&mut self, paths: Vec<String>, global: bool) -> Result<()> {
         // Get reference to the appropriate config
-        let config = if global {
-            &mut self.global_config
-        } else {
-            &mut self.profile_config
-        };
+        let config = self.get_config_mut(global);
 
         // Track if any paths were removed
         let mut removed_any = false;
@@ -433,6 +440,136 @@ impl ContextManager {
         }
         Ok(())
     }
+
+    fn get_config_mut(&mut self, global: bool) -> &mut ContextConfig {
+        if global {
+            &mut self.global_config
+        } else {
+            &mut self.profile_config
+        }
+    }
+
+    /// Add hooks to the context config. If another hook with the same name already exists, throw an
+    /// error.
+    ///
+    /// # Arguments
+    /// * `hook` - name of the hook to delete
+    /// * `global` - If true, the add to the global config. If false, add to the current profile
+    ///   config.
+    /// * `conversation_start` - If true, add the hook to conversation_start. Otherwise, it will be
+    ///   added to per_prompt.
+    pub async fn add_hook(&mut self, hook: Hook, global: bool, conversation_start: bool) -> Result<()> {
+        if self.num_hooks_with_name(&hook.name) > 0 {
+            return Err(eyre!(
+                "Cannot add hook, another hook with this name already exists in global or profile context."
+            ));
+        }
+
+        let config = self.get_config_mut(global);
+
+        let hook_vec = if conversation_start {
+            &mut config.hooks.conversation_start
+        } else {
+            &mut config.hooks.per_prompt
+        };
+
+        hook_vec.push(hook);
+        self.save_config(global).await
+    }
+
+    fn num_hooks_with_name(&self, name: &str) -> usize {
+        self.global_config
+            .hooks
+            .conversation_start
+            .iter()
+            .chain(self.global_config.hooks.per_prompt.iter())
+            .chain(self.profile_config.hooks.conversation_start.iter())
+            .chain(self.profile_config.hooks.per_prompt.iter())
+            .filter(|h| h.name == name)
+            .count()
+    }
+
+    /// Delete hook(s) by name
+    /// # Arguments
+    /// * `name` - name of the hook to delete
+    /// * `global` - If true, the delete from the global config. If false, delete from the current
+    ///   profile config
+    pub async fn remove_hook(&mut self, name: &str, global: bool) -> Result<()> {
+        let config = self.get_config_mut(global);
+
+        config.hooks.conversation_start.retain(|h| h.name != name);
+        config.hooks.per_prompt.retain(|h| h.name != name);
+
+        self.save_config(global).await
+    }
+
+    /// Sets the "disabled" field on any [`Hook`] with the given name to be true or false
+    /// # Arguments
+    /// * `enable` - If true, the "disabled" field are is to false. If false, the "disabled" field
+    ///   is set to true
+    pub async fn enable_hook(&mut self, name: &str, global: bool, enable: bool) -> Result<()> {
+        let config = self.get_config_mut(global);
+
+        config
+            .hooks
+            .conversation_start
+            .iter_mut()
+            .chain(config.hooks.per_prompt.iter_mut())
+            .filter(|h| h.name == name)
+            .for_each(|h| h.disabled = !enable);
+
+        self.save_config(global).await
+    }
+
+    /// Sets the "disabled" field on all [`Hook`]s to be true or false
+    /// # Arguments
+    /// * `enable` - If true, all "disabled" fields are set to false. If false, all "disabled"
+    ///   fields are set to true
+    pub async fn enable_all_hooks(&mut self, global: bool, enable: bool) -> Result<()> {
+        let config = self.get_config_mut(global);
+
+        config
+            .hooks
+            .conversation_start
+            .iter_mut()
+            .chain(config.hooks.per_prompt.iter_mut())
+            .for_each(|h| h.disabled = !enable);
+
+        self.save_config(global).await
+    }
+
+    /// Run all the currently enabled hooks from both the global and profile contexts
+    /// # Arguments
+    /// * `updates` - output stream to write hook run status to
+    /// # Returns
+    /// A vector containing pairs of a [`Hook`] definition and its execution output
+    pub async fn run_hooks(&mut self, updates: &mut impl Write) -> Vec<(Hook, String)> {
+        let mut hooks: Vec<&Hook> = Vec::new();
+
+        // Collect all conversation start hooks
+        hooks.extend(
+            self.global_config
+                .hooks
+                .conversation_start
+                .iter_mut()
+                .chain(self.profile_config.hooks.conversation_start.iter_mut())
+                .map(|h| {
+                    h.is_conversation_start = true;
+                    &*h
+                }),
+        );
+
+        // Collect all per-prompt hooks
+        hooks.extend(
+            self.global_config
+                .hooks
+                .per_prompt
+                .iter()
+                .chain(self.profile_config.hooks.per_prompt.iter()),
+        );
+
+        self.hook_executor.run_hooks(hooks, updates).await
+    }
 }
 
 fn profile_dir_path(ctx: &Context, profile_name: &str) -> Result<PathBuf> {
@@ -464,6 +601,7 @@ async fn load_global_config(ctx: &Context) -> Result<ContextConfig> {
                 "README.md".to_string(),
                 AMAZONQ_FILENAME.to_string(),
             ],
+            hooks: HookConfig::default(),
         })
     }
 }

--- a/crates/q_cli/src/cli/chat/hooks.rs
+++ b/crates/q_cli/src/cli/chat/hooks.rs
@@ -1,0 +1,266 @@
+use std::collections::HashMap;
+use std::io::Write;
+use std::time::{
+    Duration,
+    Instant,
+};
+
+use crossterm::style::Color;
+use crossterm::{
+    execute,
+    queue,
+    style,
+};
+use eyre::{
+    Result,
+    eyre,
+};
+use futures::future;
+use futures::future::Either;
+use serde::{
+    Deserialize,
+    Serialize,
+};
+
+use super::tools::execute_bash::run_command;
+
+const DEFAULT_TIMEOUT_MS: u64 = 30_000;
+const DEFAULT_MAX_OUTPUT_SIZE: usize = 1024 * 10;
+const DEFAULT_CACHE_TTL_SECONDS: u64 = 0;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Hook {
+    /// Unique name of the hook
+    pub name: String,
+
+    pub r#type: HookType,
+
+    #[serde(default = "Hook::default_disabled")]
+    pub disabled: bool,
+
+    /// Max time the hook can run before it throws a timeout error
+    #[serde(default = "Hook::default_timeout_ms")]
+    pub timeout_ms: u64,
+
+    /// Max output size of the hook before it is truncated
+    #[serde(default = "Hook::default_max_output_size")]
+    pub max_output_size: usize,
+
+    /// How long the hook output is cached before it will be executed again
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_ttl_seconds: Option<u64>,
+
+    // Type-specific fields
+    /// The bash command to execute
+    pub command: Option<String>, // For inline hooks
+
+    // Internal data
+    #[serde(skip)]
+    pub is_conversation_start: bool,
+}
+
+impl Hook {
+    #[allow(dead_code)] // TODO: Remove
+    pub fn new_inline_hook(name: &str, command: String, is_conversation_start: bool) -> Self {
+        Self {
+            name: name.to_string(),
+            r#type: HookType::Inline,
+            disabled: Self::default_disabled(),
+            timeout_ms: Self::default_timeout_ms(),
+            max_output_size: Self::default_max_output_size(),
+            cache_ttl_seconds: None,
+            command: Some(command),
+            is_conversation_start,
+        }
+    }
+
+    fn default_disabled() -> bool {
+        false
+    }
+
+    fn default_timeout_ms() -> u64 {
+        DEFAULT_TIMEOUT_MS
+    }
+
+    fn default_max_output_size() -> usize {
+        DEFAULT_MAX_OUTPUT_SIZE
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HookType {
+    // Execute an inline shell command
+    Inline,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct HookConfig {
+    pub conversation_start: Vec<Hook>,
+    pub per_prompt: Vec<Hook>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CachedHook {
+    output: String,
+    expiry: Option<Instant>,
+}
+
+#[derive(Debug, Clone)]
+pub struct HookExecutor {
+    pub execution_cache: HashMap<String, CachedHook>,
+}
+
+impl HookExecutor {
+    pub fn new() -> Self {
+        Self {
+            execution_cache: HashMap::new(),
+        }
+    }
+
+    /// Run all the currently enabled hooks from both the global and profile contexts
+    /// # Arguments
+    /// * `updates` - output stream to write hook run status to
+    /// # Returns
+    /// A vector containing pairs of a [`Hook`] definition and its execution output   
+    pub async fn run_hooks(&mut self, hooks: Vec<&Hook>, updates: &mut impl Write) -> Vec<(Hook, String)> {
+        let mut futures: Vec<future::Either<_, _>> = Vec::new();
+        let mut num_cached = 0;
+
+        for hook in hooks {
+            if hook.disabled {
+                continue;
+            }
+
+            // Check if the hook is cached. If so, push a completed future.
+            if let Some(cached) = self.get_cache(&hook.name) {
+                futures.push(Either::Left(future::ready((
+                    hook,
+                    Ok(cached.clone()),
+                    Duration::from_secs(0),
+                ))));
+                num_cached += 1;
+            } else {
+                // Execute the hook asynchronously
+                futures.push(Either::Right(self.execute_hook(hook)));
+            }
+        }
+
+        // Skip output if we didn't run any hooks
+        let skip_output = num_cached == futures.len();
+        if !skip_output {
+            let num_hooks = futures.len() - num_cached;
+            let _ = execute!(
+                updates,
+                style::SetForegroundColor(Color::Green),
+                style::Print(format!(
+                    "\nRunning {} {} . . . ",
+                    futures.len() - num_cached,
+                    if num_hooks == 1 { "hook" } else { "hooks" }
+                )),
+            );
+        }
+
+        // Wait for results
+        let results = future::join_all(futures).await;
+
+        if !skip_output {
+            // Output time data
+            let total_duration = format!(
+                "{:.3}s",
+                results.iter().map(|(_, _, d)| d).sum::<Duration>().as_secs_f64()
+            );
+            let _ = queue!(
+                updates,
+                style::SetForegroundColor(Color::Green),
+                style::Print(format!("completed in {}\n", total_duration)),
+                style::SetForegroundColor(Color::Reset),
+            );
+        }
+
+        let mut to_return = Vec::new();
+
+        // If executions were successful, update cache.
+        // Otherwise, report error.
+        for (hook, result, _) in results {
+            if result.is_ok() {
+                // Conversation start hooks are always cached as they are expected to run once per session.
+                let expiry = if hook.is_conversation_start {
+                    None
+                } else {
+                    Some(
+                        Instant::now()
+                            + Duration::from_secs(hook.cache_ttl_seconds.unwrap_or(DEFAULT_CACHE_TTL_SECONDS)),
+                    )
+                };
+
+                self.insert_cache(&hook.name, CachedHook {
+                    output: result.as_ref().cloned().unwrap(),
+                    expiry,
+                });
+
+                to_return.push((hook.clone(), result.unwrap()));
+            } else if !skip_output {
+                let _ = queue!(
+                    updates,
+                    style::SetForegroundColor(Color::Red),
+                    style::Print(format!("hook '{}' failed: {}\n", hook.name, result.unwrap_err())),
+                    style::SetForegroundColor(Color::Reset),
+                );
+            }
+        }
+
+        if !skip_output {
+            let _ = execute!(updates, style::Print("\n"),);
+        }
+
+        to_return
+    }
+
+    async fn execute_hook<'a>(&self, hook: &'a Hook) -> (&'a Hook, Result<String>, Duration) {
+        let start_time = Instant::now();
+        let result = match hook.r#type {
+            HookType::Inline => self.execute_inline_hook(hook).await,
+        };
+
+        (hook, result, start_time.elapsed())
+    }
+
+    async fn execute_inline_hook(&self, hook: &Hook) -> Result<String> {
+        let command = hook.command.as_ref().ok_or_else(|| eyre!("no command specified"))?;
+
+        let command_future = run_command(command, hook.max_output_size, None::<std::io::Stdout>);
+        let timeout = Duration::from_millis(hook.timeout_ms);
+
+        // Run with timeout
+        match tokio::time::timeout(timeout, command_future).await? {
+            Ok(result) => match result.exit_status.unwrap_or(0) {
+                0 => Ok(result.stdout),
+                code => Err(eyre!("command returned non-zero exit code: {}", code)),
+            },
+            Err(_) => Err(eyre!(
+                "command failed to start or timed out after {} ms",
+                timeout.as_millis()
+            )),
+        }
+    }
+
+    /// Will return a cached hook's output if it exists and isn't expired.
+    fn get_cache(&self, name: &str) -> Option<String> {
+        self.execution_cache.get(name).and_then(|o| {
+            if let Some(expiry) = o.expiry {
+                if Instant::now() < expiry {
+                    Some(o.output.clone())
+                } else {
+                    None
+                }
+            } else {
+                Some(o.output.clone())
+            }
+        })
+    }
+
+    fn insert_cache(&mut self, name: &str, hook_output: CachedHook) {
+        self.execution_cache.insert(name.to_string(), hook_output);
+    }
+}

--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -1,6 +1,7 @@
 mod command;
 mod context;
 mod conversation_state;
+mod hooks;
 mod input_source;
 mod parse;
 mod parser;

--- a/crates/q_cli/src/cli/chat/tools/execute_bash.rs
+++ b/crates/q_cli/src/cli/chat/tools/execute_bash.rs
@@ -89,92 +89,16 @@ impl ExecuteBash {
         false
     }
 
-    pub async fn invoke(&self, mut updates: impl Write) -> Result<InvokeOutput> {
-        // We need to maintain a handle on stderr and stdout, but pipe it to the terminal as well
-        let mut child = tokio::process::Command::new("bash")
-            .arg("-c")
-            .arg(&self.command)
-            .stdin(Stdio::inherit())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .wrap_err_with(|| format!("Unable to spawn command '{}'", &self.command))?;
-
-        let stdout = child.stdout.take().unwrap();
-        let stdout = tokio::io::BufReader::new(stdout);
-        let mut stdout = stdout.lines();
-
-        let stderr = child.stderr.take().unwrap();
-        let stderr = tokio::io::BufReader::new(stderr);
-        let mut stderr = stderr.lines();
-
-        const LINE_COUNT: usize = 1024;
-        let mut stdout_buf = VecDeque::with_capacity(LINE_COUNT);
-        let mut stderr_buf = VecDeque::with_capacity(LINE_COUNT);
-
-        let mut stdout_done = false;
-        let mut stderr_done = false;
-        let exit_status = loop {
-            select! {
-                biased;
-                line = stdout.next_line(), if !stdout_done => match line {
-                    Ok(Some(line)) => {
-                        writeln!(updates, "{line}")?;
-                        if stdout_buf.len() >= LINE_COUNT {
-                            stdout_buf.pop_front();
-                        }
-                        stdout_buf.push_back(line);
-                    },
-                    Ok(None) => stdout_done = true,
-                    Err(err) => error!(%err, "Failed to read stdout of child process"),
-                },
-                line = stderr.next_line(), if !stderr_done => match line {
-                    Ok(Some(line)) => {
-                        writeln!(updates, "{line}")?;
-                        if stderr_buf.len() >= LINE_COUNT {
-                            stderr_buf.pop_front();
-                        }
-                        stderr_buf.push_back(line);
-                    },
-                    Ok(None) => stderr_done = true,
-                    Err(err) => error!(%err, "Failed to read stderr of child process"),
-                },
-                exit_status = child.wait() => {
-                    break exit_status;
-                },
-            };
-        }
-        .wrap_err_with(|| format!("No exit status for '{}'", &self.command))?;
-
-        updates.flush()?;
-
-        let stdout = stdout_buf.into_iter().collect::<Vec<_>>().join("\n");
-        let stderr = stderr_buf.into_iter().collect::<Vec<_>>().join("\n");
-
-        let output = serde_json::json!({
-            "exit_status": exit_status.code().unwrap_or(0).to_string(),
-            "stdout": format!(
-                "{}{}",
-                truncate_safe(&stdout, MAX_TOOL_RESPONSE_SIZE / 3),
-                if stdout.len() > MAX_TOOL_RESPONSE_SIZE / 3 {
-                    " ... truncated"
-                } else {
-                    ""
-                }
-            ),
-            "stderr": format!(
-                "{}{}",
-                truncate_safe(&stderr, MAX_TOOL_RESPONSE_SIZE / 3),
-                if stderr.len() > MAX_TOOL_RESPONSE_SIZE / 3 {
-                    " ... truncated"
-                } else {
-                    ""
-                }
-            ),
+    pub async fn invoke(&self, updates: impl Write) -> Result<InvokeOutput> {
+        let output = run_command(&self.command, MAX_TOOL_RESPONSE_SIZE / 3, Some(updates)).await?;
+        let result = serde_json::json!({
+            "exit_status": output.exit_status.unwrap_or(0).to_string(),
+            "stdout": output.stdout,
+            "stderr": output.stderr,
         });
 
         Ok(InvokeOutput {
-            output: OutputKind::Json(output),
+            output: OutputKind::Json(result),
         })
     }
 
@@ -198,6 +122,115 @@ impl ExecuteBash {
         // TODO: probably some small amount of PATH checking
         Ok(())
     }
+}
+
+pub struct CommandResult {
+    pub exit_status: Option<i32>,
+    /// Truncated stdout
+    pub stdout: String,
+    /// Truncated stderr
+    pub stderr: String,
+}
+
+/// Run a bash command.
+/// # Arguments
+/// * `max_result_size` - max size of output streams, truncating if required
+/// * `updates` - output stream to push informational messages about the progress
+/// # Returns
+/// A [`CommandResult`]
+pub async fn run_command<W: Write>(
+    command: &str,
+    max_result_size: usize,
+    mut updates: Option<W>,
+) -> Result<CommandResult> {
+    // We need to maintain a handle on stderr and stdout, but pipe it to the terminal as well
+    let mut child = tokio::process::Command::new("bash")
+        .arg("-c")
+        .arg(command)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .wrap_err_with(|| format!("Unable to spawn command '{}'", command))?;
+
+    let stdout = child.stdout.take().unwrap();
+    let stdout = tokio::io::BufReader::new(stdout);
+    let mut stdout = stdout.lines();
+
+    let stderr = child.stderr.take().unwrap();
+    let stderr = tokio::io::BufReader::new(stderr);
+    let mut stderr = stderr.lines();
+
+    const LINE_COUNT: usize = 1024;
+    let mut stdout_buf = VecDeque::with_capacity(LINE_COUNT);
+    let mut stderr_buf = VecDeque::with_capacity(LINE_COUNT);
+
+    let mut stdout_done = false;
+    let mut stderr_done = false;
+    let exit_status = loop {
+        select! {
+            biased;
+            line = stdout.next_line(), if !stdout_done => match line {
+                Ok(Some(line)) => {
+                    if let Some(u) = updates.as_mut() {
+                        writeln!(u, "{line}")?;
+                    }
+                    if stdout_buf.len() >= LINE_COUNT {
+                        stdout_buf.pop_front();
+                    }
+                    stdout_buf.push_back(line);
+                },
+                Ok(None) => stdout_done = true,
+                Err(err) => error!(%err, "Failed to read stdout of child process"),
+            },
+            line = stderr.next_line(), if !stderr_done => match line {
+                Ok(Some(line)) => {
+                    if let Some(u) = updates.as_mut() {
+                        writeln!(u, "{line}")?;
+                    }
+                    if stderr_buf.len() >= LINE_COUNT {
+                        stderr_buf.pop_front();
+                    }
+                    stderr_buf.push_back(line);
+                },
+                Ok(None) => stderr_done = true,
+                Err(err) => error!(%err, "Failed to read stderr of child process"),
+            },
+            exit_status = child.wait() => {
+                break exit_status;
+            },
+        };
+    }
+    .wrap_err_with(|| format!("No exit status for '{}'", command))?;
+
+    if let Some(u) = updates.as_mut() {
+        u.flush()?;
+    }
+
+    let stdout = stdout_buf.into_iter().collect::<Vec<_>>().join("\n");
+    let stderr = stderr_buf.into_iter().collect::<Vec<_>>().join("\n");
+
+    Ok(CommandResult {
+        exit_status: exit_status.code(),
+        stdout: format!(
+            "{}{}",
+            truncate_safe(&stdout, max_result_size),
+            if stdout.len() > max_result_size {
+                " ... truncated"
+            } else {
+                ""
+            }
+        ),
+        stderr: format!(
+            "{}{}",
+            truncate_safe(&stderr, max_result_size),
+            if stderr.len() > max_result_size {
+                " ... truncated"
+            } else {
+                ""
+            }
+        ),
+    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
RFC: https://github.com/aws/amazon-q-developer-cli/pull/1050

This PR begins implements the required logic for executing hooks. This PR has pending follow ups to handle the remaining items. Note that the logic is currently inaccessible from a normal chat session.

It implements:
- "Hooks", which are defined in the context json files. They are loaded along with the normal context.
  - "conversation_start" hooks that run once and are attached to the top of the context,
  - "per_prompt" hooks that run each time there is a prompt, and are attached to the user prompt.
- Start with 1 hook type, "inline hooks", which simple execute a bash command.
- A HookExecutor to asynchronously call hooks in order from the configs.
- Logic to add/remove/enable/disable hooks via commands
- A cache to hold recent executions of hooks to avoid calling them too much.
  - "conversation_start" hooks are held in cache indefinitely. "per_prompt" hooks can have
- The bash execution logic from `exceute_bash` tool was moved to a helper function so that it can be re-used here.

Remaining items in another PR:
- Call the hooks during a chat session and attach them to context appropriately
- Commands to enable, disable, add, and show hooks
- Add `Criticality` as according to the spec
- Handle user having multiple hooks with the same name (enforce uniqueness)
- Tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
