### PR TITLE
fix: remove whitespace from user input message to prevent ISEs

### DIFF
--- a/crates/q_cli/src/cli/chat/message.rs
+++ b/crates/q_cli/src/cli/chat/message.rs
@@ -118,7 +118,9 @@ impl UserMessage {
     /// [FigConversationState::user_input_message].
     pub fn into_user_input_message(self) -> UserInputMessage {
         UserInputMessage {
-            content: format!("{} {}", self.additional_context, self.prompt().unwrap_or_default()),
+            content: format!("{} {}", self.additional_context, self.prompt().unwrap_or_default())
+                .trim()
+                .to_string(),
             user_input_message_context: Some(UserInputMessageContext {
                 shell_state: self.env_context.shell_state,
                 env_state: self.env_context.env_state,


### PR DESCRIPTION
*Description of changes:*
- Making sure the next message does not contain only whitespace, since that seems to cause ISE's

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
