### PR TITLE
ci: add workflow to check for merge conflicts with main branch

### DIFF
--- a/.github/workflows/check-merge-conflicts.yml
+++ b/.github/workflows/check-merge-conflicts.yml
@@ -1,0 +1,58 @@
+name: Check Merge Conflicts
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  check-merge-conflicts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Check if PR is against main branch
+        id: check-target-branch
+        run: |
+          TARGET_BRANCH="${{ github.base_ref }}"
+          if [[ "$TARGET_BRANCH" == "main" ]]; then
+            echo "PR is against main branch, no need to check for conflicts"
+            echo "is_main=true" >> $GITHUB_OUTPUT
+          else
+            echo "PR is not against main branch, will check for conflicts"
+            echo "is_main=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check for merge conflicts with main
+        if: steps.check-target-branch.outputs.is_main == 'false'
+        id: check-conflicts
+        run: |
+          
+          # Set Git identity for the merge operation
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "GitHub Actions"
+
+          # Fetch main branch
+          git fetch origin main:main
+
+          # Try to merge main into the current branch
+          MERGE_EXIT_CODE=0
+          git merge main --no-commit --no-ff || MERGE_EXIT_CODE=$?
+
+          if [ $MERGE_EXIT_CODE -eq 0 ]; then
+            echo "No merge conflicts detected"
+            # Abort the merge since we're just checking
+            git merge --abort || true  # Don't fail if there's nothing to abort
+          else
+            echo "Merge conflicts detected!"
+            # Abort the merge
+            git merge --abort || true  # Don't fail if there's nothing to abort
+            echo "::error::This branch has merge conflicts with main. Please pull from main and rebase your branch before creating a PR."
+            exit 1
+          fi
+
+      - name: Success message
+        if: success()
+        run: echo "No merge conflicts detected or PR is against main branch"


### PR DESCRIPTION
*Issue #, if available:*
For long-running feature branches, it is possible that the beta or feature branch starts deviating from main, which can cause large merge-conflicts at a later time.


*Description of changes:*

This workflow automatically checks if PRs would create merge conflicts with the main branch. It performs the following actions:

1. Skips checks if the PR is targeting the main branch
2. For PRs to other branches, attempts a test merge with main
3. Fails the workflow if conflicts are detected, prompting users to rebase
4. Provides clear error messages with instructions for resolving conflicts
5. Handles Git identity configuration and merge state properly

The workflow helps maintain a clean branch structure by encouraging developers to resolve conflicts before creating PRs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
