### PR TITLE
chore: bump version to 1.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty_terminal"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "bitflags 2.9.0",
  "camino",
@@ -283,7 +283,7 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "appkit-nsworkspace-bindings"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "bindgen 0.71.1",
  "objc",
@@ -2090,7 +2090,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "dbus"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "async_zip",
  "fig_os_shim",
@@ -2603,7 +2603,7 @@ dependencies = [
 
 [[package]]
 name = "fig-api-mock"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -2616,7 +2616,7 @@ dependencies = [
 
 [[package]]
 name = "fig_api_client"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "amzn-codewhisperer-client",
  "amzn-codewhisperer-streaming-client",
@@ -2652,7 +2652,7 @@ dependencies = [
 
 [[package]]
 name = "fig_auth"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "async-trait",
  "aws-credential-types",
@@ -2686,7 +2686,7 @@ dependencies = [
 
 [[package]]
 name = "fig_aws_common"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "aws-runtime",
  "aws-smithy-runtime",
@@ -2700,7 +2700,7 @@ dependencies = [
 
 [[package]]
 name = "fig_desktop"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -2792,7 +2792,7 @@ dependencies = [
 
 [[package]]
 name = "fig_desktop_api"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "anstream",
  "async-trait",
@@ -2828,7 +2828,7 @@ dependencies = [
 
 [[package]]
 name = "fig_diagnostic"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "cfg-if",
  "clap",
@@ -2848,7 +2848,7 @@ dependencies = [
 
 [[package]]
 name = "fig_input_method"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "apple-bundle",
  "fig_ipc",
@@ -2869,7 +2869,7 @@ dependencies = [
 
 [[package]]
 name = "fig_install"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "bitflags 2.9.0",
  "bytes",
@@ -2908,7 +2908,7 @@ dependencies = [
 
 [[package]]
 name = "fig_integrations"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "accessibility-sys",
  "async-trait",
@@ -2941,7 +2941,7 @@ dependencies = [
 
 [[package]]
 name = "fig_ipc"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2964,7 +2964,7 @@ dependencies = [
 
 [[package]]
 name = "fig_log"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "fig_util",
  "parking_lot",
@@ -2977,7 +2977,7 @@ dependencies = [
 
 [[package]]
 name = "fig_os_shim"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "cfg-if",
  "dirs",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "fig_proto"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "fig_remote_ipc"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3031,7 +3031,7 @@ dependencies = [
 
 [[package]]
 name = "fig_request"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -3056,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "fig_settings"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "fd-lock",
  "fig_test",
@@ -3077,7 +3077,7 @@ dependencies = [
 
 [[package]]
 name = "fig_telemetry"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "amzn-codewhisperer-client",
  "amzn-toolkit-telemetry",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "fig_telemetry_core"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "amzn-codewhisperer-client",
  "amzn-toolkit-telemetry",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "fig_test"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "fig_test_macro",
  "tokio",
@@ -3133,7 +3133,7 @@ dependencies = [
 
 [[package]]
 name = "fig_test_macro"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "fig_test_utils"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "bytes",
  "fig_os_shim",
@@ -3159,7 +3159,7 @@ dependencies = [
 
 [[package]]
 name = "fig_util"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "appkit-nsworkspace-bindings",
  "bstr",
@@ -3199,7 +3199,7 @@ dependencies = [
 
 [[package]]
 name = "figterm"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -3262,7 +3262,7 @@ dependencies = [
 
 [[package]]
 name = "figterm2"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4972,7 +4972,7 @@ dependencies = [
 
 [[package]]
 name = "macos-utils"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -6798,7 +6798,7 @@ dependencies = [
 
 [[package]]
 name = "q_cli"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "amzn-codewhisperer-client",
  "amzn-codewhisperer-streaming-client",
@@ -7978,7 +7978,7 @@ dependencies = [
 
 [[package]]
 name = "shell-color"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "bitflags 2.9.0",
  "fig_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ authors = [
 edition = "2021"
 homepage = "https://aws.amazon.com/q/"
 publish = false
-version = "1.7.3"
+version = "1.8.0"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]

--- a/feed.json
+++ b/feed.json
@@ -12,6 +12,58 @@
     },
     {
       "type": "release",
+      "date": "2025-04-22",
+      "version": "1.8.0",
+      "title": "Version 1.8.0",
+      "changes": [
+        {
+          "type": "added",
+          "description": "Fuzzy search for slash commands in `q chat` with `Ctrl + k` - [#1181](https://github.com/aws/amazon-q-developer-cli/pull/1181)"
+        },
+        {
+          "type": "added",
+          "description": "A new capability for dynamically adding context to messages in `q chat` with \"context hooks\" - [#1218](https://github.com/aws/amazon-q-developer-cli/pull/1218)"
+        },
+        {
+          "type": "added",
+          "description": "A new command `/usage` in `q chat` to display an estimate of the context window usage - [#1177](https://github.com/aws/amazon-q-developer-cli/pull/1177)"
+        },
+        {
+          "type": "added",
+          "description": "A new greeting UI with rotating tips in `q chat` - [#1262](https://github.com/aws/amazon-q-developer-cli/pull/1262)"
+        },
+        {
+          "type": "added",
+          "description": "An extra confirmation prompt before clearing the history in `q chat` with `/clear` - [#1180](https://github.com/aws/amazon-q-developer-cli/pull/1180)"
+        },
+        {
+          "type": "added",
+          "description": "Support for using a system proxy with the `HTTP_PROXY` environment variable - [#1199](https://github.com/aws/amazon-q-developer-cli/pull/1199)"
+        },
+        {
+          "type": "added",
+          "description": "The ability to reset a single tool's permissions in `q chat` with `/tools reset` - [#1102](https://github.com/aws/amazon-q-developer-cli/pull/1102)"
+        },
+        {
+          "type": "added",
+          "description": "Various UI improvements in `q chat`"
+        },
+        {
+          "type": "fixed",
+          "description": "Arguments for `EDITOR` not being correctly parsed by the `/editor` command in `q chat` - [#1209](https://github.com/aws/amazon-q-developer-cli/pull/1209)"
+        },
+        {
+          "type": "fixed",
+          "description": "The `/compact` command failing to compact history after the context window has been filled in `q chat` - [#1275](https://github.com/aws/amazon-q-developer-cli/pull/1275)"
+        },
+        {
+          "type": "fixed",
+          "description": "Various issues in `q chat`"
+        }
+      ]
+    },
+    {
+      "type": "release",
       "date": "2025-04-10",
       "version": "1.7.3",
       "title": "Version 1.7.3",


### PR DESCRIPTION
*Description of changes:*
- Bumping the version to `1.8.0` and adding entries to `feed.json`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
