### PR TITLE
fix: set a reqwest client as the http client for the aws sdk clients to enable system proxy use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2535,6 +2535,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
+ "fig_request",
  "http 1.2.0",
  "tracing",
 ]

--- a/crates/fig_api_client/src/clients/client.rs
+++ b/crates/fig_api_client/src/clients/client.rs
@@ -81,6 +81,7 @@ impl Client {
     pub async fn new_codewhisperer_client(endpoint: &Endpoint) -> Self {
         let conf_builder: amzn_codewhisperer_client::config::Builder = (&bearer_sdk_config(endpoint).await).into();
         let conf = conf_builder
+            .http_client(fig_aws_common::http_client::client())
             .interceptor(OptOutInterceptor::new())
             .interceptor(UserAgentOverrideInterceptor::new())
             .bearer_token_resolver(BearerResolver)
@@ -93,6 +94,7 @@ impl Client {
     pub async fn new_consolas_client(endpoint: &Endpoint) -> Result<Self, Error> {
         let conf_builder: amzn_consolas_client::config::Builder = (&sigv4_sdk_config(endpoint).await?).into();
         let conf = conf_builder
+            .http_client(fig_aws_common::http_client::client())
             .interceptor(OptOutInterceptor::new())
             .interceptor(UserAgentOverrideInterceptor::new())
             .app_name(app_name())

--- a/crates/fig_api_client/src/clients/streaming_client.rs
+++ b/crates/fig_api_client/src/clients/streaming_client.rs
@@ -70,6 +70,7 @@ impl StreamingClient {
         let conf_builder: amzn_codewhisperer_streaming_client::config::Builder =
             (&bearer_sdk_config(endpoint).await).into();
         let conf = conf_builder
+            .http_client(fig_aws_common::http_client::client())
             .interceptor(OptOutInterceptor::new())
             .interceptor(UserAgentOverrideInterceptor::new())
             .bearer_token_resolver(BearerResolver)
@@ -85,6 +86,7 @@ impl StreamingClient {
         let conf_builder: amzn_qdeveloper_streaming_client::config::Builder =
             (&sigv4_sdk_config(endpoint).await?).into();
         let conf = conf_builder
+            .http_client(fig_aws_common::http_client::client())
             .interceptor(OptOutInterceptor::new())
             .interceptor(UserAgentOverrideInterceptor::new())
             .app_name(app_name())

--- a/crates/fig_auth/src/builder_id.rs
+++ b/crates/fig_auth/src/builder_id.rs
@@ -95,6 +95,7 @@ pub(crate) fn oidc_url(region: &Region) -> String {
 pub(crate) fn client(region: Region) -> Client {
     let retry_config = RetryConfig::standard().with_max_attempts(3);
     let sdk_config = aws_types::SdkConfig::builder()
+        .http_client(fig_aws_common::http_client::client())
         .behavior_version(BehaviorVersion::v2024_03_28())
         .endpoint_url(oidc_url(&region))
         .region(region)

--- a/crates/fig_aws_common/Cargo.toml
+++ b/crates/fig_aws_common/Cargo.toml
@@ -12,6 +12,7 @@ aws-runtime = "1.4.4"
 aws-smithy-runtime-api.workspace = true
 aws-smithy-types.workspace = true
 aws-types.workspace = true
+fig_request.workspace = true
 http.workspace = true
 tracing.workspace = true
 

--- a/crates/fig_aws_common/src/http_client.rs
+++ b/crates/fig_aws_common/src/http_client.rs
@@ -1,0 +1,199 @@
+use std::time::Duration;
+
+use aws_smithy_runtime_api::client::http::{
+    HttpClient,
+    HttpConnector,
+    HttpConnectorFuture,
+    HttpConnectorSettings,
+    SharedHttpConnector,
+};
+use aws_smithy_runtime_api::client::result::ConnectorError;
+use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
+use aws_smithy_runtime_api::http::Request;
+use aws_smithy_types::body::SdkBody;
+use fig_request::reqwest;
+use fig_request::reqwest::Client as ReqwestClient;
+
+/// Returns a wrapper around the global [fig_request::client] that implements
+/// [HttpClient].
+pub fn client() -> Client {
+    let client = fig_request::client().expect("failed to create http client");
+    Client::new(client.clone())
+}
+
+/// A wrapper around [reqwest::Client] that implements [HttpClient].
+///
+/// This is required to support using proxy servers with the AWS SDK.
+#[derive(Debug, Clone)]
+pub struct Client {
+    inner: ReqwestClient,
+}
+
+impl Client {
+    pub fn new(client: ReqwestClient) -> Self {
+        Self { inner: client }
+    }
+}
+
+#[derive(Debug)]
+struct CallError {
+    kind: CallErrorKind,
+    message: &'static str,
+    source: Option<Box<dyn std::error::Error + Send + Sync>>,
+}
+
+impl CallError {
+    fn user(message: &'static str) -> Self {
+        Self {
+            kind: CallErrorKind::User,
+            message,
+            source: None,
+        }
+    }
+
+    fn user_with_source<E>(message: &'static str, source: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        Self {
+            kind: CallErrorKind::User,
+            message,
+            source: Some(Box::new(source)),
+        }
+    }
+
+    fn timeout<E>(source: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        Self {
+            kind: CallErrorKind::Timeout,
+            message: "request timed out",
+            source: Some(Box::new(source)),
+        }
+    }
+
+    fn io<E>(source: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        Self {
+            kind: CallErrorKind::Io,
+            message: "an i/o error occurred",
+            source: Some(Box::new(source)),
+        }
+    }
+
+    fn other<E>(message: &'static str, source: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        Self {
+            kind: CallErrorKind::Other,
+            message,
+            source: Some(Box::new(source)),
+        }
+    }
+}
+
+impl std::error::Error for CallError {}
+
+impl std::fmt::Display for CallError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)?;
+        if let Some(err) = self.source.as_ref() {
+            write!(f, ": {}", err)?;
+        }
+        Ok(())
+    }
+}
+
+impl From<CallError> for ConnectorError {
+    fn from(value: CallError) -> Self {
+        match &value.kind {
+            CallErrorKind::User => Self::user(Box::new(value)),
+            CallErrorKind::Timeout => Self::timeout(Box::new(value)),
+            CallErrorKind::Io => Self::io(Box::new(value)),
+            CallErrorKind::Other => Self::other(Box::new(value), None),
+        }
+    }
+}
+
+impl From<reqwest::Error> for CallError {
+    fn from(err: reqwest::Error) -> Self {
+        if err.is_timeout() {
+            CallError::timeout(err)
+        } else if err.is_connect() {
+            CallError::io(err)
+        } else {
+            CallError::other("an unknown error occurred", err)
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+enum CallErrorKind {
+    User,
+    Timeout,
+    Io,
+    Other,
+}
+
+#[derive(Debug)]
+struct ReqwestConnector {
+    client: ReqwestClient,
+    timeout: Option<Duration>,
+}
+
+impl HttpConnector for ReqwestConnector {
+    fn call(&self, request: Request) -> HttpConnectorFuture {
+        let client = self.client.clone();
+        let timeout = self.timeout;
+
+        HttpConnectorFuture::new(async move {
+            // Convert the aws_smithy_runtime_api request to a reqwest request.
+            // TODO: There surely has to be a better way to convert an aws_smith_runtime_api
+            // Request<SdkBody> to a reqwest Request<Body>.
+            let mut req_builder = client.request(
+                reqwest::Method::from_bytes(request.method().as_bytes())
+                    .map_err(|err| CallError::user_with_source("failed to create method name", err))?,
+                request.uri().to_owned(),
+            );
+            // Copy the header, body, and timeout.
+            let parts = request.into_parts();
+            for (name, value) in parts.headers.iter() {
+                let name = name.to_owned();
+                let value = value.as_bytes().to_owned();
+                req_builder = req_builder.header(name, value);
+            }
+            let body_bytes = parts
+                .body
+                .bytes()
+                .ok_or(CallError::user("streaming request body is not supported"))?
+                .to_owned();
+            req_builder = req_builder.body(body_bytes);
+            if let Some(timeout) = timeout {
+                req_builder = req_builder.timeout(timeout);
+            }
+
+            let reqwest_response = req_builder.send().await.map_err(CallError::from)?;
+
+            // Converts from a reqwest Response into an http::Response<SdkBody>.
+            let (parts, body) = http::Response::from(reqwest_response).into_parts();
+            let http_response = http::Response::from_parts(parts, SdkBody::from_body_1_x(body));
+
+            Ok(aws_smithy_runtime_api::http::Response::try_from(http_response)
+                .map_err(|err| CallError::other("failed to convert to a proper response", err))?)
+        })
+    }
+}
+
+impl HttpClient for Client {
+    fn http_connector(&self, settings: &HttpConnectorSettings, _components: &RuntimeComponents) -> SharedHttpConnector {
+        let connector = ReqwestConnector {
+            client: self.inner.clone(),
+            timeout: settings.read_timeout(),
+        };
+        SharedHttpConnector::new(connector)
+    }
+}

--- a/crates/fig_aws_common/src/lib.rs
+++ b/crates/fig_aws_common/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod http_client;
 mod sdk_error_display;
 mod user_agent_override_interceptor;
 

--- a/crates/fig_telemetry/src/lib.rs
+++ b/crates/fig_telemetry/src/lib.rs
@@ -205,6 +205,7 @@ impl Client {
         let client_id = util::get_client_id();
         let toolkit_telemetry_client = Some(amzn_toolkit_telemetry::Client::from_conf(
             Config::builder()
+                .http_client(fig_aws_common::http_client::client())
                 .behavior_version(BehaviorVersion::v2024_03_28())
                 .endpoint_resolver(StaticEndpoint(telemetry_stage.endpoint))
                 .app_name(app_name())


### PR DESCRIPTION
*Description of changes:*
- Due to [an open issue in the rust aws sdk](https://github.com/awslabs/aws-sdk-rust/issues/169), we cannot use the system proxy (ie, `HTTP_PROXY` / `HTTPS_PROXY` env var) when making requests. This is causing issues for users in corporate networks that require all outbound traffic to go through a proxy server. The only solution is to use a client-owned http client [as noted in this comment](https://github.com/awslabs/aws-sdk-rust/issues/169#issuecomment-2729530913).
- Creating an `aws-smithy-runtime-api::client::http::HttpClient` implementation using the same `reqwest` client created globally in the `fig_request` crate. `reqwest` supports use of the system proxy by default, thus this seemed to be the simplest path forward for now.

Since this will be used for all network requests now, we'll need to perform extensive testing across the app (including the update flow, etc anything that requires network access) to ensure that nothing is broken.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
