### PR TITLE
bug(fix): Make bell notifications only for final response and untrust…

### DIFF
--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -2076,6 +2076,10 @@ where
                 !tool.tool.requires_acceptance(&self.ctx)
             };
 
+            if self.settings.get_bool_or("chat.enableNotifications", false) {
+                play_notification_bell(!allowed);
+            }
+
             self.print_tool_description(tool, allowed).await?;
 
             if allowed {
@@ -2389,7 +2393,8 @@ where
                 }
 
                 if self.interactive && self.settings.get_bool_or("chat.enableNotifications", false) {
-                    play_notification_bell();
+                    // For final responses (no tools suggested), always play the bell
+                    play_notification_bell(tool_uses.is_empty());
                 }
 
                 // Handle citations for non-summarization responses

--- a/crates/q_cli/src/util/spinner.rs
+++ b/crates/q_cli/src/util/spinner.rs
@@ -53,8 +53,12 @@ pub enum SpinnerComponent {
 }
 
 /// Play the terminal bell notification sound
-/// This is a separate function to make it easier to call from multiple places
-pub fn play_notification_bell() {
+pub fn play_notification_bell(requires_confirmation: bool) {
+    // Don't play bell for tools that don't require confirmation
+    if !requires_confirmation {
+        return;
+    }
+
     // Check if we should play the bell based on terminal type
     if should_play_bell() {
         print!("\x07"); // ASCII bell character


### PR DESCRIPTION
…ed tools

Improve user experience by only playing bell notifications when necessary:
- Play bell for final responses (no tools suggested)
- Play bell for tools that require confirmation
- Skip bell for trusted tools that don't require confirmation

🤖 Assisted by [Amazon Q Developer](https://aws.amazon.com/q/developer)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
