### PR TITLE
feat(/tools): update trustall UX, /trust and /untrust capability

### DIFF
--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -211,8 +211,8 @@ const HELP_TEXT: &str = color_print::cstr! {"
   <em>--summary</em>   <black!>Display the summary after compacting</black!>
 <em>/tools</em>        <black!>View and manage tools and permissions</black!>
   <em>help</em>        <black!>Show an explanation for the trust command</black!>
-  <em>trust</em>       <black!>Trust a specific tool for the session</black!>
-  <em>untrust</em>     <black!>Revert a tool to per-request confirmation</black!>
+  <em>trust</em>       <black!>Trust a specific tool or tools for the session</black!>
+  <em>untrust</em>     <black!>Revert a tool or tools to per-request confirmation</black!>
   <em>trustall</em>    <black!>Trust all tools (equivalent to deprecated /acceptall)</black!>
   <em>reset</em>       <black!>Reset all tools to default permission levels</black!>
 <em>/profile</em>      <black!>Manage profiles</black!>
@@ -240,6 +240,8 @@ const HELP_TEXT: &str = color_print::cstr! {"
 "};
 
 const RESPONSE_TIMEOUT_CONTENT: &str = "Response timed out - message took too long to generate";
+const TRUST_ALL_TEXT: &str = color_print::cstr! {"<green!>All tools are now trusted (<red!>!</red!>). Amazon Q will execute tools <bold>without</bold> asking for confirmation.\
+\nAgents can sometimes do unexpected things so understand the risks.</green!>"};
 
 pub async fn chat(
     input: Option<String>,
@@ -695,6 +697,15 @@ where
             )
         )?;
         execute!(self.output, style::Print("\n"), style::SetForegroundColor(Color::Reset))?;
+        if self.interactive && self.all_tools_trusted() {
+            queue!(
+                self.output,
+                style::Print(format!(
+                    "{}{TRUST_ALL_TEXT}\n\n",
+                    if !is_small_screen { "\n" } else { "" }
+                ))
+            )?;
+        }
         self.output.flush()?;
 
         let mut ctrl_c_stream = signal(SignalKind::interrupt())?;
@@ -1926,29 +1937,91 @@ where
                 }
             },
             Command::Tools { subcommand } => {
+                let existing_tools: HashSet<&String> = self
+                    .conversation_state
+                    .tools
+                    .iter()
+                    .map(|FigTool::ToolSpecification(spec)| &spec.name)
+                    .collect();
+
                 match subcommand {
-                    Some(ToolsSubcommand::Trust { tool_name }) => {
-                        self.tool_permissions.trust_tool(&tool_name);
-                        queue!(
-                            self.output,
-                            style::SetForegroundColor(Color::Green),
-                            style::Print(format!("\nTool '{tool_name}' is now trusted. I will ")),
-                            style::SetAttribute(Attribute::Bold),
-                            style::Print("not"),
-                            style::SetAttribute(Attribute::Reset),
-                            style::SetForegroundColor(Color::Green),
-                            style::Print(" ask for confirmation before running this tool."),
-                            style::SetForegroundColor(Color::Reset),
-                        )?;
+                    Some(ToolsSubcommand::Trust { tool_names }) => {
+                        let (valid_tools, invalid_tools): (Vec<String>, Vec<String>) = tool_names
+                            .into_iter()
+                            .partition(|tool_name| existing_tools.contains(tool_name));
+
+                        if !invalid_tools.is_empty() {
+                            queue!(
+                                self.output,
+                                style::SetForegroundColor(Color::Red),
+                                style::Print(format!("\nCannot trust '{}', ", invalid_tools.join("', '"))),
+                                if invalid_tools.len() > 1 {
+                                    style::Print("they do not exist.")
+                                } else {
+                                    style::Print("it does not exist.")
+                                },
+                                style::SetForegroundColor(Color::Reset),
+                            )?;
+                        }
+                        if !valid_tools.is_empty() {
+                            valid_tools.iter().for_each(|t| self.tool_permissions.trust_tool(t));
+                            queue!(
+                                self.output,
+                                style::SetForegroundColor(Color::Green),
+                                if valid_tools.len() > 1 {
+                                    style::Print(format!("\nTools '{}' are ", valid_tools.join("', '")))
+                                } else {
+                                    style::Print(format!("\nTool '{}' is ", valid_tools[0]))
+                                },
+                                style::Print("now trusted. I will "),
+                                style::SetAttribute(Attribute::Bold),
+                                style::Print("not"),
+                                style::SetAttribute(Attribute::Reset),
+                                style::SetForegroundColor(Color::Green),
+                                style::Print(format!(
+                                    " ask for confirmation before running {}.",
+                                    if valid_tools.len() > 1 {
+                                        "these tools"
+                                    } else {
+                                        "this tool"
+                                    }
+                                )),
+                                style::SetForegroundColor(Color::Reset),
+                            )?;
+                        }
                     },
-                    Some(ToolsSubcommand::Untrust { tool_name }) => {
-                        self.tool_permissions.untrust_tool(&tool_name);
-                        queue!(
-                            self.output,
-                            style::SetForegroundColor(Color::Green),
-                            style::Print(format!("\nTool '{tool_name}' set to per-request confirmation."),),
-                            style::SetForegroundColor(Color::Reset),
-                        )?;
+                    Some(ToolsSubcommand::Untrust { tool_names }) => {
+                        let (valid_tools, invalid_tools): (Vec<String>, Vec<String>) = tool_names
+                            .into_iter()
+                            .partition(|tool_name| existing_tools.contains(tool_name));
+
+                        if !invalid_tools.is_empty() {
+                            queue!(
+                                self.output,
+                                style::SetForegroundColor(Color::Red),
+                                style::Print(format!("\nCannot untrust '{}', ", invalid_tools.join("', '"))),
+                                if invalid_tools.len() > 1 {
+                                    style::Print("they do not exist.")
+                                } else {
+                                    style::Print("it does not exist.")
+                                },
+                                style::SetForegroundColor(Color::Reset),
+                            )?;
+                        }
+                        if !valid_tools.is_empty() {
+                            valid_tools.iter().for_each(|t| self.tool_permissions.untrust_tool(t));
+                            queue!(
+                                self.output,
+                                style::SetForegroundColor(Color::Green),
+                                if valid_tools.len() > 1 {
+                                    style::Print(format!("\nTools '{}' are ", valid_tools.join("', '")))
+                                } else {
+                                    style::Print(format!("\nTool '{}' is ", valid_tools[0]))
+                                },
+                                style::Print("set to per-request confirmation."),
+                                style::SetForegroundColor(Color::Reset),
+                            )?;
+                        }
                     },
                     Some(ToolsSubcommand::TrustAll) => {
                         self.conversation_state
@@ -1957,17 +2030,7 @@ where
                             .for_each(|FigTool::ToolSpecification(spec)| {
                                 self.tool_permissions.trust_tool(spec.name.as_str());
                             });
-                        queue!(
-                            self.output,
-                            style::SetForegroundColor(Color::Green),
-                            style::Print("\nAll tools are now trusted. I will "),
-                            style::SetAttribute(Attribute::Bold),
-                            style::Print("not"),
-                            style::SetAttribute(Attribute::Reset),
-                            style::SetForegroundColor(Color::Green),
-                            style::Print(" ask for confirmation before running any tools."),
-                            style::SetForegroundColor(Color::Reset),
-                        )?;
+                        queue!(self.output, style::Print(TRUST_ALL_TEXT),)?;
                     },
                     Some(ToolsSubcommand::Reset) => {
                         self.tool_permissions.reset();
@@ -2857,11 +2920,7 @@ where
 
     /// Helper function to generate a prompt based on the current context
     fn generate_tool_trust_prompt(&self) -> String {
-        let all_tools_trusted = self.conversation_state.tools.iter().all(|t| match t {
-            FigTool::ToolSpecification(t) => self.tool_permissions.is_trusted(&t.name),
-        });
-
-        prompt::generate_prompt(self.conversation_state.current_profile(), all_tools_trusted)
+        prompt::generate_prompt(self.conversation_state.current_profile(), self.all_tools_trusted())
     }
 
     async fn send_tool_use_telemetry(&mut self) {
@@ -2879,6 +2938,12 @@ where
 
     fn terminal_width(&self) -> usize {
         (self.terminal_width_provider)().unwrap_or(80)
+    }
+
+    fn all_tools_trusted(&self) -> bool {
+        self.conversation_state.tools.iter().all(|t| match t {
+            FigTool::ToolSpecification(t) => self.tool_permissions.is_trusted(&t.name),
+        })
     }
 
     /// Display character limit warnings based on current conversation size


### PR DESCRIPTION
https://github.com/aws/amazon-q-developer-cli/issues/1157

- Make trustall/acceptall warning more verbose.
- Trustall/acceptall warning will show if you start chat with -a or --acceptall or --trust-all-tools
- /trust and /untrust takes an unlimited amount of tools at a time
- /trust and /untrust will display an error if you specify a tool name that does not exist

![image](https://github.com/user-attachments/assets/0f236435-e835-43aa-89b0-3162ba55a6b0)
![image](https://github.com/user-attachments/assets/0780b223-fda5-413b-9adf-56709d2732be)

![image](https://github.com/user-attachments/assets/26252925-9474-4f78-b12b-cdc142c7b673)
![image](https://github.com/user-attachments/assets/ea4f5245-69d9-4507-b0ed-04251b72b947)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
