### PR TITLE
refactor(/compact): deprecate --summary to show summary by default

### DIFF
--- a/crates/q_chat/src/command.rs
+++ b/crates/q_chat/src/command.rs
@@ -442,7 +442,7 @@ impl Command {
                 "help" => Self::Help,
                 "compact" => {
                     let mut prompt = None;
-                    let mut show_summary = false;
+                    let show_summary = true;
                     let mut help = false;
 
                     // Check if "help" is the first subcommand
@@ -451,23 +451,7 @@ impl Command {
                     } else {
                         let mut remaining_parts = Vec::new();
 
-                        // Parse the parts to handle both prompt and flags
-                        for part in &parts[1..] {
-                            if *part == "--summary" {
-                                show_summary = true;
-                            } else {
-                                remaining_parts.push(*part);
-                            }
-                        }
-
-                        // Check if the last word is "--summary" (which would have been captured as part of the prompt)
-                        if !remaining_parts.is_empty() {
-                            let last_idx = remaining_parts.len() - 1;
-                            if remaining_parts[last_idx] == "--summary" {
-                                remaining_parts.pop();
-                                show_summary = true;
-                            }
-                        }
+                        remaining_parts.extend_from_slice(&parts[1..]);
 
                         // If we have remaining parts after parsing flags, join them as the prompt
                         if !remaining_parts.is_empty() {
@@ -904,18 +888,9 @@ mod tests {
             };
         }
         let tests = &[
-            ("/compact", compact!(None, false)),
-            ("/compact --summary", compact!(None, true)),
+            ("/compact", compact!(None, true)),
             (
                 "/compact custom prompt",
-                compact!(Some("custom prompt".to_string()), false),
-            ),
-            (
-                "/compact --summary custom prompt",
-                compact!(Some("custom prompt".to_string()), true),
-            ),
-            (
-                "/compact custom prompt --summary",
                 compact!(Some("custom prompt".to_string()), true),
             ),
             ("/profile list", profile!(ProfileSubcommand::List)),

--- a/crates/q_chat/src/lib.rs
+++ b/crates/q_chat/src/lib.rs
@@ -109,7 +109,6 @@ that may eventually reach memory constraints.
 <cyan!>Usage</cyan!>
   <em>/compact</em>                   <black!>Summarize the conversation and clear history</black!>
   <em>/compact [prompt]</em>          <black!>Provide custom guidance for summarization</black!>
-  <em>/compact --summary</em>         <black!>Show the summary after compacting</black!>
 
 <cyan!>When to use</cyan!>
 • When you see the memory constraint warning message
@@ -237,7 +236,6 @@ const HELP_TEXT: &str = color_print::cstr! {"
 <em>/compact</em>      <black!>Summarize the conversation to free up context space</black!>
   <em>help</em>        <black!>Show help for the compact command</black!>
   <em>[prompt]</em>    <black!>Optional custom prompt to guide summarization</black!>
-  <em>--summary</em>   <black!>Display the summary after compacting</black!>
 <em>/tools</em>        <black!>View and manage tools and permissions</black!>
   <em>help</em>        <black!>Show an explanation for the trust command</black!>
   <em>trust</em>       <black!>Trust a specific tool or tools for the session</black!>
@@ -1158,15 +1156,6 @@ impl ChatContext {
                     style::Print(format!("• Custom prompt applied: {}\n", custom_prompt))
                 )?;
             }
-            execute!(
-                output,
-                style::Print(
-                    "• The assistant has access to all previous tool executions, code analysis, and discussion details\n"
-                ),
-                style::Print("• The assistant will reference specific information from the summary when relevant\n"),
-                style::Print("• Use '/compact --summary' to view summaries when compacting\n\n"),
-                style::SetForegroundColor(Color::Reset)
-            )?;
             animate_output(&mut self.output, &output)?;
 
             // Display the summary if the show_summary flag is set
@@ -1193,7 +1182,7 @@ impl ChatContext {
                     style::Print(&summary),
                     style::Print("\n\n"),
                     style::SetForegroundColor(Color::Cyan),
-                    style::Print("This summary is stored in memory and available to the assistant.\n"),
+                    style::Print("The conversation history has been replaced with this summary.\n"),
                     style::Print("It contains all important details from previous interactions.\n"),
                 )?;
                 animate_output(&mut self.output, &output)?;

--- a/crates/q_chat/src/prompt.rs
+++ b/crates/q_chat/src/prompt.rs
@@ -66,7 +66,6 @@ pub const COMMANDS: &[&str] = &[
     "/context clear --global",
     "/compact",
     "/compact help",
-    "/compact --summary",
     "/usage",
 ];
 


### PR DESCRIPTION
#1293 

<img width="758" alt="Screenshot 2025-04-22 at 12 07 12 PM" src="https://github.com/user-attachments/assets/e172d087-a1e6-416e-8cfa-8f16849476bb" />
