### PR TITLE
feat(cli): infer pro license when identity provider and region are sp…

### DIFF
--- a/crates/q_cli/src/cli/user.rs
+++ b/crates/q_cli/src/cli/user.rs
@@ -186,13 +186,19 @@ pub async fn login_interactive(args: LoginArgs) -> Result<()> {
         Some(LicenseType::Free) => AuthMethod::BuilderId,
         Some(LicenseType::Pro) => AuthMethod::IdentityCenter,
         None => {
-            // No license specified, prompt the user to choose
-            let options = [AuthMethod::BuilderId, AuthMethod::IdentityCenter];
-            let i = match choose("Select login method", &options)? {
-                Some(i) => i,
-                None => bail!("No login method selected"),
-            };
-            options[i]
+            if args.identity_provider.is_some() && args.region.is_some() {
+                // If license is specified and --identity-provider and --region are specified,
+                // the license is determined to be pro
+                AuthMethod::IdentityCenter
+            } else {
+                // --license is not specified, prompt the user to choose
+                let options = [AuthMethod::BuilderId, AuthMethod::IdentityCenter];
+                let i = match choose("Select login method", &options)? {
+                    Some(i) => i,
+                    None => bail!("No login method selected"),
+                };
+                options[i]
+            }
         },
     };
 


### PR DESCRIPTION
*Issue #, if available:*
resolve #1352 

*Description of changes:*
This PR improves the user experience by automatically inferring Pro license when users provide both `--identity-provider` and `--region` parameters during login.

I think --license is a necessary option regardless of pro/free.
Therefore, I thought it would be good to automatically determine that it is a pro license when --identity-provider and --region are specified.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
