### PR TITLE
fix: add check for tool use timeouts

### DIFF
--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -2569,6 +2569,7 @@ impl ChatContext {
                             tool_use_id,
                             name,
                             message,
+                            time_elapsed,
                         } => {
                             error!(
                                 recv_error.request_id,
@@ -2582,7 +2583,10 @@ impl ChatContext {
                                     cursor::MoveToColumn(0),
                                     style::SetForegroundColor(Color::Yellow),
                                     style::SetAttribute(Attribute::Bold),
-                                    style::Print("Warning: received an unexpected error from the model\n\n"),
+                                    style::Print(format!(
+                                        "Warning: received an unexpected error from the model after {:.2}s\n\n",
+                                        time_elapsed.as_secs_f64()
+                                    )),
                                     style::SetAttribute(Attribute::Reset),
                                 )?;
                                 self.spinner = Some(Spinner::new(

--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -2575,10 +2575,19 @@ impl ChatContext {
                                 tool_use_id, name, "The response stream ended before the entire tool use was received"
                             );
                             if self.interactive {
-                                execute!(self.output, cursor::Hide)?;
+                                drop(self.spinner.take());
+                                queue!(
+                                    self.output,
+                                    terminal::Clear(terminal::ClearType::CurrentLine),
+                                    cursor::MoveToColumn(0),
+                                    style::SetForegroundColor(Color::Yellow),
+                                    style::SetAttribute(Attribute::Bold),
+                                    style::Print("Warning: received an unexpected error from the model\n\n"),
+                                    style::SetAttribute(Attribute::Reset),
+                                )?;
                                 self.spinner = Some(Spinner::new(
                                     Spinners::Dots,
-                                    "The generated tool use was too large, trying to divide up the work...".to_string(),
+                                    "Trying to divide up the work...".to_string(),
                                 ));
                             }
 

--- a/crates/q_cli/src/cli/chat/parser.rs
+++ b/crates/q_cli/src/cli/chat/parser.rs
@@ -197,11 +197,9 @@ impl ResponseParser {
                 // If we failed deserializing after waiting for a long time, then this is most
                 // likely bedrock responding with a stop event for some reason without actually
                 // including the tool contents. Essentially, the tool was too large.
-                //
-                // Setting the timeout at 90 secs since it usually happens over 2 mins, but
-                // providing some buffer.
+                // Timeouts have been seen as short as ~1 minute, so setting the time to 30.
                 let elapsed = start.elapsed();
-                if self.peek().await?.is_none() && elapsed > std::time::Duration::from_secs(90) {
+                if self.peek().await?.is_none() && elapsed > std::time::Duration::from_secs(30) {
                     error!(
                         "Received an unexpected end of stream after spending ~{}s receiving tool events",
                         elapsed.as_secs_f64()


### PR DESCRIPTION
*Description of changes:*
- Updating the tool use stream timeout to handle cases where we do receive a stop event, but still fail serialization after waiting for a long time

<img width="880" alt="Screenshot 2025-04-23 at 2 57 18 PM" src="https://github.com/user-attachments/assets/99984855-bf9a-4080-a2f9-fa4f2db0393e" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
