### PR TITLE
feat: QCHAT_PROCESS_ID and pre-push hook.

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,4 @@
-#!/bin/bash
-. "$(dirname "$0")/_/husky.sh"
+
 
 # Check if Amazon Q chat is active
 if [ -n "$QCHAT_PROCESS_ID" ]; then

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,12 @@
+#!/bin/bash
+. "$(dirname "$0")/_/husky.sh"
+
+# Check if Amazon Q chat is active
+if [ -n "$QCHAT_PROCESS_ID" ]; then
+  echo "ERROR: Git push blocked while Amazon Q chat is active (QCHAT_PROCESS_ID=$QCHAT_PROCESS_ID)"
+  echo "Please exit Amazon Q chat with '/quit' before pushing changes."
+  exit 1
+fi
+
+# Continue with push if QCHAT_PROCESS_ID is not set
+exit 0

--- a/crates/q_chat/src/consts.rs
+++ b/crates/q_chat/src/consts.rs
@@ -17,3 +17,5 @@ pub const MAX_USER_MESSAGE_SIZE: usize = 600_000;
 pub const CONTEXT_WINDOW_SIZE: usize = 200_000;
 
 pub const MAX_CHARS: usize = TokenCounter::token_to_chars(CONTEXT_WINDOW_SIZE); // Character-based warning threshold
+
+pub const QCHAT_PROCESS_ID: &str = "QCHAT_PROCESS_ID";

--- a/crates/q_chat/src/lib.rs
+++ b/crates/q_chat/src/lib.rs
@@ -40,7 +40,7 @@ use command::{
     Command,
     ToolsSubcommand,
 };
-use consts::CONTEXT_WINDOW_SIZE;
+use consts::{CONTEXT_WINDOW_SIZE, QCHAT_PROCESS_ID};
 use context::ContextManager;
 use conversation_state::{
     ConversationState,
@@ -332,6 +332,11 @@ pub async fn chat(
             },
         }
     }
+
+    let process_info = ctx.process_info();
+    let current_pid = process_info.current_pid().to_string();
+
+    unsafe { ctx.env().set_var(QCHAT_PROCESS_ID, current_pid) };
 
     let tool_config = load_tools()?;
     let mut tool_permissions = ToolPermissions::new(tool_config.len());

--- a/docs/samples/git-pre-push-hook/git-hook-installation.md
+++ b/docs/samples/git-pre-push-hook/git-hook-installation.md
@@ -1,0 +1,96 @@
+# Amazon Q Git Hook Installation
+
+This document provides instructions for installing a sample git hook that prevents accidental `git push` operations while using Amazon Q chat.
+
+Note - Git hooks do not chain.  If you need more than one hook installed, you will require other tools to link more than one into a single hook.  Follow the install instructions for those other tools instead.
+
+## What This Hook Does
+
+The `pre-push` hook checks if the `QCHAT_PROCESS_ID` environment variable is set (which indicates an active Amazon Q chat session). If the variable is set, the hook blocks the push operation and displays an error message.
+
+## Installation Instructions
+
+1. Copy the hook file to your git hooks directory:
+
+```bash
+# Navigate to your git repository
+cd /path/to/your/repo
+
+# Create hooks directory if it doesn't exist
+mkdir -p .git/hooks
+
+# Copy the hook file
+cp /path/to/pre-push-hook .git/hooks/pre-push
+
+# Make the hook executable
+chmod +x .git/hooks/pre-push
+```
+
+2. Verify the installation:
+
+```bash
+ls -la .git/hooks/pre-push
+```
+
+## Testing the Hook
+
+To test if the hook is working correctly:
+
+1. Start an Amazon Q chat session:
+```bash
+q chat
+```
+
+2. From within q chat, as it to push to a git repository:
+```bash
+> git push this repo
+```
+
+You should see an error message indicating that the push is blocked while Amazon Q chat is active.
+
+## Global Installation
+
+To install this hook for all repositories:
+
+1. Configure git to use a global hooks directory:
+
+```bash
+# Create a global hooks directory
+mkdir -p ~/.git-hooks
+
+# Configure git to use this directory
+git config --global core.hooksPath ~/.git-hooks
+```
+
+2. Install the pre-push hook in the global directory:
+
+```bash
+cp /path/to/pre-push-hook ~/.git-hooks/pre-push
+chmod +x ~/.git-hooks/pre-push
+```
+
+## Uninstalling the Hook
+
+To remove the hook:
+
+```bash
+# Delete the hook file
+rm .git/hooks/pre-push
+```
+
+To remove a globally installed hook:
+
+```bash
+# Delete the hook file
+rm ~/.git-hooks/pre-push
+```
+
+
+## Troubleshooting
+
+If the hook isn't working:
+
+1. Ensure the hook file is executable (`chmod +x .git/hooks/pre-push`)
+2. Verify the hook path is correct (check `git config core.hooksPath`)
+3. Make sure the hook doesn't have Windows line endings if you're on Unix/Linux
+4. Check if you have other git configurations that might override hooks

--- a/docs/samples/git-pre-push-hook/pre-push-hook
+++ b/docs/samples/git-pre-push-hook/pre-push-hook
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Git hook is a sample, designed to show how you can prevent pushing 
+# when QCHAT_PROCESS_ID is set
+# This prevents accidental pushes while using Amazon Q chat
+
+if [ -n "$QCHAT_PROCESS_ID" ]; then
+  echo "ERROR: Git push blocked while Amazon Q chat is active (QCHAT_PROCESS_ID=$QCHAT_PROCESS_ID)"
+  echo "Please exit Amazon Q chat with '/quit' before pushing changes."
+  exit 1
+fi
+
+# Continue with push if QCHAT_PROCESS_ID is not set
+exit 0


### PR DESCRIPTION
Q Chat now sets an environment variable with its process id, which may be used by downstream processes (MCP Servers, Shell Commands, Git hooks), to specify behaviour based on being run inside Q Chat.

A sample git pre-push hook is included in docs/samples/ to show how it could work, and the husky hooks in the project have been updated to include the push prevention.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
