### PR TITLE
docs: Fix typo in Windows installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@
 - **Windows**:
   - Follow the discussions for
     [Windows](https://github.com/aws/q-command-line-discussions/discussions/15)
-  - Or [use it on Window with WSL](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-installing.html#command-line-installing-windows)
+  - Or [use it on Windows with WSL](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-installing.html#command-line-installing-windows)
 - **Remote machines**
   - [Autocomplete in SSH](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-autocomplete-ssh.html)
 


### PR DESCRIPTION
Change 'Window' to 'Windows' in the WSL installation instructions for better clarity.

🤖 Assisted by [Amazon Q Developer](https://aws.amazon.com/q/developer)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
