### PR TITLE
feat(tools): Add think tool with option to disable it.

### DIFF
--- a/crates/q_chat/src/lib.rs
+++ b/crates/q_chat/src/lib.rs
@@ -3463,6 +3463,18 @@ fn create_stream(model_responses: serde_json::Value) -> StreamingClient {
     StreamingClient::mock(mock)
 }
 
+/// Returns all tools supported by Q chat.
+pub fn load_tools() -> Result<HashMap<String, ToolSpec>> {
+    let mut tools: HashMap<String, ToolSpec> = serde_json::from_str(include_str!("tools/tool_index.json"))?;
+
+    // Only include the think tool if the feature is enabled
+    if !tools::think::Think::should_include_in_tools() {
+        tools.remove("think");
+    }
+
+    Ok(tools)
+}
+
 #[cfg(test)]
 mod tests {
     use bstr::ByteSlice;
@@ -3724,7 +3736,6 @@ mod tests {
                 "Done",
             ],
         ]));
-
         let tool_manager = ToolManager::default();
         let tool_config = serde_json::from_str::<HashMap<String, ToolSpec>>(include_str!("tools/tool_index.json"))
             .expect("Tools failed to load");

--- a/crates/q_chat/src/lib.rs
+++ b/crates/q_chat/src/lib.rs
@@ -3463,18 +3463,6 @@ fn create_stream(model_responses: serde_json::Value) -> StreamingClient {
     StreamingClient::mock(mock)
 }
 
-/// Returns all tools supported by Q chat.
-pub fn load_tools() -> Result<HashMap<String, ToolSpec>> {
-    let mut tools: HashMap<String, ToolSpec> = serde_json::from_str(include_str!("tools/tool_index.json"))?;
-
-    // Only include the think tool if the feature is enabled
-    if !tools::think::Think::should_include_in_tools() {
-        tools.remove("think");
-    }
-
-    Ok(tools)
-}
-
 #[cfg(test)]
 mod tests {
     use bstr::ByteSlice;

--- a/crates/q_chat/src/tool_manager.rs
+++ b/crates/q_chat/src/tool_manager.rs
@@ -496,11 +496,12 @@ impl ToolManager {
         let tx = self.loading_status_sender.take();
         let display_task = self.loading_display_task.take();
         let tool_specs = {
-            let mut tool_specs = serde_json::from_str::<HashMap<String, ToolSpec>>(include_str!("tools/tool_index.json"))?;
+            let mut tool_specs =
+                serde_json::from_str::<HashMap<String, ToolSpec>>(include_str!("tools/tool_index.json"))?;
             if !crate::tools::think::Think::is_enabled() {
                 tool_specs.remove("q_think_tool");
             }
-            
+
             Arc::new(Mutex::new(tool_specs))
         };
         let conversation_id = self.conversation_id.clone();
@@ -675,7 +676,9 @@ impl ToolManager {
             "execute_bash" => Tool::ExecuteBash(serde_json::from_value::<ExecuteBash>(value.args).map_err(map_err)?),
             "use_aws" => Tool::UseAws(serde_json::from_value::<UseAws>(value.args).map_err(map_err)?),
             "report_issue" => Tool::GhIssue(serde_json::from_value::<GhIssue>(value.args).map_err(map_err)?),
-            "q_think_tool" => Tool::Think(serde_json::from_value::<crate::tools::think::Think>(value.args).map_err(map_err)?),
+            "q_think_tool" => {
+                Tool::Think(serde_json::from_value::<crate::tools::think::Think>(value.args).map_err(map_err)?)
+            },
             // Note that this name is namespaced with server_name{DELIMITER}tool_name
             name => {
                 let name = self.tn_map.get(name).map_or(name, String::as_str);

--- a/crates/q_chat/src/tool_manager.rs
+++ b/crates/q_chat/src/tool_manager.rs
@@ -496,7 +496,11 @@ impl ToolManager {
         let tx = self.loading_status_sender.take();
         let display_task = self.loading_display_task.take();
         let tool_specs = {
-            let tool_specs = serde_json::from_str::<HashMap<String, ToolSpec>>(include_str!("tools/tool_index.json"))?;
+            let mut tool_specs = serde_json::from_str::<HashMap<String, ToolSpec>>(include_str!("tools/tool_index.json"))?;
+            if !crate::tools::think::Think::is_enabled() {
+                tool_specs.remove("q_think_tool");
+            }
+            
             Arc::new(Mutex::new(tool_specs))
         };
         let conversation_id = self.conversation_id.clone();
@@ -671,6 +675,7 @@ impl ToolManager {
             "execute_bash" => Tool::ExecuteBash(serde_json::from_value::<ExecuteBash>(value.args).map_err(map_err)?),
             "use_aws" => Tool::UseAws(serde_json::from_value::<UseAws>(value.args).map_err(map_err)?),
             "report_issue" => Tool::GhIssue(serde_json::from_value::<GhIssue>(value.args).map_err(map_err)?),
+            "q_think_tool" => Tool::Think(serde_json::from_value::<crate::tools::think::Think>(value.args).map_err(map_err)?),
             // Note that this name is namespaced with server_name{DELIMITER}tool_name
             name => {
                 let name = self.tn_map.get(name).map_or(name, String::as_str);

--- a/crates/q_chat/src/tools/mod.rs
+++ b/crates/q_chat/src/tools/mod.rs
@@ -55,7 +55,7 @@ impl Tool {
             Tool::UseAws(_) => "use_aws",
             Tool::Custom(custom_tool) => &custom_tool.name,
             Tool::GhIssue(_) => "gh_issue",
-            Tool::Think(_) => "model_think_tool",
+            Tool::Think(_) => "q_think_tool",
         }
         .to_owned()
     }
@@ -69,7 +69,7 @@ impl Tool {
             Tool::UseAws(use_aws) => use_aws.requires_acceptance(),
             Tool::Custom(_) => true,
             Tool::GhIssue(_) => false,
-            Tool::Think(_) => false,
+            Tool::Think(_) => true,
         }
     }
 
@@ -182,6 +182,7 @@ impl ToolPermissions {
             "execute_bash" => "trust read-only commands".dark_grey(),
             "use_aws" => "trust read-only commands".dark_grey(),
             "report_issue" => "trusted".dark_green().bold(),
+            "q_think_tool" => "trusted".dark_green().bold(),
             _ => "not trusted".dark_grey(),
         };
 

--- a/crates/q_chat/src/tools/mod.rs
+++ b/crates/q_chat/src/tools/mod.rs
@@ -55,7 +55,7 @@ impl Tool {
             Tool::UseAws(_) => "use_aws",
             Tool::Custom(custom_tool) => &custom_tool.name,
             Tool::GhIssue(_) => "gh_issue",
-            Tool::Think(_) => "q_think_tool",
+            Tool::Think(_) => "q_think_tool (beta)",
         }
         .to_owned()
     }
@@ -182,7 +182,7 @@ impl ToolPermissions {
             "execute_bash" => "trust read-only commands".dark_grey(),
             "use_aws" => "trust read-only commands".dark_grey(),
             "report_issue" => "trusted".dark_green().bold(),
-            "q_think_tool" => "trusted".dark_green().bold(),
+            "q_think_tool" => "trusted (beta)".dark_green().bold(),
             _ => "not trusted".dark_grey(),
         };
 

--- a/crates/q_chat/src/tools/mod.rs
+++ b/crates/q_chat/src/tools/mod.rs
@@ -3,8 +3,8 @@ pub mod execute_bash;
 pub mod fs_read;
 pub mod fs_write;
 pub mod gh_issue;
+pub mod think;
 pub mod use_aws;
-
 use std::collections::HashMap;
 use std::io::Write;
 use std::path::{
@@ -28,6 +28,7 @@ use serde::{
     Deserialize,
     Serialize,
 };
+use think::Think;
 use use_aws::UseAws;
 
 use super::consts::MAX_TOOL_RESPONSE_SIZE;
@@ -41,6 +42,7 @@ pub enum Tool {
     UseAws(UseAws),
     Custom(CustomTool),
     GhIssue(GhIssue),
+    Think(Think),
 }
 
 impl Tool {
@@ -53,6 +55,7 @@ impl Tool {
             Tool::UseAws(_) => "use_aws",
             Tool::Custom(custom_tool) => &custom_tool.name,
             Tool::GhIssue(_) => "gh_issue",
+            Tool::Think(_) => "model_think_tool",
         }
         .to_owned()
     }
@@ -66,6 +69,7 @@ impl Tool {
             Tool::UseAws(use_aws) => use_aws.requires_acceptance(),
             Tool::Custom(_) => true,
             Tool::GhIssue(_) => false,
+            Tool::Think(_) => false,
         }
     }
 
@@ -78,6 +82,7 @@ impl Tool {
             Tool::UseAws(use_aws) => use_aws.invoke(context, updates).await,
             Tool::Custom(custom_tool) => custom_tool.invoke(context, updates).await,
             Tool::GhIssue(gh_issue) => gh_issue.invoke(updates).await,
+            Tool::Think(think) => think.invoke(updates).await,
         }
     }
 
@@ -90,6 +95,7 @@ impl Tool {
             Tool::UseAws(use_aws) => use_aws.queue_description(updates),
             Tool::Custom(custom_tool) => custom_tool.queue_description(updates),
             Tool::GhIssue(gh_issue) => gh_issue.queue_description(updates),
+            Tool::Think(think) => Think::queue_description(think, updates),
         }
     }
 
@@ -102,6 +108,7 @@ impl Tool {
             Tool::UseAws(use_aws) => use_aws.validate(ctx).await,
             Tool::Custom(custom_tool) => custom_tool.validate(ctx).await,
             Tool::GhIssue(gh_issue) => gh_issue.validate(ctx).await,
+            Tool::Think(think) => think.validate(ctx).await,
         }
     }
 }

--- a/crates/q_chat/src/tools/think.rs
+++ b/crates/q_chat/src/tools/think.rs
@@ -1,0 +1,86 @@
+use std::io::Write;
+
+use crossterm::queue;
+use crossterm::style::{
+    self,
+    Color,
+};
+use eyre::Result;
+use fig_settings::settings;
+use serde::Deserialize;
+
+use super::{
+    InvokeOutput,
+    OutputKind,
+};
+
+/// The Think tool allows the model to reason through complex problems during response generation.
+/// It provides a dedicated space for the model to process information from tool call results,
+/// navigate complex decision trees, and improve the quality of responses in multi-step scenarios.
+///
+/// This is a beta feature that must be enabled via settings:
+/// `q settings enable_thinking true`
+#[derive(Debug, Clone, Deserialize)]
+pub struct Think {
+    /// The thought content that the model wants to process
+    pub thought: String,
+}
+
+impl Think {
+    /// Checks if the thinking feature is enabled in settings
+    fn is_enabled() -> bool {
+        // Default to enabled if setting doesn't exist or can't be read
+        settings::get_value("chat.enableThinking")
+            .map(|val| val.and_then(|v| v.as_bool()).unwrap_or(true))
+            .unwrap_or(true)
+    }
+
+    /// Checks if the think tool should be included in the tool list
+    /// This allows us to completely exclude the tool when the feature is disabled
+    pub fn should_include_in_tools() -> bool {
+        Self::is_enabled()
+    }
+
+    /// Queues up a description of the think tool for the user
+    pub fn queue_description(think: &Think, updates: &mut impl Write) -> Result<()> {
+        // Only show a description if the feature is enabled and there's actual thought content
+        if Self::is_enabled() && !think.thought.trim().is_empty() {
+            // Show a preview of the thought that will be displayed
+            queue!(
+                updates,
+                style::SetForegroundColor(Color::Blue),
+                style::Print("I'll share my reasoning process: "),
+                style::SetForegroundColor(Color::Reset),
+                style::Print(&think.thought),
+                style::Print("\n")
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Invokes the think tool. This doesn't actually perform any system operations,
+    /// it's purely for the model's internal reasoning process.
+    pub async fn invoke(&self, _updates: &mut impl Write) -> Result<InvokeOutput> {
+        // Only process non-empty thoughts if the feature is enabled
+        if Self::is_enabled() && !self.thought.trim().is_empty() {
+            // We've already shown the thought in queue_description
+            // Just return an empty output to avoid duplication
+            return Ok(InvokeOutput {
+                output: OutputKind::Text(String::new()),
+            });
+        }
+
+        // If disabled or empty thought, return empty output
+        Ok(InvokeOutput {
+            output: OutputKind::Text(String::new()),
+        })
+    }
+
+    /// Validates the thought - accepts empty thoughts
+    /// Also checks if the thinking feature is enabled in settings
+    pub async fn validate(&mut self, _ctx: &fig_os_shim::Context) -> Result<()> {
+        // We accept empty thoughts - they'll just be ignored
+        // This makes the tool more robust and prevents errors from blocking the model
+        Ok(())
+    }
+}

--- a/crates/q_chat/src/tools/think.rs
+++ b/crates/q_chat/src/tools/think.rs
@@ -28,7 +28,7 @@ pub struct Think {
 
 impl Think {
     /// Checks if the thinking feature is enabled in settings
-    pub fn is_think_tool_enabled() -> bool {
+    pub fn is_enabled() -> bool {
         // Default to enabled if setting doesn't exist or can't be read
         settings::get_bool_or("chat.enableThinking", true)
     }

--- a/crates/q_chat/src/tools/tool_index.json
+++ b/crates/q_chat/src/tools/tool_index.json
@@ -173,8 +173,8 @@
       "required": ["title"]
     }
   },
-  "think":{
-    "name": "think",
+  "q_think_tool":{
+    "name": "q_think_tool",
     "description": "The Think Tool is an internal reasoning mechanism enabling the model to systematically approach complex tasks by logically breaking them down before responding or acting; use it specifically for multi-step problems requiring step-by-step dependencies, reasoning through multiple constraints, synthesizing results from previous tool calls, planning intricate sequences of actions, troubleshooting complex errors, or making decisions involving multiple trade-offs. Avoid using it for straightforward tasks, basic information retrieval, summaries, always clearly define the reasoning challenge, structure thoughts explicitly, consider multiple perspectives, and summarize key insights before important decisions or complex tool interactions.",
     "input_schema": {
       "type": "object",

--- a/crates/q_chat/src/tools/tool_index.json
+++ b/crates/q_chat/src/tools/tool_index.json
@@ -172,5 +172,19 @@
       },
       "required": ["title"]
     }
+  },
+  "think":{
+    "name": "think",
+    "description": "The Think Tool is an internal reasoning mechanism enabling the model to systematically approach complex tasks by logically breaking them down before responding or acting; use it specifically for multi-step problems requiring step-by-step dependencies, reasoning through multiple constraints, synthesizing results from previous tool calls, planning intricate sequences of actions, troubleshooting complex errors, or making decisions involving multiple trade-offs. Avoid using it for straightforward tasks, basic information retrieval, summaries, always clearly define the reasoning challenge, structure thoughts explicitly, consider multiple perspectives, and summarize key insights before important decisions or complex tool interactions.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "thought": {
+          "type": "string",
+          "description": "A reflective note or intermediate reasoning step."
+        }
+      },
+      "required": ["thought"]
+    }
   }
 }

--- a/crates/q_cli/src/cli/settings.rs
+++ b/crates/q_cli/src/cli/settings.rs
@@ -106,6 +106,7 @@ impl SettingsArgs {
 
                 Ok(ExitCode::SUCCESS)
             },
+
             None => match &self.key {
                 Some(key) => match (&self.value, self.delete) {
                     (None, false) => match fig_settings::settings::get_value(key)? {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

## Testing

`With tool enabled` - `q settings chat.enableThinking true`

<img width="1119" alt="Screenshot 2025-05-01 at 9 33 34 PM" src="https://github.com/user-attachments/assets/685e0747-e7e7-4e36-817a-fcc5a734829d" />




`with tool disabled` - `q settings chat.enableThinking false`

<img width="607" alt="Screenshot 2025-05-01 at 4 05 34 PM" src="https://github.com/user-attachments/assets/658f52ec-4651-4388-a45d-2b381835f157" />

```
Trusted tools can be run without confirmation

* Default settings

> use think tool

I don't have a "think tool" available in my current toolset. The tools I can use include:

• fs_write: For creating and editing files
• use_aws: For making AWS CLI API calls
• execute_bash: For executing bash commands
• fs_read: For reading files and directories
• report_issue: For reporting issues with the chat

Is there something specific you'd like me to help you with using these available tools? I can help with file operations, AWS CLI commands, bash execution, or other tasks related to the Amazon Q CLI project you're working on.

```


Add Think Tool with Configurable Enablement

## Description
This PR introduces a new "Think" tool that enhances Amazon Q's reasoning capabilities during chat interactions. The Think tool provides a dedicated space for the model to process information, navigate 
complex decision trees, and improve response quality in multi-step scenarios.

## Key Features
• Added a new think.rs module implementing the Think tool functionality
• Integrated the tool into the existing tools framework
• Made the feature configurable via settings (q settings enable_thinking [true|false])
• Added conditional tool registration based on the feature flag
• Implemented blue-colored visual feedback when the model shares its reasoning process

## Implementation Details
• The Think tool allows the model to explicitly reason through complex problems during response generation
• When enabled, the tool displays the model's thought process in blue text
• The feature is enabled by default but can be disabled via settings
• Empty thoughts are accepted but ignored to maintain robustness
• The tool is completely excluded from the available tools list when disabled

## Technical Changes
• Added new file: crates/q_cli/src/cli/chat/tools/think.rs (86 lines)
• Modified tool registration in load_tools() to conditionally include the Think tool
• Updated tool index JSON to include the Think tool definition
• Added tool handling in the Tool enum and related functions
• Implemented validation, invocation, and description methods for the tool

## Usage
Users can control this feature with:
q settings enable_thinking true   # Enable the thinking feature (default)
q settings enable_thinking false  # Disable the thinking feature


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
