### PR TITLE
chore: make skimCommandKey configurable and add help text

### DIFF
--- a/crates/q_cli/src/cli/chat/input_source.rs
+++ b/crates/q_cli/src/cli/chat/input_source.rs
@@ -38,8 +38,12 @@ impl InputSource {
 
     pub fn put_skim_command_selector(&mut self, context_manager: Arc<ContextManager>) {
         if let inner::Inner::Readline(rl) = &mut self.0 {
+            let key_char = match fig_settings::settings::get_string_opt("chat.skimCommandKey").as_deref() {
+                Some(key) if key.len() == 1 => key.chars().next().unwrap_or('k'),
+                _ => 'k', // Default to 'k' if setting is missing or invalid
+            };
             rl.bind_sequence(
-                KeyEvent::ctrl('k'),
+                KeyEvent::ctrl(key_char),
                 EventHandler::Conditional(Box::new(SkimCommandSelector::new(context_manager))),
             );
         }

--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -168,7 +168,7 @@ const WELCOME_TEXT: &str = color_print::cstr! {"
 <em>/quit</em>         <black!>Quit the application</black!>
 
 <cyan!>Use Ctrl(^) + j to provide multi-line prompts.</cyan!>
-<cyan!>Use Ctrl(^) + k to fuzzily search commands and context (use tab to select multiple files).</cyan!>
+<cyan!>Use Ctrl(^) + k to fuzzily search commands and context.</cyan!>
 
 "};
 
@@ -211,6 +211,8 @@ const HELP_TEXT: &str = color_print::cstr! {"
 <cyan,em>Tips:</cyan,em>
 <em>!{command}</em>            <black!>Quickly execute a command in your current session</black!>
 <em>Ctrl(^) + j</em>           <black!>Insert new-line to provide multi-line prompt. Alternatively, [Alt(⌥) + Enter(⏎)]</black!>
+<em>Ctrl(^) + k</em>           <black!>Fuzzy search commands and context files. Use Tab to select multiple items.</black!>
+                      <black!>Change the keybind to ctrl+x with: q settings chat.skimCommandKey x (where x is any key)</black!>
 
 "};
 


### PR DESCRIPTION
*Description of changes:* This makes it so users can configure which key is used with ctrl to enter the skim thing



<img width="685" alt="Screenshot 2025-04-17 at 8 33 21 AM" src="https://github.com/user-attachments/assets/32c968a2-c50b-4447-9500-c9b1cd103c13" />
