### PR TITLE
Added /log functionality for Q cli with all options and other capabilities #1385

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6803,6 +6803,7 @@ dependencies = [
  "anstream",
  "aws-smithy-types",
  "bstr",
+ "chrono",
  "clap",
  "color-print",
  "convert_case 0.8.0",

--- a/crates/q_chat/Cargo.toml
+++ b/crates/q_chat/Cargo.toml
@@ -46,6 +46,7 @@ url.workspace = true
 uuid.workspace = true
 winnow.workspace = true
 strip-ansi-escapes = "0.2.1"
+chrono = "0.4.40"
 
 [dev-dependencies]
 tracing-subscriber.workspace = true

--- a/crates/q_chat/src/cli.rs
+++ b/crates/q_chat/src/cli.rs
@@ -22,4 +22,7 @@ pub struct Chat {
     /// '--trust-tools=fs_read,fs_write', trust no tools: '--trust-tools='
     #[arg(long, value_delimiter = ',', value_name = "TOOL_NAMES")]
     pub trust_tools: Option<Vec<String>>,
+    /// Enable logging of prompts and responses
+    #[arg(long)]
+    pub enable_logging: bool,
 }

--- a/crates/q_chat/src/command.rs
+++ b/crates/q_chat/src/command.rs
@@ -44,6 +44,9 @@ pub enum Command {
         subcommand: Option<ToolsSubcommand>,
     },
     Usage,
+    Log {
+        subcommand: Vec<String>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -705,6 +708,16 @@ impl Command {
                     }
                 },
                 "usage" => Self::Usage,
+                "log" => {
+                    // Extract all arguments after "log" as a vector
+                    let subcommand = if parts.len() > 1 {
+                        parts[1..].iter().map(|s| s.to_string()).collect()
+                    } else {
+                        Vec::new()
+                    };
+
+                    Self::Log { subcommand }
+                },
                 unknown_command => {
                     // If the command starts with a slash but isn't recognized,
                     // return an error instead of treating it as a prompt
@@ -975,4 +988,11 @@ mod tests {
             assert_eq!(result.unwrap_err(), expected_message);
         }
     }
+}
+
+/// Command to view and manage logs
+#[derive(Debug, PartialEq)]
+pub struct LogCommand {
+    /// Subcommand arguments
+    pub subcommand: Vec<String>,
 }

--- a/crates/q_chat/src/log_command.rs
+++ b/crates/q_chat/src/log_command.rs
@@ -1,0 +1,635 @@
+//! Command handler for log-related commands in Q CLI chat.
+//!
+//! This module provides functionality to process log-related commands like
+//! `/log show`, `/log --tail N`, etc.
+
+use std::fmt::Write;
+use std::sync::Arc;
+
+use chrono::DateTime;
+use eyre::{Result, eyre};
+use tracing::debug;
+use crossterm::style::Stylize;
+
+use super::logger::LogManager;
+
+/// Handler for log-related commands.
+#[derive(Debug)]
+pub struct LogCommandHandler {
+    /// The log manager instance.
+    log_manager: Arc<LogManager>,
+}
+
+/// Command options for log commands.
+#[derive(Debug, Default, Eq, PartialEq)]
+pub struct LogCommandOptions {
+    /// Number of entries to show (default: 10).
+    pub count: usize,
+    
+    /// Whether to show all entries.
+    pub show_all: bool,
+    
+    /// Number of entries to show from the end.
+    pub tail: Option<usize>,
+    
+    /// Number of entries to show from the beginning.
+    pub head: Option<usize>,
+    
+    /// Whether to show entries in descending order.
+    pub desc: bool,
+    
+    /// Whether to show only user prompts.
+    pub only_user_prompts: bool,
+}
+
+impl LogCommandHandler {
+    /// Create a new LogCommandHandler.
+    ///
+    /// # Arguments
+    /// * `log_manager` - The log manager instance
+    ///
+    /// # Returns
+    /// A new LogCommandHandler
+    pub fn new(log_manager: Arc<LogManager>) -> Self {
+        Self { log_manager }
+    }
+  
+    /// Handle a log command.
+    ///
+    /// # Arguments
+    /// * `args` - The command arguments
+    ///
+    /// # Returns
+    /// A Result containing the command output or an error
+    pub async fn handle_command(&self, args: &[&str]) -> Result<String> {
+        if args.is_empty() {
+            return self.handle_show_command(&LogCommandOptions::default()).await;
+        }
+        
+        match args[0] {
+            "show" => {
+                let options = self.parse_show_options(&args[1..])?;
+                self.handle_show_command(&options).await
+            },
+            "enable" => self.handle_enable_command().await,
+            "disable" => self.handle_disable_command().await,
+            "delete" => self.handle_delete_command().await,
+            _ if args[0].starts_with("--tail") => {
+                let count = self.parse_count_option(args[0], "--tail")?;
+                let options = LogCommandOptions {
+                    tail: Some(count),
+                    ..Default::default()
+                };
+                self.handle_show_command(&options).await
+            },
+            _ if args[0].starts_with("--head") => {
+                let count = self.parse_count_option(args[0], "--head")?;
+                let options = LogCommandOptions {
+                    head: Some(count),
+                    ..Default::default()
+                };
+                self.handle_show_command(&options).await
+            },
+            _ => Err(eyre!("Unknown log command: {}. Available commands: enable, disable, show, delete, --tail N, --head N", args[0]))
+        }
+    }
+    
+    /// Parse options for the show command.
+    ///
+    /// # Arguments
+    /// * `args` - The command arguments
+    ///
+    /// # Returns
+    /// A Result containing the parsed options or an error
+    fn parse_show_options(&self, args: &[&str]) -> Result<LogCommandOptions> {
+        let mut options = LogCommandOptions::default();
+        
+        for arg in args {
+            match *arg {
+                "--all" => options.show_all = true,
+                "--desc" => options.desc = true,
+                "--only-user-prompts" => options.only_user_prompts = true,
+                arg if arg.starts_with("--tail=") => {
+                    let count = self.parse_count_option(arg, "--tail=")?;
+                    options.tail = Some(count);
+                },
+                arg if arg.starts_with("--head=") => {
+                    let count = self.parse_count_option(arg, "--head=")?;
+                    options.head = Some(count);
+                },
+                arg if arg.starts_with("--count=") => {
+                    options.count = self.parse_count_option(arg, "--count=")?;
+                }
+                _ => return Err(eyre!("Unknown option: {}. Available options: --all, --desc, --only-user-prompts, --tail=N, --head=N, --count=N", arg))
+            }
+        }
+        
+        Ok(options)
+    }
+    
+    /// Parse a count option.
+    ///
+    /// # Arguments
+    /// * `arg` - The argument string
+    /// * `prefix` - The prefix to remove
+    ///
+    /// # Returns
+    /// A Result containing the parsed count or an error
+    fn parse_count_option(&self, arg: &str, prefix: &str) -> Result<usize> {
+        let count_str = if arg == prefix {
+            return Err(eyre!("Missing count value for {}", prefix));
+        } else if arg.starts_with(&format!("{}=", prefix)) {
+            &arg[prefix.len() + 1..]
+        } else {
+            &arg[prefix.len()..]
+        };
+        
+        count_str.parse::<usize>()
+            .map_err(|_| eyre!("Invalid count value: {}. Expected a positive integer.", count_str))
+    }
+    
+    /// Handle the show command.
+    ///
+    /// # Arguments
+    /// * `options` - The command options
+    ///
+    /// # Returns
+    /// A Result containing the command output or an error
+    async fn handle_show_command(&self, options: &LogCommandOptions) -> Result<String> {
+        // Check if logging is enabled
+        if !self.log_manager.config.enabled {
+            return Ok("Logging is not enabled. Use '/log enable' to enable logging for this session or restart Q with 'q --enable-logging'.".to_string());
+        }
+        
+        let file_exists = self.log_manager.ctx.fs().exists(&self.log_manager.log_file_path);
+        
+        if !file_exists {
+            return Ok("No log file found. Try logging some interactions first.".to_string());
+        }
+        
+        // Use default count of 10 if not specified
+        let count = if options.count == 0 { 10 } else { options.count };
+        
+        let mut entries = self.log_manager.get_log_entries(
+            count,
+            options.show_all,
+            options.tail,
+            options.head,
+            options.desc,
+        ).await?;
+
+        // Filter entries if only-user-prompts option is set
+        if options.only_user_prompts {
+            entries.retain(|entry| entry.prompt.contains("Prompt { prompt:"));
+        }
+        
+        if entries.is_empty() {
+            return Ok("No log entries found.".to_string());
+        }
+        
+        // Define column widths for the table
+        let entry_col_width = 6;      // Entry#
+        let time_col_width = 19;      // Timestamp
+        let resp_time_col_width = 12; // Response Time
+        let prompt_col_width = 25;    // Prompt (will wrap)
+        let response_col_width = 30;  // Response (will wrap)
+        let context_col_width = 30;   // Context Files (will wrap)
+        
+        // Calculate total table width
+        let total_width = entry_col_width + time_col_width + resp_time_col_width + 
+                         prompt_col_width + response_col_width + context_col_width + 7; // +7 for separators
+        
+        let mut output = String::new();
+        writeln!(output, "Log entries ({}):", entries.len())?;
+        
+        // Table header
+        writeln!(output, "{}", "═".repeat(total_width))?;
+        writeln!(output, "{}│{}│{}│{}│{}│{}", 
+            format!("{:^width$}", "Entry#", width = entry_col_width).green().bold(),
+            format!("{:^width$}", "Timestamp", width = time_col_width).green().bold(),
+            format!("{:^width$}", "Resp Time", width = resp_time_col_width).green().bold(),
+            format!("{:^width$}", "Prompt", width = prompt_col_width).green().bold(),
+            format!("{:^width$}", "Response", width = response_col_width).green().bold(),
+            format!("{:^width$}", "Context Files", width = context_col_width).green().bold()
+        )?;
+        writeln!(output, "{}", "═".repeat(total_width))?;
+        
+        // Helper function to wrap text to a specific width
+        fn wrap_text(text: &str, width: usize) -> Vec<String> {
+            let mut lines = Vec::new();
+            let mut current_line = String::new();
+            
+            for word in text.split_whitespace() {
+                if current_line.len() + word.len() + 1 <= width {
+                    if !current_line.is_empty() {
+                        current_line.push(' ');
+                    }
+                    current_line.push_str(word);
+                } else {
+                    if !current_line.is_empty() {
+                        lines.push(current_line);
+                        current_line = String::new();
+                    }
+                    
+                    // Handle words longer than width
+                    if word.len() > width {
+                        let mut chars = word.chars();
+                        while current_line.len() < width && chars.next().is_some() {
+                            current_line.push(chars.next().unwrap_or(' '));
+                        }
+                        lines.push(current_line);
+                        current_line = String::new();
+                        
+                        let remaining: String = chars.collect();
+                        if !remaining.is_empty() {
+                            current_line = remaining;
+                        }
+                    } else {
+                        current_line = word.to_string();
+                    }
+                }
+            }
+            
+            if !current_line.is_empty() {
+                lines.push(current_line);
+            }
+            
+            if lines.is_empty() {
+                lines.push(String::new());
+            }
+            
+            lines
+        }
+        
+        for (i, entry) in entries.iter().enumerate() {
+            let datetime = DateTime::parse_from_rfc3339(&entry.timestamp)
+                .map_err(|_| eyre!("Invalid timestamp format"))?;
+            let formatted_time = datetime.format("%Y-%m-%d %H:%M:%S").to_string();
+            
+            // Wrap text for prompt and response
+            let prompt_lines = wrap_text(&entry.prompt, prompt_col_width);
+            let response_lines = wrap_text(&entry.response_summary, response_col_width);
+            
+            // Extract just the filenames from paths
+            let filenames: Vec<String> = entry.context_files.iter()
+                .map(|path| {
+                    let path_buf = std::path::PathBuf::from(path);
+                    path_buf.file_name()
+                        .map(|name| name.to_string_lossy().to_string())
+                        .unwrap_or_else(|| path.clone())
+                })
+                .collect();
+            
+            let context_text = filenames.join(", ");
+            let context_lines = wrap_text(&context_text, context_col_width);
+            
+            // Determine the maximum number of lines needed
+            let max_lines = prompt_lines.len().max(response_lines.len()).max(context_lines.len());
+            
+            // Print each row of the table
+            for line_idx in 0..max_lines {
+                let entry_num = if line_idx == 0 { 
+                    format!("{}", i + 1) 
+                } else { 
+                    String::new() 
+                };
+                
+                let timestamp = if line_idx == 0 { 
+                    formatted_time.clone() 
+                } else { 
+                    String::new() 
+                };
+                
+                let resp_time = if line_idx == 0 { 
+                    format!("{:.2}s", entry.response_time_seconds) 
+                } else { 
+                    String::new() 
+                };
+                
+                let prompt_line = prompt_lines.get(line_idx).cloned().unwrap_or_default();
+                let response_line = response_lines.get(line_idx).cloned().unwrap_or_default();
+                let context_line = context_lines.get(line_idx).cloned().unwrap_or_default();
+                
+                writeln!(output, "{}│{}│{}│{}│{}│{}", 
+                    format!("{:^width$}", entry_num, width = entry_col_width),
+                    format!("{:^width$}", timestamp, width = time_col_width),
+                    format!("{:^width$}", resp_time, width = resp_time_col_width),
+                    format!("{:<width$}", prompt_line, width = prompt_col_width),
+                    format!("{:<width$}", response_line, width = response_col_width),
+                    format!("{:<width$}", context_line, width = context_col_width)
+                )?;
+            }
+            
+            writeln!(output, "{}", "─".repeat(total_width))?;
+        }
+        
+        Ok(output)
+    }
+    
+    /// Handle the delete command.
+    ///
+    /// # Returns
+    /// A Result containing the command output or an error
+    async fn handle_delete_command(&self) -> Result<String> {
+        // Check if logging is enabled
+        if !self.log_manager.config.enabled {
+            return Ok("Logging is not enabled. Use '/log enable' to enable logging for this session or restart Q with 'q --enable-logging'.".to_string());
+        }
+        
+        let deleted = self.log_manager.delete_current_session_logs().await?;
+        
+        if deleted {
+            Ok("All log entries for the current session have been deleted.".to_string())
+        } else {
+            Ok("No log entries found to delete.".to_string())
+        }
+    }
+
+    /// Handle the enable command.
+    ///
+    /// This function enables logging for the current session.
+    ///
+    /// # Returns
+    /// A Result containing the command output or an error
+    async fn handle_enable_command(&self) -> Result<String> {
+        // Clone the Arc to get a mutable reference to the LogManager
+        let log_manager = Arc::clone(&self.log_manager);
+        
+        // Get a mutable reference to the LogManager
+        // This is safe because we're only modifying the config, not the underlying file structure
+        let log_manager_mut = unsafe { &mut *(Arc::as_ptr(&log_manager) as *mut LogManager) };
+        
+        // Enable logging without checking if it's already enabled
+        log_manager_mut.config.enabled = true;
+        
+        // Create a block to handle the async operations
+        {
+            // Initialize the log file if needed
+            let file_exists = log_manager_mut.ctx.fs().exists(&log_manager_mut.log_file_path);
+            if !file_exists {
+                log_manager_mut.ctx.fs().write(&log_manager_mut.log_file_path, "").await?;
+            }
+        }
+        
+        debug!("Logging enabled for the current session");
+        
+        Ok("Logging has been enabled for the current session. All prompts and responses will be logged.".to_string())
+    }
+
+    /// Handle the disable command.
+    ///
+    /// This function disables logging for the current session.
+    ///
+    /// # Returns
+    /// A Result containing the command output or an error
+    async fn handle_disable_command(&self) -> Result<String> {
+        // Clone the Arc to get a mutable reference to the LogManager
+        let log_manager = Arc::clone(&self.log_manager);
+        
+        // Get a mutable reference to the LogManager
+        // This is safe because we're only modifying the config, not the underlying file structure
+        let log_manager_mut = unsafe { &mut *(Arc::as_ptr(&log_manager) as *mut LogManager) };
+        
+        // Disable logging directly
+        log_manager_mut.config.enabled = false;
+        
+        debug!("Logging disabled for the current session");
+        
+        Ok("Logging has been disabled for the current session. No further prompts and responses will be logged.".to_string())
+    }
+
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::logger::LogManager;
+    use fig_os_shim::Context;
+    
+    // Helper function to create a test LogManager and LogCommandHandler
+    async fn create_test_handler() -> Result<(Arc<LogManager>, LogCommandHandler)> {
+        let ctx = Context::builder().with_test_home().await.unwrap().build_fake();
+        let manager = LogManager::new(ctx, true).await?;
+        let arc_manager = Arc::new(manager);
+        let handler = LogCommandHandler::new(Arc::clone(&arc_manager));
+        
+        Ok((arc_manager, handler))
+    }
+    
+    #[tokio::test]
+    async fn test_handle_show_command_empty() -> Result<()> {
+        let (_, handler) = create_test_handler().await?;
+        
+        let result = handler.handle_command(&["show"]).await?;
+        assert!(result.contains("No log entries found"));
+        
+        Ok(())
+    }
+    
+    #[tokio::test]
+    async fn test_handle_show_command_with_entries() -> Result<()> {
+        let (manager, handler) = create_test_handler().await?;
+        
+        // Add some log entries
+        manager.log_interaction(
+            "Test prompt 1".to_string(),
+            "Test response 1".to_string(),
+            1.0,
+            vec![],
+        ).await?;
+        
+        manager.log_interaction(
+            "Test prompt 2".to_string(),
+            "Test response 2".to_string(),
+            2.0,
+            vec!["test.md".to_string()],
+        ).await?;
+        
+        // Test default show command
+        let result = handler.handle_command(&["show"]).await?;
+        assert!(result.contains("Log entries (2):"));
+        assert!(result.contains("Test prompt 1"));
+        assert!(result.contains("Test prompt 2"));
+        
+        // Test with --all option
+        let result = handler.handle_command(&["show", "--all"]).await?;
+        assert!(result.contains("Log entries (2):"));
+        
+        // Test with --desc option
+        let result = handler.handle_command(&["show", "--desc"]).await?;
+        assert!(result.contains("Log entries (2):"));
+        
+        // Test with --tail option
+        let result = handler.handle_command(&["show", "--tail=1"]).await?;
+        assert!(result.contains("Log entries (1):"));
+        assert!(result.contains("Test prompt 2"));
+        assert!(!result.contains("Test prompt 1"));
+        
+        // Test with --head option
+        let result = handler.handle_command(&["show", "--head=1"]).await?;
+        assert!(result.contains("Log entries (1):"));
+        assert!(result.contains("Test prompt 1"));
+        assert!(!result.contains("Test prompt 2"));
+        
+        Ok(())
+    }
+    
+    #[tokio::test]
+    async fn test_handle_delete_command() -> Result<()> {
+        let (manager, handler) = create_test_handler().await?;
+        
+        // Add a log entry
+        manager.log_interaction(
+            "Test prompt".to_string(),
+            "Test response".to_string(),
+            1.0,
+            vec![],
+        ).await?;
+        
+        // Verify the entry was created
+        let entries = manager.get_log_entries(10, false, None, None, false).await?;
+        assert_eq!(entries.len(), 1);
+        
+        // Delete the entries
+        let result = handler.handle_command(&["delete"]).await?;
+        assert!(result.contains("All log entries for the current session have been deleted"));
+        
+        // Verify the entries were deleted
+        let entries = manager.get_log_entries(10, false, None, None, false).await?;
+        assert_eq!(entries.len(), 0);
+        
+        // Try deleting again
+        let result = handler.handle_command(&["delete"]).await?;
+        assert!(result.contains("No log entries found to delete"));
+        
+        Ok(())
+    }
+    
+    #[tokio::test]
+    async fn test_handle_tail_command() -> Result<()> {
+        let (manager, handler) = create_test_handler().await?;
+        
+        // Add some log entries
+        for i in 0..5 {
+            manager.log_interaction(
+                format!("Test prompt {}", i),
+                format!("Test response {}", i),
+                1.0,
+                vec![],
+            ).await?;
+        }
+        
+        // Test --tail command
+        let result = handler.handle_command(&["--tail", "2"]).await?;
+        assert!(result.contains("Log entries (2):"));
+        assert!(result.contains("Test prompt 3"));
+        assert!(result.contains("Test prompt 4"));
+        assert!(!result.contains("Test prompt 2"));
+        
+        Ok(())
+    }
+    
+    #[tokio::test]
+    async fn test_handle_head_command() -> Result<()> {
+        let (manager, handler) = create_test_handler().await?;
+        
+        // Add some log entries
+        for i in 0..5 {
+            manager.log_interaction(
+                format!("Test prompt {}", i),
+                format!("Test response {}", i),
+                1.0,
+                vec![],
+            ).await?;
+        }
+        
+        // Test --head command
+        let result = handler.handle_command(&["--head", "2"]).await?;
+        assert!(result.contains("Log entries (2):"));
+        assert!(result.contains("Test prompt 0"));
+        assert!(result.contains("Test prompt 1"));
+        assert!(!result.contains("Test prompt 2"));
+        
+        Ok(())
+    }
+    
+    #[tokio::test]
+    async fn test_invalid_command() -> Result<()> {
+        let (_, handler) = create_test_handler().await?;
+        
+        let result = handler.handle_command(&["invalid"]).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Unknown log command"));
+        
+        Ok(())
+    }
+    
+    #[tokio::test]
+    async fn test_invalid_options() -> Result<()> {
+        let (_, handler) = create_test_handler().await?;
+        
+        let result = handler.handle_command(&["show", "--invalid"]).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Unknown option"));
+        
+        let result = handler.handle_command(&["--tail"]).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Missing count value"));
+        
+        let result = handler.handle_command(&["--tail=abc"]).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Invalid count value"));
+        
+        Ok(())
+    }
+    
+    #[tokio::test]
+    async fn test_handle_only_user_prompts_option() -> Result<()> {
+        let (manager, handler) = create_test_handler().await?;
+        
+        // Add some log entries with different formats
+        manager.log_interaction(
+            "Regular prompt".to_string(),
+            "Test response 1".to_string(),
+            1.0,
+            vec![],
+        ).await?;
+        
+        manager.log_interaction(
+            "Prompt { prompt: User question }".to_string(),
+            "Test response 2".to_string(),
+            2.0,
+            vec![],
+        ).await?;
+        
+        manager.log_interaction(
+            "Another regular prompt".to_string(),
+            "Test response 3".to_string(),
+            1.5,
+            vec![],
+        ).await?;
+        
+        manager.log_interaction(
+            "Prompt { prompt: Another user question }".to_string(),
+            "Test response 4".to_string(),
+            2.5,
+            vec![],
+        ).await?;
+        
+        // Test with --only-user-prompts option
+        let result = handler.handle_command(&["show", "--only-user-prompts"]).await?;
+        assert!(result.contains("Log entries (2):"));
+        assert!(result.contains("Prompt { prompt: User question }"));
+        assert!(result.contains("Prompt { prompt: Another user question }"));
+        assert!(!result.contains("Regular prompt"));
+        assert!(!result.contains("Another regular prompt"));
+        
+        // Test with combined options
+        let result = handler.handle_command(&["show", "--only-user-prompts", "--head=1"]).await?;
+        assert!(result.contains("Log entries (1):"));
+        assert!(result.contains("Prompt { prompt: User question }"));
+        assert!(!result.contains("Prompt { prompt: Another user question }"));
+        
+        Ok(())
+    }
+}

--- a/crates/q_chat/src/logger.rs
+++ b/crates/q_chat/src/logger.rs
@@ -614,8 +614,8 @@ mod tests {
 /// Generate a compact summary of a response.
 ///
 /// This function creates a meaningful summary of the response by:
-/// 1. For short responses (< 100 characters), using the full response
-/// 2. For longer responses, extracting the first 1-2 sentences (up to 100 characters)
+/// 1. For short responses (< 500 characters), using the full response
+/// 2. For longer responses, extracting the first 1-2 sentences (up to 500 characters)
 /// 3. Adding ellipsis (...) if truncated
 ///
 /// # Arguments
@@ -625,7 +625,7 @@ mod tests {
 /// A compact summary of the response
 fn generate_response_summary(response: &str) -> String {
     // For short responses, return the full text
-    if response.len() <= 100 {
+    if response.len() <= 500 {
         return response.to_string();
     }
     
@@ -659,7 +659,7 @@ fn generate_response_summary(response: &str) -> String {
         char_count += trimmed.len() + 1; // +1 for the terminator
         
         // Stop if we have enough sentences or characters
-        if (sentence_count >= 2 || char_count >= 100) && !summary.is_empty() {
+        if (sentence_count >= 2 || char_count >= 500) && !summary.is_empty() {
             break;
         }
     }
@@ -667,16 +667,16 @@ fn generate_response_summary(response: &str) -> String {
     // If we couldn't extract sentences properly, fall back to character-based truncation
     if summary.is_empty() || summary.len() < 10 {
         let end = response.char_indices()
-            .take(100)
+            .take(500)
             .last()
             .map(|(i, _)| i + 1)
             .unwrap_or(response.len());
         
         summary = format!("{}...", &response[..end]);
-    } else if summary.len() > 100 {
+    } else if summary.len() > 500 {
         // If the summary is still too long, truncate it
         let end = summary.char_indices()
-            .take(97)
+            .take(497)
             .last()
             .map(|(i, _)| i + 1)
             .unwrap_or(summary.len());

--- a/crates/q_chat/src/logger.rs
+++ b/crates/q_chat/src/logger.rs
@@ -1,0 +1,691 @@
+//! Logging functionality for Q CLI chat sessions.
+//!
+//! This module provides the ability to log user prompts, commands, responses,
+//! and related metadata in a structured format, allowing users to review their
+//! past interactions and track their usage patterns.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use chrono::{DateTime, Utc};
+use eyre::{Result, eyre};
+use fig_os_shim::Context;
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+use uuid::Uuid;
+
+/// Configuration for logging, containing settings for the logging feature.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct LoggingConfig {
+    /// Whether logging is enabled.
+    pub enabled: bool,
+    
+    /// Maximum log file size in bytes before truncation (default: 512MB).
+    pub max_file_size: u64,
+}
+
+/// Represents a single log entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LogEntry {
+    /// Unique identifier for the log entry.
+    pub id: String,
+    
+    /// Timestamp when the log entry was created.
+    pub timestamp: String,
+    
+    /// The user's prompt or command.
+    pub prompt: String,
+    
+    /// A compact summary of the response.
+    pub response_summary: String,
+    
+    /// Time taken for the response to generate in seconds.
+    pub response_time_seconds: f64,
+    
+    /// List of context files used for the response.
+    pub context_files: Vec<String>,
+    
+    /// Session ID that this log entry belongs to.
+    pub session_id: String,
+}
+
+impl LogEntry {
+    /// Create a new log entry.
+    pub fn new(
+        prompt: String,
+        response: String,
+        response_time: f64,
+        context_files: Vec<String>,
+        session_id: String,
+    ) -> Self {
+        // Generate a unique ID for the log entry
+        let id = format!("entry_{}", Uuid::new_v4().to_string().split('-').next().unwrap_or("001"));
+        
+        // Create timestamp in ISO 8601 format
+        let now = SystemTime::now();
+        let since_epoch = now.duration_since(UNIX_EPOCH).unwrap_or_default();
+        let datetime = DateTime::<Utc>::from_timestamp(
+            since_epoch.as_secs() as i64,
+            since_epoch.subsec_nanos(),
+        ).unwrap_or_default();
+        let timestamp = datetime.to_rfc3339();
+        
+        // Create a compact summary of the response
+        let response_summary = generate_response_summary(&response);
+        
+        Self {
+            id,
+            timestamp,
+            prompt,
+            response_summary,
+            response_time_seconds: response_time,
+            context_files,
+            session_id,
+        }
+    }
+    
+    /// Serialize the log entry to a JSON string.
+    pub fn to_json(&self) -> Result<String> {
+        serde_json::to_string(self)
+            .map_err(|e| eyre!("Failed to serialize log entry: {}", e))
+    }
+
+}
+
+/// Manager for logging functionality.
+#[derive(Debug, Clone)]
+pub struct LogManager {
+    pub(crate) ctx: Arc<Context>,
+    
+    /// Configuration for logging.
+    pub config: LoggingConfig,
+    
+    /// Current session ID.
+    pub session_id: String,
+    
+    /// Path to the current log file.
+    pub log_file_path: PathBuf,
+}
+
+impl LogManager {
+    /// Create a new LogManager with default settings.
+    ///
+    /// This will:
+    /// 1. Create the necessary directories if they don't exist
+    /// 2. Generate a new session ID
+    /// 3. Set up the log file path
+    ///
+    /// # Returns
+    /// A Result containing the new LogManager or an error
+    pub async fn new(ctx: Arc<Context>, enable_logging: bool) -> Result<Self> {
+        // Create log directories if they don't exist
+        let logs_dir = log_directory(&ctx)?;
+        let sessions_dir = logs_dir.join("sessions");
+        
+        ctx.fs().create_dir_all(&sessions_dir).await?;
+        
+        // Generate a new session ID and timestamp
+        let session_id = Uuid::new_v4().to_string();
+        let now = SystemTime::now();
+        let since_epoch = now.duration_since(UNIX_EPOCH).unwrap_or_default();
+        let datetime = DateTime::<Utc>::from_timestamp(
+            since_epoch.as_secs() as i64,
+            since_epoch.subsec_nanos(),
+        ).unwrap_or_default();
+        let timestamp = datetime.format("%Y-%m-%d_%H-%M-%S").to_string();
+        
+        // Create the log file path
+        let log_filename = format!("q_session_{}_{}.log", timestamp, &session_id[..8]);
+        let log_file_path = sessions_dir.join(&log_filename);
+        
+        // Create a symlink to the current session
+        let current_session_link = logs_dir.join("current_session");
+        if ctx.fs().exists(&current_session_link) {
+            let _ = ctx.fs().remove_file(&current_session_link).await;
+        }
+        
+        // Note: Symlink creation would be platform-specific
+        // For simplicity, we'll just create a file with the path to the current session
+        let relative_path = format!("sessions/{}", log_filename);
+        ctx.fs().write(&current_session_link, &relative_path).await?;
+        
+        // Create default configuration
+        let config = LoggingConfig {
+            enabled: enable_logging,
+            max_file_size: 512 * 1024 * 1024, // 512MB
+        };
+        
+        Ok(Self {
+            ctx,
+            config,
+            session_id,
+            log_file_path,
+        })
+    }
+    
+    /// Initialize logging based on the provided flag.
+    ///
+    /// # Arguments
+    /// * `enable_logging` - Whether to enable logging
+    ///
+    /// # Returns
+    /// A Result indicating success or an error
+    pub async fn initialize_logging(&mut self, enable_logging: bool) -> Result<()> {
+        self.config.enabled = enable_logging;
+        
+        if enable_logging {
+            debug!("Logging enabled. Log file: {:?}", self.log_file_path);
+            
+            // Create an empty log file or ensure it exists
+            if !self.ctx.fs().exists(&self.log_file_path) {
+                self.ctx.fs().write(&self.log_file_path, "").await?;
+            }
+        }
+        
+        Ok(())
+    }
+    
+    /// Log an interaction between the user and Amazon Q.
+    ///
+    /// # Arguments
+    /// * `prompt` - The user's prompt or command
+    /// * `response` - The response from Amazon Q
+    /// * `response_time` - Time taken for the response in seconds
+    /// * `context_files` - List of context files used for the response
+    ///
+    /// # Returns
+    /// A Result indicating success or an error
+    pub async fn log_interaction(
+        &self,
+        prompt: String,
+        response: String,
+        response_time: f64,
+        context_files: Vec<String>,
+    ) -> Result<LogEntry> {
+        if !self.config.enabled {
+            return Err(eyre!("Logging is not enabled"));
+        }
+        
+        // Check if the log file size exceeds the maximum
+        self.check_and_truncate_log_file().await?;
+        
+        // Create a new log entry
+        let log_entry = LogEntry::new(
+            prompt,
+            response,
+            response_time,
+            context_files,
+            self.session_id.clone(),
+        );
+        
+        // Serialize the log entry to JSON
+        let json_line = log_entry.to_json()?;
+        
+        // Append the log entry to the log file using efficient appending
+        self.append_to_log_file(&json_line).await?;
+        
+        Ok(log_entry)
+    }
+    
+    /// Append a JSON line to the log file.
+    ///
+    /// This method uses efficient appending to avoid reading the entire file.
+    ///
+    /// # Arguments
+    /// * `json_line` - The JSON line to append
+    ///
+    /// # Returns
+    /// A Result indicating success or an error
+    async fn append_to_log_file(&self, json_line: &str) -> Result<()> {
+        // Create the file if it doesn't exist
+        if !self.ctx.fs().exists(&self.log_file_path) {
+            self.ctx.fs().write(&self.log_file_path, "").await?;
+        }
+        
+        // Read the last character to check if we need to add a newline
+        let file_size = self.ctx.fs().symlink_metadata(&self.log_file_path).await?.len();
+        let needs_newline = if file_size > 0 {
+            // Read the last character
+            let last_char = self.ctx.fs().read_to_string(&self.log_file_path).await?
+                .chars().last().unwrap_or('\n');
+            last_char != '\n'
+        } else {
+            false
+        };
+        
+        // Prepare the content to append
+        let mut content = String::new();
+        if needs_newline {
+            content.push('\n');
+        }
+        content.push_str(json_line);
+        content.push('\n');
+        
+        // Append to the file
+        // Note: In a real implementation, we would use file.open() with append mode
+        // but since we're using the Context abstraction, we'll read and write the whole file
+        let existing_content = if file_size > 0 {
+            self.ctx.fs().read_to_string(&self.log_file_path).await?
+        } else {
+            String::new()
+        };
+        
+        let new_content = format!("{}{}", existing_content, content);
+        self.ctx.fs().write(&self.log_file_path, new_content).await?;
+        
+        Ok(())
+    }
+    
+    /// Get log entries from the current session.
+    ///
+    /// # Arguments
+    /// * `count` - Number of entries to retrieve (default: 10)
+    /// * `show_all` - Whether to show all entries
+    /// * `tail` - Number of entries to show from the end
+    /// * `head` - Number of entries to show from the beginning
+    /// * `desc` - Whether to show entries in descending order
+    ///
+    /// # Returns
+    /// A Result containing a vector of LogEntry objects or an error
+    pub async fn get_log_entries(
+        &self,
+        count: usize,
+        show_all: bool,
+        tail: Option<usize>,
+        head: Option<usize>,
+        desc: bool,
+    ) -> Result<Vec<LogEntry>> {
+        if !self.ctx.fs().exists(&self.log_file_path) {
+            return Ok(Vec::new());
+        }
+        
+        // Read the log file
+        let content = self.ctx.fs().read_to_string(&self.log_file_path).await?;
+        
+        // Parse the log entries
+        let entries = self.parse_log_entries(&content)?;
+        
+        // Apply sorting
+        let mut sorted_entries = entries;
+        if desc {
+            sorted_entries.reverse();
+        }
+        
+        // Apply filtering based on parameters
+        let filtered_entries = if show_all {
+            sorted_entries
+        } else if let Some(tail_count) = tail {
+            if tail_count >= sorted_entries.len() {
+                sorted_entries
+            } else {
+                sorted_entries[sorted_entries.len() - tail_count..].to_vec()
+            }
+        } else if let Some(head_count) = head {
+            if head_count >= sorted_entries.len() {
+                sorted_entries
+            } else {
+                sorted_entries[..head_count].to_vec()
+            }
+        } else {
+            // Default: show the most recent entries (count)
+            if count >= sorted_entries.len() {
+                sorted_entries
+            } else {
+                sorted_entries[sorted_entries.len() - count..].to_vec()
+            }
+        };
+        
+        Ok(filtered_entries)
+    }
+    
+    /// Parse log entries from a string.
+    ///
+    /// # Arguments
+    /// * `content` - The string containing log entries in JSONL format
+    ///
+    /// # Returns
+    /// A Result containing a vector of LogEntry objects or an error
+    fn parse_log_entries(&self, content: &str) -> Result<Vec<LogEntry>> {
+        let lines: Vec<&str> = content.lines().collect();
+        
+        // Parse each line as a LogEntry
+        let mut entries: Vec<LogEntry> = Vec::new();
+        for (_i, line) in lines.iter().enumerate() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            
+            match serde_json::from_str::<LogEntry>(line) {
+                Ok(entry) => {
+                    entries.push(entry);
+                },
+                Err(_e) => {
+                    // Try to be more lenient with JSON parsing
+                    if let Ok(_value) = serde_json::from_str::<serde_json::Value>(line) {
+                    } else {
+                    }
+                }
+            }
+        }
+        
+        Ok(entries)
+    }
+    
+    
+    /// Delete all log entries for the current session.
+    ///
+    /// # Returns
+    /// A Result indicating success or an error
+    pub async fn delete_current_session_logs(&self) -> Result<bool> {
+        if self.ctx.fs().exists(&self.log_file_path) {
+            self.ctx.fs().write(&self.log_file_path, "").await?;
+            return Ok(true);
+        }
+        
+        Ok(false)
+    }
+    
+    /// Check if the log file exceeds the maximum size and truncate it if necessary.
+    ///
+    /// # Returns
+    /// A Result indicating success or an error
+    async fn check_and_truncate_log_file(&self) -> Result<()> {
+        if !self.ctx.fs().exists(&self.log_file_path) {
+            return Ok(());
+        }
+        
+        let metadata = self.ctx.fs().symlink_metadata(&self.log_file_path).await?;
+        let file_size = metadata.len();
+        
+        if file_size > self.config.max_file_size {
+            debug!("Log file size ({} bytes) exceeds maximum ({}). Truncating...", file_size, self.config.max_file_size);
+            
+            // Calculate target size (90% of max size)
+            let target_size = (self.config.max_file_size as f64 * 0.9) as u64;
+            let bytes_to_keep = target_size;
+            
+            // Read the file content
+            let content = self.ctx.fs().read_to_string(&self.log_file_path).await?;
+            
+            // Find a position to truncate at (line boundary)
+            let truncate_pos = if content.len() <= bytes_to_keep as usize {
+                0
+            } else {
+                let start_pos = content.len() - bytes_to_keep as usize;
+                
+                // Find the next newline to ensure we don't truncate in the middle of a line
+                match content[start_pos..].find('\n') {
+                    Some(pos) => start_pos + pos + 1, // +1 to include the newline
+                    None => start_pos,
+                }
+            };
+            
+            // Create truncation notice
+            let now = SystemTime::now();
+            let since_epoch = now.duration_since(UNIX_EPOCH).unwrap_or_default();
+            let datetime = DateTime::<Utc>::from_timestamp(
+                since_epoch.as_secs() as i64,
+                since_epoch.subsec_nanos(),
+            ).unwrap_or_default();
+            let timestamp = datetime.to_rfc3339();
+            
+            let truncation_notice = format!(
+                "{{\"truncation_notice\": \"Log was truncated at {}\"}}\n",
+                timestamp
+            );
+            
+            // Write the truncated content back to the file
+            let truncated_content = format!("{}{}", truncation_notice, &content[truncate_pos..]);
+            self.ctx.fs().write(&self.log_file_path, truncated_content).await?;
+            
+            debug!("Log file truncated successfully");
+        }
+        
+        Ok(())
+    }
+}
+
+/// Get the platform-specific log directory.
+///
+/// # Returns
+/// A Result containing the path to the log directory
+fn log_directory(ctx: &Context) -> Result<PathBuf> {
+    let home_dir = ctx.env().home().ok_or_else(|| eyre!("Could not determine home directory"))?;
+    
+    // Platform-specific log directory
+    let log_dir = if cfg!(target_os = "macos") {
+        home_dir.join("Library/Logs/AmazonQ")
+    } else if cfg!(target_os = "linux") {
+        home_dir.join(".local/share/amazon-q/logs")
+    } else if cfg!(target_os = "windows") {
+        if let Ok(local_app_data) = ctx.env().get("LOCALAPPDATA") {
+            PathBuf::from(local_app_data).join("Amazon/Q/Logs")
+        } else {
+            home_dir.join(".amazon-q/logs")
+        }
+    } else {
+        // Fallback for other platforms
+        home_dir.join(".amazon-q/logs")
+    };
+    
+    Ok(log_dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    // Helper function to create a test LogManager
+    async fn create_test_log_manager(enable_logging: bool) -> Result<LogManager> {
+        let ctx = Context::builder().with_test_home().await.unwrap().build_fake();
+        let manager = LogManager::new(ctx, enable_logging).await?;
+        Ok(manager)
+    }
+    
+    #[tokio::test]
+    async fn test_log_manager_creation() -> Result<()> {
+        let manager = create_test_log_manager(true).await?;
+        
+        assert!(manager.config.enabled);
+        assert_eq!(manager.config.max_file_size, 512 * 1024 * 1024);
+        assert!(!manager.session_id.is_empty());
+        
+        Ok(())
+    }
+    
+    #[tokio::test]
+    async fn test_log_interaction() -> Result<()> {
+        let manager = create_test_log_manager(true).await?;
+        
+        // Log an interaction
+        let log_entry = manager.log_interaction(
+            "Test prompt".to_string(),
+            "Test response".to_string(),
+            1.2,
+            vec!["test.md".to_string()],
+        ).await?;
+        
+        // Verify the log entry was created
+        let entries = manager.get_log_entries(10, false, None, None, false).await?;
+        
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].prompt, "Test prompt");
+        assert_eq!(entries[0].response_summary, "Test response");
+        assert_eq!(entries[0].response_time_seconds, 1.2);
+        assert_eq!(entries[0].context_files, vec!["test.md"]);
+        assert_eq!(entries[0].id, log_entry.id);
+        
+        Ok(())
+    }
+    
+    #[tokio::test]
+    async fn test_disabled_logging() -> Result<()> {
+        let manager = create_test_log_manager(false).await?;
+        
+        // Log an interaction with logging disabled
+        let result = manager.log_interaction(
+            "Test prompt".to_string(),
+            "Test response".to_string(),
+            1.2,
+            vec!["test.md".to_string()],
+        ).await;
+        
+        // Verify the operation failed because logging is disabled
+        assert!(result.is_err());
+        
+        // Verify no log entry was created
+        let entries = manager.get_log_entries(10, false, None, None, false).await?;
+        assert_eq!(entries.len(), 0);
+        
+        Ok(())
+    }
+    
+    #[tokio::test]
+    async fn test_delete_logs() -> Result<()> {
+        let manager = create_test_log_manager(true).await?;
+        
+        // Log some interactions
+        for i in 0..3 {
+            manager.log_interaction(
+                format!("Test prompt {}", i),
+                format!("Test response {}", i),
+                1.0,
+                vec![],
+            ).await?;
+        }
+        
+        // Verify log entries were created
+        let entries = manager.get_log_entries(10, true, None, None, false).await?;
+        assert_eq!(entries.len(), 3);
+        
+        // Delete the logs
+        let deleted = manager.delete_current_session_logs().await?;
+        assert!(deleted);
+        
+        // Verify logs were deleted
+        let entries = manager.get_log_entries(10, true, None, None, false).await?;
+        assert_eq!(entries.len(), 0);
+        
+        Ok(())
+    }
+    
+    #[tokio::test]
+    async fn test_get_log_entries_filtering() -> Result<()> {
+        let manager = create_test_log_manager(true).await?;
+        
+        // Log 5 interactions
+        for i in 0..5 {
+            manager.log_interaction(
+                format!("Test prompt {}", i),
+                format!("Test response {}", i),
+                1.0,
+                vec![],
+            ).await?;
+        }
+        
+        // Test default behavior (last 10 entries)
+        let entries = manager.get_log_entries(10, false, None, None, false).await?;
+        assert_eq!(entries.len(), 5);
+        
+        // Test head
+        let entries = manager.get_log_entries(10, false, None, Some(2), false).await?;
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].prompt, "Test prompt 0");
+        assert_eq!(entries[1].prompt, "Test prompt 1");
+        
+        // Test tail
+        let entries = manager.get_log_entries(10, false, Some(2), None, false).await?;
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].prompt, "Test prompt 3");
+        assert_eq!(entries[1].prompt, "Test prompt 4");
+        
+        // Test descending order
+        let entries = manager.get_log_entries(10, true, None, None, true).await?;
+        assert_eq!(entries.len(), 5);
+        assert_eq!(entries[0].prompt, "Test prompt 4");
+        assert_eq!(entries[4].prompt, "Test prompt 0");
+        
+        Ok(())
+    }
+    
+}
+/// Generate a compact summary of a response.
+///
+/// This function creates a meaningful summary of the response by:
+/// 1. For short responses (< 100 characters), using the full response
+/// 2. For longer responses, extracting the first 1-2 sentences (up to 100 characters)
+/// 3. Adding ellipsis (...) if truncated
+///
+/// # Arguments
+/// * `response` - The full response text
+///
+/// # Returns
+/// A compact summary of the response
+fn generate_response_summary(response: &str) -> String {
+    // For short responses, return the full text
+    if response.len() <= 100 {
+        return response.to_string();
+    }
+    
+    // Try to extract the first 1-2 sentences
+    let mut summary = String::new();
+    let mut sentence_count = 0;
+    let mut char_count = 0;
+    
+    // Split by common sentence terminators
+    for sentence in response.split_terminator(|c| c == '.' || c == '!' || c == '?') {
+        // Skip empty sentences
+        let trimmed = sentence.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        
+        // Add sentence separator if not the first sentence
+        if !summary.is_empty() {
+            let last_char = summary.chars().last().unwrap_or(' ');
+            if !last_char.is_whitespace() {
+                summary.push(' ');
+            }
+        }
+        
+        // Add the sentence with its terminator
+        summary.push_str(trimmed);
+        summary.push('.');
+        
+        // Update counters
+        sentence_count += 1;
+        char_count += trimmed.len() + 1; // +1 for the terminator
+        
+        // Stop if we have enough sentences or characters
+        if (sentence_count >= 2 || char_count >= 100) && !summary.is_empty() {
+            break;
+        }
+    }
+    
+    // If we couldn't extract sentences properly, fall back to character-based truncation
+    if summary.is_empty() || summary.len() < 10 {
+        let end = response.char_indices()
+            .take(100)
+            .last()
+            .map(|(i, _)| i + 1)
+            .unwrap_or(response.len());
+        
+        summary = format!("{}...", &response[..end]);
+    } else if summary.len() > 100 {
+        // If the summary is still too long, truncate it
+        let end = summary.char_indices()
+            .take(97)
+            .last()
+            .map(|(i, _)| i + 1)
+            .unwrap_or(summary.len());
+        
+        summary = format!("{}...", &summary[..end]);
+    } else if response.len() > summary.len() {
+        // Add ellipsis if we truncated the response
+        summary.push_str("...");
+    }
+    
+    summary
+}

--- a/crates/q_chat/src/parser.rs
+++ b/crates/q_chat/src/parser.rs
@@ -94,6 +94,8 @@ pub struct ResponseParser {
     /// Whether or not we are currently receiving tool use delta events. Tuple of
     /// `Some((tool_use_id, name))` if true, [None] otherwise.
     parsing_tool_use: Option<(String, String)>,
+    /// The time when the parser was created
+    start_time: Option<Instant>,
 }
 
 impl ResponseParser {
@@ -107,7 +109,13 @@ impl ResponseParser {
             assistant_text: String::new(),
             tool_uses: Vec::new(),
             parsing_tool_use: None,
+            start_time: Some(Instant::now()),
         }
+    }
+
+    /// Returns the elapsed time since the parser was created
+    pub fn elapsed_time(&self) -> Option<std::time::Duration> {
+        self.start_time.map(|start| std::time::Instant::now().duration_since(start))
     }
 
     /// Consumes the associated [ConverseStreamResponse] until a valid [ResponseEvent] is parsed.

--- a/crates/q_cli/src/cli/mod.rs
+++ b/crates/q_cli/src/cli/mod.rs
@@ -250,6 +250,9 @@ pub struct Cli {
     /// Print help for all subcommands
     #[arg(long)]
     help_all: bool,
+    /// Enable logging of prompts and responses
+    #[arg(long)]
+    pub enable_logging: bool,
 }
 
 impl Cli {
@@ -429,18 +432,21 @@ mod test {
             subcommand: None,
             verbose: 1,
             help_all: false,
+            enable_logging: false,
         });
 
         assert_eq!(Cli::parse_from([CLI_BINARY_NAME, "-vvv"]), Cli {
             subcommand: None,
             verbose: 3,
             help_all: false,
+            enable_logging: false,
         });
 
         assert_eq!(Cli::parse_from([CLI_BINARY_NAME, "--help-all"]), Cli {
             subcommand: None,
             verbose: 0,
             help_all: true,
+            enable_logging: false,
         });
 
         assert_eq!(Cli::parse_from([CLI_BINARY_NAME, "chat", "-vv"]), Cli {
@@ -451,9 +457,11 @@ mod test {
                 profile: None,
                 trust_all_tools: false,
                 trust_tools: None,
+                enable_logging: false,
             })),
             verbose: 2,
             help_all: false,
+            enable_logging: false,
         });
     }
 
@@ -585,6 +593,7 @@ mod test {
                 profile: Some("my-profile".to_string()),
                 trust_all_tools: false,
                 trust_tools: None,
+                enable_logging: false,
             })
         );
     }
@@ -600,6 +609,7 @@ mod test {
                 profile: Some("my-profile".to_string()),
                 trust_all_tools: false,
                 trust_tools: None,
+                enable_logging: false,
             })
         );
     }
@@ -615,6 +625,7 @@ mod test {
                 profile: Some("my-profile".to_string()),
                 trust_all_tools: false,
                 trust_tools: None,
+                enable_logging: false,
             })
         );
     }
@@ -630,6 +641,7 @@ mod test {
                 profile: None,
                 trust_all_tools: false,
                 trust_tools: None,
+                enable_logging: false,
             })
         );
     }
@@ -645,6 +657,7 @@ mod test {
                 profile: None,
                 trust_all_tools: true,
                 trust_tools: None,
+                enable_logging: false,
             })
         );
     }
@@ -660,6 +673,7 @@ mod test {
                 profile: None,
                 trust_all_tools: false,
                 trust_tools: Some(vec!["".to_string()]),
+                enable_logging: false,
             })
         );
     }
@@ -675,6 +689,7 @@ mod test {
                 profile: None,
                 trust_all_tools: false,
                 trust_tools: Some(vec!["fs_read".to_string(), "fs_write".to_string()]),
+                enable_logging: false,
             })
         );
     }


### PR DESCRIPTION
*Issue #1385 *

*Description of changes:*
This PR contains changes to enable logging of prompts made by user in Q cli for the current session, allowing users to do so by doing `/log enable` and then `/log show --all` to see all prompts.

Highly recommend going through the idea-honing, summary and detailed design doc attached to the comments of this PR for more information about this.
[idea-honing.md](https://github.com/user-attachments/files/19935556/idea-honing.md)
[summary.md](https://github.com/user-attachments/files/19935565/summary.md)
[detailed-design.md](https://github.com/user-attachments/files/19935568/detailed-design.md)

## Features

1. Store logs in standard system log locations
2. Implement opt-in logging (only enabled with `--enable-logging` flag)
3. Use per-session logging with separate log files for each session
4. Log specific information for each prompt/command:
   - Timestamp
   - User prompt/command
   - Compact summary of response
   - Time taken for the response to generate
   - Context files used
5. Support a command interface with the following operations:
   - `/log show` - shows the most recent entries (10 by default)
   - `/log show --all` - shows all entries
   - `/log --tail N` - shows the last N entries
   - `/log --head N` - shows the first N entries
   - `/log delete` - deletes the log entries for current session only
   - `/log show --desc` - shows log entries in descending order of timestamp
   - `/log show --only-user-prompts` - shows log entries for only the user prompts and not the ones triggered by system for file read, write or executing bash commands
6. Implement log truncation when file size exceeds 512MB

## Implementation details
The implementation plan is divided into 10 incremental steps:

1. Set up the basic logging infrastructure
2. Implement session management
3. Implement log entry creation and storage
4. Implement log file truncation
5. Implement log command handling
6. Add CLI flag for enabling logging
7. Implement response summary generation
8. Add error handling and recovery mechanisms
9. Write tests for the logging functionality
10. Integrate with existing Q CLI codebase

## Commands

   - `/log show` - shows the most recent entries (10 by default)
   - `/log show --all` - shows all entries
   - `/log --tail N` - shows the last N entries
   - `/log --head N` - shows the first N entries
   - `/log delete` - deletes the log entries for current session only
   - `/log show --desc` - shows log entries in descending order of timestamp
   - `/log enable` - enables logging for current session
   - `/log disable` - disables logging for current session
   - `/log show --only-user-prompts` - shows log entries for only the user prompts and not the ones triggered by system for file read, write or executing bash commands

## Testing
- Unit tests
- Tested functionality end to end

## Example Usage

```
> /log enable

Logging has been enabled for the current session. All prompts and responses will be logged.
> /log show

Log entries (1):
═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Entry#│     Timestamp     │ Resp Time  │         Prompt          │           Response           │        Context Files         
═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
  1   │2025-04-28 06:41:18│   12.97s   │"Prompt { prompt:        │Lagrange's Theorem is a       │         
      │                   │            │\"Explain lagrange's     │fundamental result in group   │AmazonQ.md, base.md,          
      │                   │            │theorem.\" }"            │theory, which is a branch of  │
      │                   │            │                         │abstract algebra. The theorem │ 
      │                   │            │                         │states that if H is a subgroup│ 
      │                   │            │                         │of a finite group G, then the │      
      │                   │            │                         │order (number of elements) of │
      │                   │            │                         │H divides the order of G....  │         
      │                   │            │                         │                              │ 
      │                   │            │                         │                              │    
      │                   │            │                         │                              │ 
      │                   │            │                         │                              │   
      │                   │            │                         │                              │  
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
