### PR TITLE
Move summary prompt templates to dedicated file

### DIFF
--- a/crates/q_cli/src/cli/chat/conversation_state.rs
+++ b/crates/q_cli/src/cli/chat/conversation_state.rs
@@ -56,7 +56,7 @@ use crate::cli::chat::tools::{
 const MAX_CURRENT_WORKING_DIRECTORY_LEN: usize = 256;
 
 /// Limit to send the number of messages as part of chat.
-const MAX_CONVERSATION_STATE_HISTORY_LEN: usize = 100;
+const MAX_CONVERSATION_STATE_HISTORY_LEN: usize = 250;
 
 /// Tracks state related to an ongoing conversation.
 #[derive(Debug, Clone)]
@@ -206,51 +206,64 @@ impl ConversationState {
     ///    message is set without tool results, then the user message will have cancelled tool
     ///    results.
     pub fn fix_history(&mut self) {
-        // Trim the conversation history by finding the second oldest message from the user without
-        // tool results - this will be the new oldest message in the history.
-        //
+        // Trim the conversation history by finding a valid cut point that preserves tool use/result pairs
         // Note that we reserve 2 slots for [ConversationState::context_messages].
         if self.history.len() > MAX_CONVERSATION_STATE_HISTORY_LEN - 2 {
-            match self
-                .history
-                .iter()
-                .enumerate()
-                // Skip the first message which should be from the user.
-                .skip(1)
-                .find(|(_, m)| -> bool {
-                    match m {
-                        ChatMessage::UserInputMessage(m) => {
-                            matches!(
-                                m.user_input_message_context.as_ref(),
-                                Some(ctx) if ctx.tool_results.as_ref().is_none_or(|v| v.is_empty())
-                            ) && !m.content.is_empty()
-                        },
-                        ChatMessage::AssistantResponseMessage(_) => false,
+            // Basic cut index based on window size
+            let mut valid_cut_index = self.history.len() - (MAX_CONVERSATION_STATE_HISTORY_LEN - 2);
+            let mut history_len = self.history.len();
+            debug!("history length is {history_len}");
+            debug!("basic cut index is {valid_cut_index}");
+
+            // Map tool use IDs to their message indices
+            let mut tool_use_ids: HashMap<String, usize> = HashMap::new();
+            let mut tool_result_ids: HashMap<String, usize> = HashMap::new();
+
+            // Build the tool use/result mappings
+            for (i, msg) in self.history.iter().enumerate() {
+                match msg {
+                    ChatMessage::AssistantResponseMessage(m) => {
+                        if let Some(tool_uses) = &m.tool_uses {
+                            for tool_use in tool_uses {
+                                tool_use_ids.insert(tool_use.tool_use_id.clone(), i);
+                            }
+                        }
+                    },
+                    ChatMessage::UserInputMessage(m) => {
+                        if let Some(ctx) = &m.user_input_message_context {
+                            if let Some(tool_results) = &ctx.tool_results {
+                                for tool_result in tool_results {
+                                    tool_result_ids.insert(tool_result.tool_use_id.clone(), i);
+                                }
+                            }
+                        }
+                    },
+                }
+            }
+
+            // Ensure we don't break any tool use/result pairs
+            for (tool_id, use_index) in &tool_use_ids {
+                if let Some(result_index) = tool_result_ids.get(tool_id) {
+                    // If the tool use would be cut but the tool result would remain,
+                    // or vice versa, adjust the cut index to preserve the pair
+                    if (*use_index < valid_cut_index && *result_index >= valid_cut_index)
+                        || (*use_index >= valid_cut_index && *result_index < valid_cut_index)
+                    {
+                        // Move the cut point to include both the tool use and tool result
+                        valid_cut_index = valid_cut_index.min(*use_index).min(*result_index);
+                        debug!(
+                            "adjusting cut index to {valid_cut_index} to preserve tool use/result pair for {tool_id}"
+                        );
                     }
-                })
-                .map(|v| v.0)
-            {
-                Some(i) => {
-                    debug!("removing the first {i} elements in the history");
-                    self.history.drain(..i);
-                },
-                None => {
-                    debug!("no valid starting user message found in the history, clearing");
-                    self.history.clear();
-                    // Edge case: if the next message contains tool results, then we have to just
-                    // abandon them.
-                    match &mut self.next_message {
-                        Some(UserInputMessage {
-                            ref mut content,
-                            user_input_message_context: Some(ctx),
-                            ..
-                        }) if ctx.tool_results.as_ref().is_some_and(|r| !r.is_empty()) => {
-                            *content = "The conversation history has overflowed, clearing state".to_string();
-                            ctx.tool_results.take();
-                        },
-                        _ => {},
-                    }
-                },
+                }
+            }
+
+            // Apply the cut at the valid index
+            if valid_cut_index > 0 {
+                debug!("removing the first {valid_cut_index} elements in the history");
+                self.history.drain(..valid_cut_index);
+                history_len = self.history.len();
+                debug!("history length is {history_len}");
             }
         }
 

--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -5,6 +5,7 @@ mod input_source;
 mod parse;
 mod parser;
 mod prompt;
+mod prompts;
 mod summarization_state;
 mod tools;
 
@@ -911,46 +912,8 @@ where
 
                 // Create a summary request based on user input or default
                 let summary_request = match prompt {
-                    Some(custom_prompt) => {
-                        // Make the custom instructions much more prominent and directive
-                        format!(
-                            "[SYSTEM NOTE: This is an automated summarization request, not from the user]\n\n\
-                            FORMAT REQUIREMENTS: Create a structured, concise summary in bullet-point format. DO NOT respond conversationally. DO NOT address the user directly.\n\n\
-                            IMPORTANT CUSTOM INSTRUCTION: {}\n\n\
-                            Your task is to create a structured summary document containing:\n\
-                            1) A bullet-point list of key topics/questions covered\n\
-                            2) Bullet points for all significant tools executed and their results\n\
-                            3) Bullet points for any code or technical information shared\n\
-                            4) A section of key insights gained\n\n\
-                            FORMAT THE SUMMARY IN THIRD PERSON, NOT AS A DIRECT RESPONSE. Example format:\n\n\
-                            ## CONVERSATION SUMMARY\n\
-                            * Topic 1: Key information\n\
-                            * Topic 2: Key information\n\n\
-                            ## TOOLS EXECUTED\n\
-                            * Tool X: Result Y\n\n\
-                            Remember this is a DOCUMENT not a chat response. The custom instruction above modifies what to prioritize.\n\
-                            FILTER OUT CHAT CONVENTIONS (greetings, offers to help, etc).",
-                            custom_prompt
-                        )
-                    },
-                    None => {
-                        // Default prompt
-                        "[SYSTEM NOTE: This is an automated summarization request, not from the user]\n\n\
-                        FORMAT REQUIREMENTS: Create a structured, concise summary in bullet-point format. DO NOT respond conversationally. DO NOT address the user directly.\n\n\
-                        Your task is to create a structured summary document containing:\n\
-                        1) A bullet-point list of key topics/questions covered\n\
-                        2) Bullet points for all significant tools executed and their results\n\
-                        3) Bullet points for any code or technical information shared\n\
-                        4) A section of key insights gained\n\n\
-                        FORMAT THE SUMMARY IN THIRD PERSON, NOT AS A DIRECT RESPONSE. Example format:\n\n\
-                        ## CONVERSATION SUMMARY\n\
-                        * Topic 1: Key information\n\
-                        * Topic 2: Key information\n\n\
-                        ## TOOLS EXECUTED\n\
-                        * Tool X: Result Y\n\n\
-                        Remember this is a DOCUMENT not a chat response.\n\
-                        FILTER OUT CHAT CONVENTIONS (greetings, offers to help, etc).".to_string()
-                    },
+                    Some(custom_prompt) => prompts::summary::with_custom_prompt(&custom_prompt),
+                    None => prompts::summary::default(),
                 };
 
                 // Add the summarization request

--- a/crates/q_cli/src/cli/chat/prompts.rs
+++ b/crates/q_cli/src/cli/chat/prompts.rs
@@ -1,0 +1,46 @@
+/// This file contains prompt templates used in the chat module.
+
+/// Summary request templates for conversation summarization
+pub mod summary {
+    /// Creates a summary request with custom instructions
+    pub fn with_custom_prompt(custom_prompt: &str) -> String {
+        format!(
+            "\n\n\
+            FORMAT REQUIREMENTS: Create a structured, concise summary in bullet-point format. DO NOT respond conversationally. DO NOT address the user directly.\n\n\
+            IMPORTANT CUSTOM INSTRUCTION: {}\n\n\
+            Your task is to create a structured summary document containing:\n\
+            1) A bullet-point list of key topics/questions covered\n\
+            2) Bullet points for all significant tools executed and their results\n\
+            3) Bullet points for any code or technical information shared\n\
+            4) A section of key insights gained\n\n\
+            FORMAT THE SUMMARY IN THIRD PERSON, NOT AS A DIRECT RESPONSE. Example format:\n\n\
+            ## CONVERSATION SUMMARY\n\
+            * Topic 1: Key information\n\
+            * Topic 2: Key information\n\n\
+            ## TOOLS EXECUTED\n\
+            * Tool X: Result Y\n\n\
+            Remember this is a DOCUMENT not a chat response. The custom instruction above modifies what to prioritize.\n\
+            FILTER OUT CHAT CONVENTIONS (greetings, offers to help, etc).",
+            custom_prompt
+        )
+    }
+
+    /// Default summary request without custom instructions
+    pub fn default() -> String {
+        "[SYSTEM NOTE: This is an automated summarization request, not from the user]\n\n\
+        FORMAT REQUIREMENTS: Create a structured, concise summary in bullet-point format. DO NOT respond conversationally. DO NOT address the user directly.\n\n\
+        Your task is to create a structured summary document containing:\n\
+        1) A bullet-point list of key topics/questions covered\n\
+        2) Bullet points for all significant tools executed and their results\n\
+        3) Bullet points for any code or technical information shared\n\
+        4) A section of key insights gained\n\n\
+        FORMAT THE SUMMARY IN THIRD PERSON, NOT AS A DIRECT RESPONSE. Example format:\n\n\
+        ## CONVERSATION SUMMARY\n\
+        * Topic 1: Key information\n\
+        * Topic 2: Key information\n\n\
+        ## TOOLS EXECUTED\n\
+        * Tool X: Result Y\n\n\
+        Remember this is a DOCUMENT not a chat response.\n\
+        FILTER OUT CHAT CONVENTIONS (greetings, offers to help, etc).".to_string()
+    }
+}

--- a/crates/q_cli/src/cli/chat/summarization_state.rs
+++ b/crates/q_cli/src/cli/chat/summarization_state.rs
@@ -26,15 +26,6 @@ pub struct SummarizationState {
 }
 
 impl SummarizationState {
-    #[allow(dead_code)]
-    pub fn new() -> Self {
-        Self {
-            original_history: None,
-            custom_prompt: None,
-            show_summary: false,
-        }
-    }
-
     pub fn with_prompt(prompt: Option<String>) -> Self {
         Self {
             original_history: None,


### PR DESCRIPTION
Extract large string literals from chat/mod.rs into a new prompts.rs file to improve code organization and maintainability. The functionality remains unchanged while making the code more readable.

[Suggested comment](https://github.com/aws/amazon-q-developer-cli/pull/1128/files#r2035988531) in #1128 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
