### PR TITLE
feat(context): context hooks with `/context hooks`

### DIFF
--- a/crates/q_cli/src/cli/chat/command.rs
+++ b/crates/q_cli/src/cli/chat/command.rs
@@ -1,5 +1,9 @@
 use std::io::Write;
 
+use clap::{
+    Parser,
+    Subcommand,
+};
 use crossterm::style::Color;
 use crossterm::{
     queue,
@@ -87,6 +91,57 @@ Profiles allow you to organize and manage different sets of context files for di
     }
 }
 
+#[derive(Parser, Debug, Clone)]
+#[command(name = "hooks", disable_help_flag = true, disable_help_subcommand = true)]
+struct HooksCommand {
+    #[command(subcommand)]
+    command: HooksSubcommand,
+}
+
+#[derive(Subcommand, Debug, Clone, Eq, PartialEq)]
+pub enum HooksSubcommand {
+    Add {
+        name: String,
+
+        #[arg(long, value_parser = ["per_prompt", "conversation_start"])]
+        r#type: String,
+
+        #[arg(long, value_parser = clap::value_parser!(String))]
+        command: String,
+
+        #[arg(long)]
+        global: bool,
+    },
+    #[command(name = "rm")]
+    Remove {
+        name: String,
+
+        #[arg(long)]
+        global: bool,
+    },
+    Enable {
+        name: String,
+
+        #[arg(long)]
+        global: bool,
+    },
+    Disable {
+        name: String,
+
+        #[arg(long)]
+        global: bool,
+    },
+    EnableAll {
+        #[arg(long)]
+        global: bool,
+    },
+    DisableAll {
+        #[arg(long)]
+        global: bool,
+    },
+    Help,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ContextSubcommand {
     Show {
@@ -103,6 +158,9 @@ pub enum ContextSubcommand {
     },
     Clear {
         global: bool,
+    },
+    Hooks {
+        subcommand: Option<HooksSubcommand>,
     },
     Help,
 }
@@ -124,13 +182,41 @@ impl ContextSubcommand {
                                  <black!>--global: Remove specified rules globally</black!>
 
   <em>clear [--global]</em>               <black!>Remove all rules from current profile</black!>
-                                 <black!>--global: Remove global rules</black!>"};
+                                 <black!>--global: Remove global rules</black!>
+
+  <em>hooks</em>                          <black!>View and manage context hooks</black!>"};
     const CLEAR_USAGE: &str = "/context clear [--global]";
+    const HOOKS_AVAILABLE_COMMANDS: &str = color_print::cstr! {"<cyan!>Available subcommands</cyan!>
+  <em>hooks help</em>                         <black!>Show an explanation for context hooks commands</black!>
+
+  <em>hooks add [--global] <<name>></em>        <black!>Add a new command context hook</black!>
+                                         <black!>--global: Add to global hooks</black!>
+         <em>--type <<type>></em>                <black!>Type of hook, valid options: `per_prompt` or `conversation_start`</black!>
+         <em>--command <<command>></em>             <black!>Shell command to execute</black!>
+
+  <em>hooks rm [--global] <<name>></em>         <black!>Remove an existing context hook</black!>
+                                         <black!>--global: Remove from global hooks</black!>
+
+  <em>hooks enable [--global] <<name>></em>     <black!>Enable an existing context hook</black!>
+                                         <black!>--global: Enable in global hooks</black!>
+
+  <em>hooks disable [--global] <<name>></em>    <black!>Disable an existing context hook</black!>
+                                         <black!>--global: Disable in global hooks</black!>
+
+  <em>hooks enable-all [--global]</em>        <black!>Enable all existing context hooks</black!>
+                                         <black!>--global: Enable all in global hooks</black!>
+
+  <em>hooks disable-all [--global]</em>       <black!>Disable all existing context hooks</black!>
+                                         <black!>--global: Disable all in global hooks</black!>"};
     const REMOVE_USAGE: &str = "/context rm [--global] <path1> [path2...]";
     const SHOW_USAGE: &str = "/context show [--expand]";
 
     fn usage_msg(header: impl AsRef<str>) -> String {
         format!("{}\n\n{}", header.as_ref(), Self::AVAILABLE_COMMANDS)
+    }
+
+    fn hooks_usage_msg(header: impl AsRef<str>) -> String {
+        format!("{}\n\n{}", header.as_ref(), Self::HOOKS_AVAILABLE_COMMANDS)
     }
 
     pub fn help_text() -> String {
@@ -143,6 +229,9 @@ The files matched by these rules provide Amazon Q with additional information
 about your project or environment. Adding relevant files helps Q generate 
 more accurate and helpful responses.
 
+In addition to files, you can specify hooks that will run commands and return 
+the output as context to Amazon Q.
+
 {}
 
 <cyan!>Notes</cyan!>
@@ -152,6 +241,32 @@ more accurate and helpful responses.
 • Context is preserved between chat sessions
 "#,
             Self::AVAILABLE_COMMANDS
+        )
+    }
+
+    pub fn hooks_help_text() -> String {
+        color_print::cformat!(
+            r#"
+<magenta,em>(Beta) Context Hooks</magenta,em>
+
+Use context hooks to specify shell commands to run. The output from these 
+commands will be appended to the prompt to Amazon Q. Hooks can be defined 
+in global or local profiles.
+
+<cyan!>Usage: /context hooks [SUBCOMMAND]</cyan!>
+
+<cyan!>Description</cyan!>
+  Show existing global or profile-specific hooks.
+  Alternatively, specify a subcommand to modify the hooks.
+
+{}
+
+<cyan!>Notes</cyan!>
+• Hooks are executed in parallel
+• 'conversation_start' hooks run on the first user prompt and are attached once to the conversation history sent to Amazon Q
+• 'per_prompt' hooks run on each user prompt and are attached to the prompt
+"#,
+            Self::HOOKS_AVAILABLE_COMMANDS
         )
     }
 }
@@ -493,6 +608,18 @@ impl Command {
                         "help" => Self::Context {
                             subcommand: ContextSubcommand::Help,
                         },
+                        "hooks" => {
+                            if parts.get(2).is_none() {
+                                return Ok(Self::Context {
+                                    subcommand: ContextSubcommand::Hooks { subcommand: None },
+                                });
+                            };
+
+                            match Self::parse_hooks(&parts) {
+                                Ok(command) => command,
+                                Err(err) => return Err(ContextSubcommand::hooks_usage_msg(err)),
+                            }
+                        },
                         other => {
                             return Err(ContextSubcommand::usage_msg(format!("Unknown subcommand '{}'.", other)));
                         },
@@ -566,6 +693,27 @@ impl Command {
         Ok(Self::Ask {
             prompt: input.to_string(),
         })
+    }
+
+    // NOTE: Here we use clap to parse the hooks subcommand instead of parsing manually
+    // like the rest of the file.
+    // Since the hooks subcommand has a lot of options, this makes more sense.
+    // Ideally, we parse everything with clap instead of trying to do it manually.
+    fn parse_hooks(parts: &[&str]) -> Result<Self, String> {
+        // Skip the first two parts ("/context" and "hooks")
+        let args = match shlex::split(&parts[1..].join(" ")) {
+            Some(args) => args,
+            None => return Err("Failed to parse arguments".to_string()),
+        };
+
+        // Parse with Clap
+        HooksCommand::try_parse_from(args)
+            .map(|hooks_command| Self::Context {
+                subcommand: ContextSubcommand::Hooks {
+                    subcommand: Some(hooks_command.command),
+                },
+            })
+            .map_err(|e| e.to_string())
     }
 }
 
@@ -688,6 +836,66 @@ mod tests {
             ("/issue \"there was an error in the chat\"", Command::Issue {
                 prompt: Some("\"there was an error in the chat\"".to_string()),
             }),
+            (
+                "/context hooks",
+                context!(ContextSubcommand::Hooks { subcommand: None }),
+            ),
+            (
+                "/context hooks add test --type per_prompt --command 'echo 1' --global",
+                context!(ContextSubcommand::Hooks {
+                    subcommand: Some(HooksSubcommand::Add {
+                        name: "test".to_string(),
+                        global: true,
+                        r#type: "per_prompt".to_string(),
+                        command: "echo 1".to_string()
+                    })
+                }),
+            ),
+            (
+                "/context hooks rm test --global",
+                context!(ContextSubcommand::Hooks {
+                    subcommand: Some(HooksSubcommand::Remove {
+                        name: "test".to_string(),
+                        global: true
+                    })
+                }),
+            ),
+            (
+                "/context hooks enable test --global",
+                context!(ContextSubcommand::Hooks {
+                    subcommand: Some(HooksSubcommand::Enable {
+                        name: "test".to_string(),
+                        global: true
+                    })
+                }),
+            ),
+            (
+                "/context hooks disable test",
+                context!(ContextSubcommand::Hooks {
+                    subcommand: Some(HooksSubcommand::Disable {
+                        name: "test".to_string(),
+                        global: false
+                    })
+                }),
+            ),
+            (
+                "/context hooks enable-all --global",
+                context!(ContextSubcommand::Hooks {
+                    subcommand: Some(HooksSubcommand::EnableAll { global: true })
+                }),
+            ),
+            (
+                "/context hooks disable-all",
+                context!(ContextSubcommand::Hooks {
+                    subcommand: Some(HooksSubcommand::DisableAll { global: false })
+                }),
+            ),
+            (
+                "/context hooks help",
+                context!(ContextSubcommand::Hooks {
+                    subcommand: Some(HooksSubcommand::Help)
+                }),
+            ),
         ];
 
         for (input, parsed) in tests {

--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -49,6 +49,7 @@ use crossterm::{
     terminal,
 };
 use eyre::{
+    ErrReport,
     Result,
     bail,
 };
@@ -66,6 +67,7 @@ use fig_api_client::model::{
 use fig_os_shim::Context;
 use fig_settings::Settings;
 use fig_util::CLI_BINARY_NAME;
+use hooks::Hook;
 use summarization_state::{
     SummarizationState,
     TokenWarningLevel,
@@ -155,7 +157,7 @@ const WELCOME_TEXT: &str = color_print::cstr! {"
 <em>/tools</em>        <black!>View and manage tools and permissions</black!>
 <em>/issue</em>        <black!>Report an issue or make a feature request</black!>
 <em>/profile</em>      <black!>(Beta) Manage profiles for the chat session</black!>
-<em>/context</em>      <black!>(Beta) Manage context files for a profile</black!>
+<em>/context</em>      <black!>(Beta) Manage context files and hooks for a profile</black!>
 <em>/compact</em>      <black!>Summarize the conversation to free up context space</black!>
 <em>/help</em>         <black!>Show the help dialogue</black!>
 <em>/quit</em>         <black!>Quit the application</black!>
@@ -191,12 +193,13 @@ const HELP_TEXT: &str = color_print::cstr! {"
   <em>create</em>      <black!>Create a new profile</black!>
   <em>delete</em>      <black!>Delete a profile</black!>
   <em>rename</em>      <black!>Rename a profile</black!>
-<em>/context</em>      <black!>Manage context files for the chat session</black!>
+<em>/context</em>      <black!>Manage context files and hooks for the chat session</black!>
   <em>help</em>        <black!>Show context help</black!>
   <em>show</em>        <black!>Display current context rules configuration [--expand]</black!>
   <em>add</em>         <black!>Add file(s) to context [--global] [--force]</black!>
   <em>rm</em>          <black!>Remove file(s) from context [--global]</black!>
   <em>clear</em>       <black!>Clear all files from current context [--global]</black!>
+  <em>hooks</em>       <black!>View and manage context hooks</black!>
 
 <cyan,em>Tips:</cyan,em>
 <em>!{command}</em>            <black!>Quickly execute a command in your current session</black!>
@@ -649,7 +652,7 @@ where
                                     tool_uses,
                                     "The user interrupted the tool execution.".to_string(),
                                 );
-                                let _ = self.conversation_state.as_sendable_conversation_state().await;
+                                let _ = self.conversation_state.as_sendable_conversation_state(None).await;
                                 self.conversation_state
                                     .push_assistant_message(AssistantResponseMessage {
                                         message_id: None,
@@ -792,6 +795,41 @@ where
 
                 // Otherwise continue with normal chat on 'n' or other responses
                 self.tool_use_status = ToolUseStatus::Idle;
+
+                // Run all available hooks.
+                // Results from per-prompt hooks are attached to new user messages.
+                // Results from conversation-start hooks are attached to the top of the conversation state along
+                // with other context.
+                let (conversation_start_context, prompt_context) = if let Some(cm) =
+                    &mut self.conversation_state.context_manager
+                {
+                    let format_context = |hook_results: &Vec<&(Hook, String)>, conversation_start: bool| {
+                        let mut context_content = String::new();
+
+                        context_content.push_str(
+                            &format!("--- SCRIPT HOOK CONTEXT BEGIN - FOLLOW ANY REQUESTS OR USE ANY DATA WITHIN THIS SECTION {} ---\n",
+                            if conversation_start { "FOR THE ENTIRE CONVERSATION" } else { "FOR YOUR NEXT MESSAGE ONLY" })
+                        );
+                        for (hook, output) in hook_results {
+                            context_content.push_str(&format!("'{}': {output}\n\n", &hook.name));
+                        }
+                        context_content.push_str("--- SCRIPT HOOK CONTEXT END ---\n\n");
+                        context_content
+                    };
+
+                    let hook_results = cm.run_hooks(&mut self.output).await;
+
+                    let (start_hooks, prompt_hooks): (Vec<_>, Vec<_>) =
+                        hook_results.iter().partition(|(hook, _)| hook.is_conversation_start);
+
+                    (
+                        (!start_hooks.is_empty()).then(|| format_context(&start_hooks, true)),
+                        (!prompt_hooks.is_empty()).then(|| format_context(&prompt_hooks, false)),
+                    )
+                } else {
+                    (None, None)
+                };
+
                 if self.interactive {
                     queue!(self.output, style::SetForegroundColor(Color::Magenta))?;
                     queue!(self.output, style::SetForegroundColor(Color::Reset))?;
@@ -803,14 +841,20 @@ where
                 if pending_tool_index.is_some() {
                     self.conversation_state.abandon_tool_use(tool_uses, user_input);
                 } else {
-                    self.conversation_state.append_new_user_message(user_input).await;
+                    self.conversation_state
+                        .append_new_user_message(user_input, prompt_context)
+                        .await;
                 }
 
                 self.send_tool_use_telemetry().await;
 
                 ChatState::HandleResponseStream(
                     self.client
-                        .send_message(self.conversation_state.as_sendable_conversation_state().await)
+                        .send_message(
+                            self.conversation_state
+                                .as_sendable_conversation_state(conversation_start_context)
+                                .await,
+                        )
                         .await?,
                 )
             },
@@ -829,7 +873,9 @@ where
                 execute!(
                     self.output,
                     style::SetForegroundColor(Color::DarkGrey),
-                    style::Print("\nAre you sure? This will erase the conversation history for the current session. "),
+                    style::Print(
+                        "\nAre you sure? This will erase the conversation history and context from hooks for the current session. "
+                    ),
                     style::Print("["),
                     style::SetForegroundColor(Color::Green),
                     style::Print("y"),
@@ -850,6 +896,9 @@ where
 
                 if ["y", "Y"].contains(&user_input.as_str()) {
                     self.conversation_state.clear(true);
+                    if let Some(cm) = self.conversation_state.context_manager.as_mut() {
+                        cm.hook_executor.execution_cache.clear();
+                    }
                     execute!(
                         self.output,
                         style::SetForegroundColor(Color::Green),
@@ -952,7 +1001,9 @@ where
                 };
 
                 // Add the summarization request
-                self.conversation_state.append_new_user_message(summary_request).await;
+                self.conversation_state
+                    .append_new_user_message(summary_request, None)
+                    .await;
 
                 // Use spinner while we wait
                 if self.interactive {
@@ -963,7 +1014,7 @@ where
                 // Return to handle response stream state
                 return Ok(ChatState::HandleResponseStream(
                     self.client
-                        .send_message(self.conversation_state.as_sendable_conversation_state().await)
+                        .send_message(self.conversation_state.as_sendable_conversation_state(None).await)
                         .await?,
                 ));
             },
@@ -1410,6 +1461,196 @@ where
                                 style::Print("\n")
                             )?;
                         },
+                        command::ContextSubcommand::Hooks { subcommand } => {
+                            fn map_chat_error(e: ErrReport) -> ChatError {
+                                ChatError::Custom(e.to_string().into())
+                            }
+
+                            let scope = |g: bool| if g { "global" } else { "profile" };
+                            if let Some(subcommand) = subcommand {
+                                match subcommand {
+                                    command::HooksSubcommand::Add {
+                                        name,
+                                        r#type,
+                                        command,
+                                        global,
+                                    } => {
+                                        context_manager
+                                            .add_hook(
+                                                Hook::new_inline_hook(&name, command, false),
+                                                global,
+                                                r#type == "conversation_start",
+                                            )
+                                            .await
+                                            .map_err(map_chat_error)?;
+                                        execute!(
+                                            self.output,
+                                            style::SetForegroundColor(Color::Green),
+                                            style::Print(format!("\nAdded {} hook '{name}'.\n\n", scope(global))),
+                                            style::SetForegroundColor(Color::Reset)
+                                        )?;
+                                    },
+                                    command::HooksSubcommand::Remove { name, global } => {
+                                        context_manager
+                                            .remove_hook(&name, global)
+                                            .await
+                                            .map_err(map_chat_error)?;
+                                        execute!(
+                                            self.output,
+                                            style::SetForegroundColor(Color::Green),
+                                            style::Print(format!("\nRemoved {} hook '{name}'.\n\n", scope(global))),
+                                            style::SetForegroundColor(Color::Reset)
+                                        )?;
+                                    },
+                                    command::HooksSubcommand::Enable { name, global } => {
+                                        context_manager
+                                            .set_hook_disabled(&name, global, false)
+                                            .await
+                                            .map_err(map_chat_error)?;
+                                        execute!(
+                                            self.output,
+                                            style::SetForegroundColor(Color::Green),
+                                            style::Print(format!("\nEnabled {} hook '{name}'.\n\n", scope(global))),
+                                            style::SetForegroundColor(Color::Reset)
+                                        )?;
+                                    },
+                                    command::HooksSubcommand::Disable { name, global } => {
+                                        context_manager
+                                            .set_hook_disabled(&name, global, true)
+                                            .await
+                                            .map_err(map_chat_error)?;
+                                        execute!(
+                                            self.output,
+                                            style::SetForegroundColor(Color::Green),
+                                            style::Print(format!("\nDisabled {} hook '{name}'.\n\n", scope(global))),
+                                            style::SetForegroundColor(Color::Reset)
+                                        )?;
+                                    },
+                                    command::HooksSubcommand::EnableAll { global } => {
+                                        context_manager
+                                            .set_all_hooks_disabled(global, false)
+                                            .await
+                                            .map_err(map_chat_error)?;
+                                        execute!(
+                                            self.output,
+                                            style::SetForegroundColor(Color::Green),
+                                            style::Print(format!("\nEnabled all {} hooks.\n\n", scope(global))),
+                                            style::SetForegroundColor(Color::Reset)
+                                        )?;
+                                    },
+                                    command::HooksSubcommand::DisableAll { global } => {
+                                        context_manager
+                                            .set_all_hooks_disabled(global, true)
+                                            .await
+                                            .map_err(map_chat_error)?;
+                                        execute!(
+                                            self.output,
+                                            style::SetForegroundColor(Color::Green),
+                                            style::Print(format!("\nDisabled all {} hooks.\n\n", scope(global))),
+                                            style::SetForegroundColor(Color::Reset)
+                                        )?;
+                                    },
+                                    command::HooksSubcommand::Help => {
+                                        execute!(
+                                            self.output,
+                                            style::Print("\n"),
+                                            style::Print(command::ContextSubcommand::hooks_help_text()),
+                                            style::Print("\n")
+                                        )?;
+                                    },
+                                }
+                            } else {
+                                fn print_hook_section(
+                                    output: &mut impl Write,
+                                    hooks: &Vec<Hook>,
+                                    conversation_start: bool,
+                                ) -> Result<()> {
+                                    let section = if conversation_start {
+                                        "Conversation start"
+                                    } else {
+                                        "Per prompt"
+                                    };
+                                    queue!(
+                                        output,
+                                        style::SetForegroundColor(Color::Cyan),
+                                        style::Print(format!("    {section}:\n")),
+                                        style::SetForegroundColor(Color::Reset),
+                                    )?;
+
+                                    if hooks.is_empty() {
+                                        queue!(
+                                            output,
+                                            style::SetForegroundColor(Color::DarkGrey),
+                                            style::Print("      <none>\n"),
+                                            style::SetForegroundColor(Color::Reset)
+                                        )?;
+                                    } else {
+                                        for hook in hooks {
+                                            if hook.disabled {
+                                                queue!(
+                                                    output,
+                                                    style::SetForegroundColor(Color::DarkGrey),
+                                                    style::Print(format!("      {} (disabled)\n", hook.name)),
+                                                    style::SetForegroundColor(Color::Reset)
+                                                )?;
+                                            } else {
+                                                queue!(output, style::Print(format!("      {}\n", hook.name)),)?;
+                                            }
+                                        }
+                                    }
+                                    Ok(())
+                                }
+                                queue!(
+                                    self.output,
+                                    style::SetAttribute(Attribute::Bold),
+                                    style::SetForegroundColor(Color::Magenta),
+                                    style::Print("\n🌍 global:\n"),
+                                    style::SetAttribute(Attribute::Reset),
+                                )?;
+
+                                print_hook_section(
+                                    &mut self.output,
+                                    &context_manager.global_config.hooks.conversation_start,
+                                    true,
+                                )
+                                .map_err(map_chat_error)?;
+                                print_hook_section(
+                                    &mut self.output,
+                                    &context_manager.global_config.hooks.per_prompt,
+                                    false,
+                                )
+                                .map_err(map_chat_error)?;
+
+                                queue!(
+                                    self.output,
+                                    style::SetAttribute(Attribute::Bold),
+                                    style::SetForegroundColor(Color::Magenta),
+                                    style::Print(format!("\n👤 profile ({}):\n", &context_manager.current_profile)),
+                                    style::SetAttribute(Attribute::Reset),
+                                )?;
+
+                                print_hook_section(
+                                    &mut self.output,
+                                    &context_manager.profile_config.hooks.conversation_start,
+                                    true,
+                                )
+                                .map_err(map_chat_error)?;
+                                print_hook_section(
+                                    &mut self.output,
+                                    &context_manager.profile_config.hooks.per_prompt,
+                                    false,
+                                )
+                                .map_err(map_chat_error)?;
+
+                                execute!(
+                                    self.output,
+                                    style::Print(format!(
+                                        "\nUse {} to manage hooks.\n\n",
+                                        "/context hooks help".to_string().dark_green()
+                                    )),
+                                )?;
+                            }
+                        },
                     }
                     // fig_telemetry::send_context_command_executed
                 } else {
@@ -1665,7 +1906,7 @@ where
         self.send_tool_use_telemetry().await;
         return Ok(ChatState::HandleResponseStream(
             self.client
-                .send_message(self.conversation_state.as_sendable_conversation_state().await)
+                .send_message(self.conversation_state.as_sendable_conversation_state(None).await)
                 .await?,
         ));
     }
@@ -1751,12 +1992,13 @@ where
                                 .append_new_user_message(
                                     "You took too long to respond - try to split up the work into smaller steps."
                                         .to_string(),
+                                    None,
                                 )
                                 .await;
                             self.send_tool_use_telemetry().await;
                             return Ok(ChatState::HandleResponseStream(
                                 self.client
-                                    .send_message(self.conversation_state.as_sendable_conversation_state().await)
+                                    .send_message(self.conversation_state.as_sendable_conversation_state(None).await)
                                     .await?,
                             ));
                         },
@@ -1789,7 +2031,7 @@ where
                             self.send_tool_use_telemetry().await;
                             return Ok(ChatState::HandleResponseStream(
                                 self.client
-                                    .send_message(self.conversation_state.as_sendable_conversation_state().await)
+                                    .send_message(self.conversation_state.as_sendable_conversation_state(None).await)
                                     .await?,
                             ));
                         },
@@ -2087,7 +2329,7 @@ where
 
             let response = self
                 .client
-                .send_message(self.conversation_state.as_sendable_conversation_state().await)
+                .send_message(self.conversation_state.as_sendable_conversation_state(None).await)
                 .await?;
             return Ok(ChatState::HandleResponseStream(response));
         }


### PR DESCRIPTION
Follow up to: https://github.com/aws/amazon-q-developer-cli/pull/1176
RFC: https://github.com/aws/amazon-q-developer-cli/pull/1050

- Add new command `/context hooks`
  - subcommands to add/remove and enable/disable hooks
- Context hooks are called then added to the beginning of the chat history as context, or to each prompt, depending on what is chosen.

<img width="950" alt="image" src="https://github.com/user-attachments/assets/3662f935-e7b7-4e75-b023-8470e66775b9" />

<img width="1142" alt="image" src="https://github.com/user-attachments/assets/6adf6903-ca65-453b-9d80-5e72c02944e9" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
