### PR TITLE
chore: update chat imports to be relative, minor code refactoring

### DIFF
--- a/crates/q_cli/src/cli/chat/context.rs
+++ b/crates/q_cli/src/cli/chat/context.rs
@@ -758,8 +758,8 @@ fn validate_profile_name(name: &str) -> Result<()> {
 mod tests {
     use std::io::Stdout;
 
-    use super::*;
     use super::super::hooks::HookTrigger;
+    use super::*;
 
     // Helper function to create a test ContextManager with Context
     pub async fn create_test_context_manager() -> Result<ContextManager> {

--- a/crates/q_cli/src/cli/chat/context.rs
+++ b/crates/q_cli/src/cli/chat/context.rs
@@ -759,7 +759,7 @@ mod tests {
     use std::io::Stdout;
 
     use super::*;
-    use crate::cli::chat::hooks::HookTrigger;
+    use super::super::hooks::HookTrigger;
 
     // Helper function to create a test ContextManager with Context
     pub async fn create_test_context_manager() -> Result<ContextManager> {

--- a/crates/q_cli/src/cli/chat/conversation_state.rs
+++ b/crates/q_cli/src/cli/chat/conversation_state.rs
@@ -34,7 +34,10 @@ use super::consts::{
     MAX_CONVERSATION_STATE_HISTORY_LEN,
 };
 use super::context::ContextManager;
-use super::hooks::Hook;
+use super::hooks::{
+    Hook,
+    HookTrigger,
+};
 use super::message::{
     AssistantMessage,
     ToolUseResult,
@@ -49,12 +52,9 @@ use super::token_counter::{
     CharCounter,
 };
 use super::tools::{
+    InputSchema,
     QueuedTool,
     ToolSpec,
-};
-use super::hooks::HookTrigger;
-use super::tools::{
-    InputSchema,
     serde_value_to_document,
 };
 /// Tracks state related to an ongoing conversation.

--- a/crates/q_cli/src/cli/chat/conversation_state.rs
+++ b/crates/q_cli/src/cli/chat/conversation_state.rs
@@ -52,8 +52,8 @@ use super::tools::{
     QueuedTool,
     ToolSpec,
 };
-use crate::cli::chat::hooks::HookTrigger;
-use crate::cli::chat::tools::{
+use super::hooks::HookTrigger;
+use super::tools::{
     InputSchema,
     serde_value_to_document,
 };

--- a/crates/q_cli/src/cli/chat/input_source.rs
+++ b/crates/q_cli/src/cli/chat/input_source.rs
@@ -7,9 +7,9 @@ use rustyline::{
     KeyEvent,
 };
 
-use super::skim_integration::SkimCommandSelector;
 use super::context::ContextManager;
 use super::prompt::rl;
+use super::skim_integration::SkimCommandSelector;
 
 #[derive(Debug)]
 pub struct InputSource(inner::Inner);

--- a/crates/q_cli/src/cli/chat/input_source.rs
+++ b/crates/q_cli/src/cli/chat/input_source.rs
@@ -8,8 +8,8 @@ use rustyline::{
 };
 
 use super::skim_integration::SkimCommandSelector;
-use crate::cli::chat::context::ContextManager;
-use crate::cli::chat::prompt::rl;
+use super::context::ContextManager;
+use super::prompt::rl;
 
 #[derive(Debug)]
 pub struct InputSource(inner::Inner);
@@ -18,7 +18,7 @@ mod inner {
     use rustyline::Editor;
     use rustyline::history::FileHistory;
 
-    use crate::cli::chat::prompt::ChatHelper;
+    use super::super::prompt::ChatHelper;
 
     #[derive(Debug)]
     pub enum Inner {

--- a/crates/q_cli/src/cli/chat/message.rs
+++ b/crates/q_cli/src/cli/chat/message.rs
@@ -20,14 +20,12 @@ use tracing::error;
 
 use super::consts::MAX_CURRENT_WORKING_DIRECTORY_LEN;
 use super::tools::{
+    InvokeOutput,
     OutputKind,
     document_to_serde_value,
-};
-use super::util::truncate_safe;
-use crate::cli::chat::tools::{
-    InvokeOutput,
     serde_value_to_document,
 };
+use super::util::truncate_safe;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UserMessage {

--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -119,6 +119,10 @@ that may eventually reach memory constraints.
     )
 }
 use input_source::InputSource;
+use parse::{
+    ParseState,
+    interpret_markdown,
+};
 use parser::{
     RecvErrorKind,
     ResponseParser,
@@ -151,17 +155,14 @@ use tracing::{
     trace,
     warn,
 };
-use util::animate_output;
+use util::{
+    animate_output,
+    play_notification_bell,
+    region_check,
+};
 use uuid::Uuid;
 use winnow::Partial;
 use winnow::stream::Offset;
-
-use crate::cli::chat::parse::{
-    ParseState,
-    interpret_markdown,
-};
-use crate::util::region_check;
-use crate::util::spinner::play_notification_bell;
 
 const WELCOME_TEXT: &str = color_print::cstr! {"
 

--- a/crates/q_cli/src/cli/chat/tools/gh_issue.rs
+++ b/crates/q_cli/src/cli/chat/tools/gh_issue.rs
@@ -21,7 +21,7 @@ use super::{
     InvokeOutput,
     ToolPermission,
 };
-use crate::cli::chat::context::ContextManager;
+use super::super::context::ContextManager;
 use crate::cli::issue::IssueCreator;
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/q_cli/src/cli/chat/tools/gh_issue.rs
+++ b/crates/q_cli/src/cli/chat/tools/gh_issue.rs
@@ -17,11 +17,11 @@ use eyre::{
 use fig_os_shim::Context;
 use serde::Deserialize;
 
+use super::super::context::ContextManager;
 use super::{
     InvokeOutput,
     ToolPermission,
 };
-use super::super::context::ContextManager;
 use crate::cli::issue::IssueCreator;
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/q_cli/src/cli/chat/util/mod.rs
+++ b/crates/q_cli/src/cli/chat/util/mod.rs
@@ -1,7 +1,23 @@
 use std::io::Write;
 use std::time::Duration;
 
+use fig_util::system_info::in_cloudshell;
+
 use super::ChatError;
+
+const GOV_REGIONS: &[&str] = &["us-gov-east-1", "us-gov-west-1"];
+
+pub fn region_check(capability: &'static str) -> eyre::Result<()> {
+    let Ok(region) = std::env::var("AWS_REGION") else {
+        return Ok(());
+    };
+
+    if in_cloudshell() && GOV_REGIONS.contains(&region.as_str()) {
+        eyre::bail!("AWS GovCloud ({region}) is not supported for {capability}.");
+    }
+
+    Ok(())
+}
 
 pub fn truncate_safe(s: &str, max_bytes: usize) -> &str {
     if s.len() <= max_bytes {
@@ -27,6 +43,57 @@ pub fn animate_output(output: &mut impl Write, bytes: &[u8]) -> Result<(), ChatE
         std::thread::sleep(Duration::from_millis(16));
     }
     Ok(())
+}
+
+/// Play the terminal bell notification sound
+pub fn play_notification_bell(requires_confirmation: bool) {
+    // Don't play bell for tools that don't require confirmation
+    if !requires_confirmation {
+        return;
+    }
+
+    // Check if we should play the bell based on terminal type
+    if should_play_bell() {
+        print!("\x07"); // ASCII bell character
+        std::io::stdout().flush().unwrap();
+    }
+}
+
+/// Determine if we should play the bell based on terminal type
+fn should_play_bell() -> bool {
+    // Get the TERM environment variable
+    if let Ok(term) = std::env::var("TERM") {
+        // List of terminals known to handle bell character well
+        let bell_compatible_terms = [
+            "xterm",
+            "xterm-256color",
+            "screen",
+            "screen-256color",
+            "tmux",
+            "tmux-256color",
+            "rxvt",
+            "rxvt-unicode",
+            "linux",
+            "konsole",
+            "gnome",
+            "gnome-256color",
+            "alacritty",
+            "iterm2",
+        ];
+
+        // Check if the current terminal is in the compatible list
+        for compatible_term in bell_compatible_terms.iter() {
+            if term.starts_with(compatible_term) {
+                return true;
+            }
+        }
+
+        // For other terminals, don't play the bell
+        return false;
+    }
+
+    // If TERM is not set, default to not playing the bell
+    false
 }
 
 #[cfg(test)]

--- a/crates/q_cli/src/util/spinner.rs
+++ b/crates/q_cli/src/util/spinner.rs
@@ -7,12 +7,9 @@ use std::sync::mpsc::{
     TryRecvError,
     channel,
 };
+use std::thread;
 use std::thread::JoinHandle;
 use std::time::Duration;
-use std::{
-    env,
-    thread,
-};
 
 use anstream::{
     print,
@@ -50,57 +47,6 @@ impl Drop for Spinner {
 pub enum SpinnerComponent {
     Text(String),
     Spinner,
-}
-
-/// Play the terminal bell notification sound
-pub fn play_notification_bell(requires_confirmation: bool) {
-    // Don't play bell for tools that don't require confirmation
-    if !requires_confirmation {
-        return;
-    }
-
-    // Check if we should play the bell based on terminal type
-    if should_play_bell() {
-        print!("\x07"); // ASCII bell character
-        stdout().flush().unwrap();
-    }
-}
-
-/// Determine if we should play the bell based on terminal type
-fn should_play_bell() -> bool {
-    // Get the TERM environment variable
-    if let Ok(term) = env::var("TERM") {
-        // List of terminals known to handle bell character well
-        let bell_compatible_terms = [
-            "xterm",
-            "xterm-256color",
-            "screen",
-            "screen-256color",
-            "tmux",
-            "tmux-256color",
-            "rxvt",
-            "rxvt-unicode",
-            "linux",
-            "konsole",
-            "gnome",
-            "gnome-256color",
-            "alacritty",
-            "iterm2",
-        ];
-
-        // Check if the current terminal is in the compatible list
-        for compatible_term in bell_compatible_terms.iter() {
-            if term.starts_with(compatible_term) {
-                return true;
-            }
-        }
-
-        // For other terminals, don't play the bell
-        return false;
-    }
-
-    // If TERM is not set, default to not playing the bell
-    false
 }
 
 impl Spinner {


### PR DESCRIPTION
*Description of changes:*
Doing some minor prep to make moving all of the chat code to a separate crate a bit easier.
- Updating the `q chat` imports to be relative
- Copy/pasting the current region check code, since it's only otherwise used in `translate`
- Moving the terminal notification code to a util mod in chat

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
