### PR TITLE
fix: add request id to errored json message

### DIFF
--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -2584,11 +2584,17 @@ impl ChatContext {
                                     style::SetForegroundColor(Color::Yellow),
                                     style::SetAttribute(Attribute::Bold),
                                     style::Print(format!(
-                                        "Warning: received an unexpected error from the model after {:.2}s\n\n",
+                                        "Warning: received an unexpected error from the model after {:.2}s",
                                         time_elapsed.as_secs_f64()
                                     )),
-                                    style::SetAttribute(Attribute::Reset),
                                 )?;
+                                if let Some(request_id) = recv_error.request_id {
+                                    queue!(
+                                        self.output,
+                                        style::Print(format!("\n         request_id: {}", request_id))
+                                    )?;
+                                }
+                                execute!(self.output, style::Print("\n\n"), style::SetAttribute(Attribute::Reset))?;
                                 self.spinner = Some(Spinner::new(
                                     Spinners::Dots,
                                     "Trying to divide up the work...".to_string(),

--- a/crates/q_cli/src/cli/chat/mod.rs
+++ b/crates/q_cli/src/cli/chat/mod.rs
@@ -2863,7 +2863,7 @@ impl ChatContext {
             .tool
             .queue_description(&self.ctx, &mut self.output)
             .await
-            .map_err(|e| ChatError::Custom(format!("failed to print tool: {}", e).into()))?;
+            .map_err(|e| ChatError::Custom(format!("failed to print tool, `{}`: {}", tool_use.name, e).into()))?;
 
         Ok(())
     }


### PR DESCRIPTION
*Description of changes:*
- Adding the request id to the error message presented to the user in the case invalid JSON is returned by the model.

<img width="880" alt="Screenshot 2025-04-23 at 4 28 56 PM" src="https://github.com/user-attachments/assets/e1a44510-3903-4bee-be15-38dc50401c3b" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
