### PR TITLE
refactor(chat): address auto compaction regressions and minor cleanup

### DIFF
--- a/crates/q_cli/src/cli/chat/token_counter.rs
+++ b/crates/q_cli/src/cli/chat/token_counter.rs
@@ -105,7 +105,7 @@ pub trait CharCounter {
 
 impl CharCounter for BackendConversationState<'_> {
     fn char_count(&self) -> CharCount {
-        self.get_utilization().char_count()
+        self.calculate_conversation_size().char_count()
     }
 }
 


### PR DESCRIPTION
*Description of changes:*
Addressing some followups to #1275 
- only run context hooks on new user prompts
- don't include per prompt context in the conversation history
- remove comments, minor cleanup

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
