### PR TITLE
Added support for /prompt - rebased

### DIFF
--- a/crates/q_cli/src/cli/chat/command.rs
+++ b/crates/q_cli/src/cli/chat/command.rs
@@ -38,6 +38,7 @@ pub enum Command {
     Tools {
         subcommand: Option<ToolsSubcommand>,
     },
+    Prompt { filename: String },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -498,6 +499,13 @@ impl Command {
                         },
                     }
                 },
+                "prompt" => {
+                    if parts.len() < 2 {
+                        return Err("Missing filename for /prompt. Usage: /prompt <filename>".to_string());
+                    }
+                    let filename = parts[1..].join(" ");
+                    Self::Prompt { filename }
+                },
                 "tools" => {
                     if parts.len() < 2 {
                         return Ok(Self::Tools { subcommand: None });
@@ -687,6 +695,12 @@ mod tests {
             }),
             ("/issue \"there was an error in the chat\"", Command::Issue {
                 prompt: Some("\"there was an error in the chat\"".to_string()),
+            }),
+            ("/prompt my-prompt", Command::Prompt {
+                filename: "my-prompt".to_string(),
+            }),
+            ("/prompt my prompt with spaces", Command::Prompt {
+                filename: "my prompt with spaces".to_string(),
             }),
         ];
 

--- a/crates/q_cli/src/cli/chat/prompt.rs
+++ b/crates/q_cli/src/cli/chat/prompt.rs
@@ -39,6 +39,7 @@ const COMMANDS: &[&str] = &[
     "/clear",
     "/help",
     "/editor",
+    "/prompt",
     "/issue",
     // "/acceptall", /// Functional, but deprecated in favor of /tools trustall
     "/quit",


### PR DESCRIPTION
*Issue #, if available:*
Initial PR #1055
*Description of changes:*
New PR after rebase.

This PR implements a new /prompt command allowing the use of pre-saved prompts stored locally (~/.aws/amazonq/prompts as per the IDE plugin).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
