### PR TITLE
fix: handle slash commands

### DIFF
--- a/crates/q_cli/src/cli/chat/command.rs
+++ b/crates/q_cli/src/cli/chat/command.rs
@@ -236,6 +236,14 @@ impl Command {
             return Err(suggestion);
         }
 
+        // Check if the input starts with a literal backslash followed by a slash
+        // This allows users to escape the slash if they actually want to start with one
+        if input.starts_with("\\/") {
+            return Ok(Self::Ask {
+                prompt: input[1..].to_string(), // Remove the backslash but keep the slash
+            });
+        }
+
         if let Some(command) = input.strip_prefix("/") {
             let parts: Vec<&str> = command.split_whitespace().collect();
 
@@ -561,10 +569,13 @@ impl Command {
                         },
                     }
                 },
-                _ => {
-                    return Ok(Self::Ask {
-                        prompt: input.to_string(),
-                    });
+                unknown_command => {
+                    // If the command starts with a slash but isn't recognized,
+                    // return an error instead of treating it as a prompt
+                    return Err(format!(
+                        "Unknown command: '/{}'. Type '/help' to see available commands.\nTo use a literal slash at the beginning of your message, escape it with a backslash (e.g., '\\//hey' for '/hey').",
+                        unknown_command
+                    ));
                 },
             });
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Handle slash commands properly to avoid mistakes.

Produces
Error: Unknown command: '/a'. Type '/help' to see available commands.
To use a literal slash at the beginning of your message, escape it with a backslash (e.g., '\//hey' for '/hey').

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
<img width="870" alt="Screenshot 2025-04-14 at 4 13 19 PM" src="https://github.com/user-attachments/assets/8ee1903c-be64-42f3-9a05-b183553eea5a" />

