### PR TITLE
fix(cli): remove --accept-all references from chat help

### DIFF
--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -279,7 +279,7 @@ pub async fn chat(
             queue!(
                 output,
                 style::SetForegroundColor(Color::Yellow),
-                style::Print("\n--accept-all is deprecated. Use --trust-all-tools instead."),
+                style::Print("\n--accept-all, -a is deprecated. Use --trust-all-tools instead."),
                 style::SetForegroundColor(Color::Reset),
             )?;
         }
@@ -341,7 +341,7 @@ pub enum ChatError {
     #[error("interrupted")]
     Interrupted { tool_uses: Option<Vec<QueuedTool>> },
     #[error(
-        "Tool approval required but --no-interactive was specified. Use --accept-all to automatically approve tools."
+        "Tool approval required but --no-interactive was specified. Use --trust-all-tools to automatically approve tools."
     )]
     NonInteractiveToolApproval,
 }

--- a/crates/q_cli/src/cli/mod.rs
+++ b/crates/q_cli/src/cli/mod.rs
@@ -184,10 +184,10 @@ pub enum CliRootCommands {
     Chat {
         /// (Deprecated, use --trust-all-tools) Enabling this flag allows the model to execute
         /// all commands without first accepting them.
-        #[arg(short, long)]
+        #[arg(short, long, hide = true)]
         accept_all: bool,
         /// Print the first response to STDOUT without interactive mode. This will fail if the
-        /// prompt requests permissions to use a tool, unless --accept-all is also used.
+        /// prompt requests permissions to use a tool, unless --trust-all-tools is also used.
         #[arg(long)]
         no_interactive: bool,
         /// The first question to ask


### PR DESCRIPTION
https://github.com/aws/amazon-q-developer-cli/issues/1202

Before:
![image](https://github.com/user-attachments/assets/ba354e06-496f-4eee-b3b7-8181e481c7a9)


After:
![image](https://github.com/user-attachments/assets/73bb592d-a168-4ca2-90fc-54c506200c68)
![image](https://github.com/user-attachments/assets/b4982d06-992b-437a-9250-7cca1eef7369)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
