### PR TITLE
Revert "feat: fuzzy select profiles (#1388)"

### DIFF
--- a/crates/q_chat/src/context.rs
+++ b/crates/q_chat/src/context.rs
@@ -229,40 +229,6 @@ impl ContextManager {
         Ok(profiles)
     }
 
-    /// List all available profiles using blocking operations.
-    ///
-    /// Similar to list_profiles but uses synchronous filesystem operations.
-    ///
-    /// # Returns
-    /// A Result containing a vector of profile names, with "default" always first
-    pub fn list_profiles_blocking(&self) -> Result<Vec<String>> {
-        let mut profiles = Vec::new();
-
-        // Always include default profile
-        profiles.push("default".to_string());
-
-        // Read profile directory and extract profile names
-        let profiles_dir = directories::chat_profiles_dir(&self.ctx)?;
-        if profiles_dir.exists() {
-            for entry in std::fs::read_dir(profiles_dir)? {
-                let entry = entry?;
-                let path = entry.path();
-                if let (true, Some(name)) = (path.is_dir(), path.file_name()) {
-                    if name != "default" {
-                        profiles.push(name.to_string_lossy().to_string());
-                    }
-                }
-            }
-        }
-
-        // Sort non-default profiles alphabetically
-        if profiles.len() > 1 {
-            profiles[1..].sort();
-        }
-
-        Ok(profiles)
-    }
-
     /// Clear all paths from the context configuration.
     ///
     /// # Arguments


### PR DESCRIPTION
This reverts commit 99b8eef4a550dd6155941b3f50670a56a019abf0.

However, this PR fails with the same failure as the reverted PR... so I think it's pointless to revert

*Issue #, if available:*

*Description of changes:* Just reverting the PR https://github.com/aws/amazon-q-developer-cli/pull/1388 because the build is failing for macos for very weird reasons... 

```
Run cargo +nightly llvm-cov --locked --workspace --codecov --output-path lcov.info
info: cargo-llvm-cov currently setting cfg(coverage) and cfg(coverage_nightly); you can opt-out it by passing --no-cfg-coverage and --no-cfg-coverage-nightly
 Downloading crates ...
  Downloaded arboard v3.5.0
  Downloaded anstream v0.6.18
  Downloaded arg_enum_proc_macro v0.3.4
  Downloaded allocator-api2 v0.2.21
  Downloaded http-body v1.0.1
  Downloaded async-trait v0.1.87
  Downloaded matchers v0.1.0
  Downloaded malloc_buf v0.0.6
  Downloaded http-body-util v0.1.3
  Downloaded home v0.5.11
  Downloaded maplit v1.0.2
  Downloaded mach2 v0.4.2
  Downloaded lscolors v0.17.0
  Downloaded simd-adler32 v0.3.7
  Downloaded thread_local v1.1.8
  Downloaded wait-timeout v0.2.0
  Downloaded form_urlencoded v1.2.1
  Downloaded profiling v1.0.16
  Downloaded supports-hyperlinks v3.1.0
  Downloaded core-graphics v0.24.0
  Downloaded quick-error v2.0.1
  Downloaded pure-rust-locales v0.8.1
  Downloaded petgraph v0.6.5
  Downloaded nanorand v0.7.0
  Downloaded rgb v0.8.50
  Downloaded rfd v0.15.2
  Downloaded ryu v1.0.18
  Downloaded sys-locale v0.3.2
  Downloaded sysinfo v0.32.1
  Downloaded term v0.7.0
  Downloaded tempfile v3.18.0
  Downloaded rustls-pemfile v1.0.4
  Downloaded tinytemplate v1.2.1
  Downloaded tinystr v0.7.6
  Downloaded typenum v1.17.0
  Downloaded toml_edit v0.22.22
  Downloaded try-lock v0.2.5
  Downloaded wasm-bindgen v0.2.100
  Downloaded wasm-bindgen-backend v0.2.100
  Downloaded tuikit v0.5.0
  Downloaded unicode-segmentation v1.12.0
  Downloaded unicode-linebreak v0.1.5
  Downloaded tokio-macros v2.5.0
  Downloaded unicode-ident v1.0.14
  Downloaded unicode-width v0.1.14
  Downloaded typetag v0.2.19
  Downloaded unicase v2.8.1
  Downloaded typetag-impl v0.2.19
  Downloaded toml v0.8.19
  Downloaded tokio-util v0.7.15
  Downloaded want v0.3.1
  Downloaded walkdir v2.5.0
  Downloaded tray-icon v0.19.2
  Downloaded tinyvec_macros v0.1.1
  Downloaded tinyvec v1.8.1
  Downloaded wasm-bindgen-macro v0.2.100
  Downloaded tracing-log v0.2.0
  Downloaded tracing-error v0.2.1
  Downloaded ring v0.17.14
  Downloaded unicode-width v0.2.0
  Downloaded tracing-test-macro v0.2.5
  Downloaded tower v0.5.2
  Downloaded tokio-rustls v0.26.1
  Downloaded tokio-socks v0.5.2
  Downloaded tracing-core v0.1.33
  Downloaded typeid v1.0.2
  Downloaded tungstenite v0.26.2
  Downloaded tracing-attributes v0.1.28
  Downloaded tracing-appender v0.2.3
  Downloaded tracing v0.1.41
  Downloaded tower-service v0.3.3
  Downloaded tower-layer v0.3.3
  Downloaded toml_datetime v0.6.8
  Downloaded tokio-tungstenite v0.26.2
  Downloaded tokio-rustls v0.24.1
  Downloaded timer v0.2.0
  Downloaded criterion v0.5.1
  Downloaded whoami v1.5.2
  Downloaded webpki-roots v0.26.8
  Downloaded rustls v0.23.23
  Downloaded crc32fast v1.4.2
  Downloaded cpufeatures v0.2.16
  Downloaded xdg-home v1.3.0
  Downloaded wry v0.48.1
  Downloaded writeable v0.5.5
  Downloaded winnow v0.6.22
  Downloaded which v7.0.3
  Downloaded weezl v0.1.8
  Downloaded tokio v1.44.2
  Downloaded web-time v1.1.0
  Downloaded wasm-bindgen-shared v0.2.100
  Downloaded wasm-bindgen-macro-support v0.2.100
  Downloaded tracing-test v0.2.5
  Downloaded tracing-subscriber v0.3.19
  Downloaded tracing-serde v0.2.0
  Downloaded sysinfo v0.33.1
  Downloaded rustls-webpki v0.101.7
  Downloaded rustls v0.21.12
  Downloaded time-macros v0.2.20
  Downloaded write16 v1.0.0
  Downloaded which v6.0.3
  Downloaded tao v0.31.1
  Downloaded rustyline v15.0.0
  Downloaded rustls-webpki v0.102.8
  Downloaded roxmltree v0.14.1
  Downloaded rustyline-derive v0.11.0
  Downloaded rustls-pki-types v1.10.1
  Downloaded rustls-pemfile v2.2.0
  Downloaded rustls-native-certs v0.8.1
  Downloaded rustls-native-certs v0.6.3
  Downloaded rmp-serde v1.3.0
  Downloaded rmp v0.8.14
  Downloaded num-format v0.4.4
  Downloaded nix v0.25.1
  Downloaded nix v0.24.3
  Downloaded tagptr v0.2.0
  Downloaded system-configuration-sys v0.6.0
  Downloaded system-configuration v0.6.1
  Downloaded syntect v5.2.0
  Downloaded syn v2.0.100
  Downloaded serde_urlencoded v0.7.1
  Downloaded semver v1.0.26
  Downloaded same-file v1.0.6
  Downloaded rustversion v1.0.19
  Downloaded regex-automata v0.4.9
  Downloaded nu-protocol v0.103.0
  Downloaded nu-glob v0.103.0
  Downloaded nu-color-config v0.103.0
  Downloaded notify v8.0.0
  Downloaded normalize-line-endings v0.3.0
  Downloaded noop_proc_macro v0.3.0
  Downloaded nix v0.29.0
  Downloaded encoding_rs v0.8.35
  Downloaded syn v1.0.109
  Downloaded serde_yaml v0.9.34+deprecated
  Downloaded security-framework v3.2.0
  Downloaded security-framework v2.11.1
  Downloaded scheduled-thread-pool v0.2.7
  Downloaded num-integer v0.1.46
  Downloaded num-derive v0.4.2
  Downloaded num-conv v0.1.0
  Downloaded num-bigint v0.4.6
  Downloaded nu-utils v0.103.0
  Downloaded nu-system v0.103.0
  Downloaded nu-path v0.103.0
  Downloaded nu-json v0.103.0
  Downloaded nu-engine v0.103.0
  Downloaded nu-derive-value v0.103.0
  Downloaded nu-ansi-term v0.50.1
  Downloaded nu-ansi-term v0.46.0
  Downloaded ntest_timeout v0.9.3
  Downloaded ntest_test_cases v0.9.3
  Downloaded ntest v0.9.3
  Downloaded notify-types v2.0.0
  Downloaded nom v7.1.3
  Downloaded dirs-sys-next v0.1.2
  Downloaded dirs-sys v0.4.1
  Downloaded dirs-next v2.0.0
  Downloaded dirs v5.0.1
  Downloaded digest v0.10.7
  Downloaded difflib v0.4.0
  Downloaded diff v0.1.13
  Downloaded dialoguer v0.11.0
  Downloaded derive_builder_macro v0.20.2
  Downloaded derive_builder_core v0.20.2
  Downloaded derive_builder v0.20.2
  Downloaded derive_arbitrary v1.4.1
  Downloaded deranged v0.3.11
  Downloaded defer-drop v1.3.0
  Downloaded data-encoding v2.6.0
  Downloaded dashmap v6.1.0
  Downloaded darling_core v0.20.11
  Downloaded darling v0.20.11
  Downloaded ctrlc v3.4.6
  Downloaded crossterm v0.28.1
  Downloaded crossbeam-utils v0.8.21
  Downloaded crossbeam-queue v0.3.12
  Downloaded crossbeam-channel v0.5.15
  Downloaded libsqlite3-sys v0.30.1
  Downloaded aws-lc-sys v0.24.1
  Downloaded synstructure v0.13.1
  Downloaded sync_wrapper v1.0.2
  Downloaded supports-unicode v3.0.0
  Downloaded serial v0.4.0
  Downloaded serde_spanned v0.6.8
  Downloaded serde_repr v0.1.20
  Downloaded separator v0.4.1
  Downloaded security-framework-sys v2.14.0
  Downloaded sct v0.7.1
  Downloaded scopeguard v1.2.0
  Downloaded regex-syntax v0.8.5
  Downloaded regex-syntax v0.6.29
  Downloaded objc2 v0.6.0
  Downloaded darling_macro v0.20.11
  Downloaded crypto-common v0.1.6
  Downloaded crossbeam-epoch v0.9.18
  Downloaded crossbeam-deque v0.8.6
  Downloaded crossbeam v0.8.4
  Downloaded criterion-plot v0.5.0
  Downloaded onig_sys v69.8.1
  Downloaded reqwest v0.12.14
  Downloaded regex v1.11.1
  Downloaded rayon v1.10.0
  Downloaded radix_trie v0.2.1
  Downloaded quinn-proto v0.11.9
  Downloaded quick-xml v0.32.0
  Downloaded quick-xml v0.30.0
  Downloaded objc2 v0.5.2
  Downloaded object v0.32.2
  Downloaded objc2-web-kit v0.2.2
  Downloaded objc2-quartz-core v0.2.2
  Downloaded objc2-foundation v0.3.0
  Downloaded objc2-foundation v0.2.2
  Downloaded objc2-core-data v0.2.2
  Downloaded objc2-app-kit v0.3.0
  Downloaded regex-lite v0.1.6
  Downloaded regex-automata v0.1.10
  Downloaded rayon-core v1.12.1
  Downloaded rand v0.9.0
  Downloaded rand v0.8.5
  Downloaded quote v1.0.40
  Downloaded quinn-udp v0.5.9
  Downloaded quinn v0.11.6
  Downloaded num-traits v0.2.19
  Downloaded moka v0.12.10
  Downloaded ordered-stream v0.2.0
  Downloaded ordered-float v2.10.1
  Downloaded option-ext v0.2.0
  Downloaded oorandom v11.1.4
  Downloaded onig v6.4.0
  Downloaded once_cell v1.20.2
  Downloaded objc2-io-surface v0.3.0
  Downloaded objc2-input-method-kit v0.2.2
  Downloaded objc2-encode v4.1.0
  Downloaded objc2-core-graphics v0.3.0
  Downloaded objc2-core-foundation v0.3.0
  Downloaded objc2-app-kit v0.2.2
  Downloaded reqwest_cookie_store v0.8.0
  Downloaded ref-cast-impl v1.0.24
  Downloaded ref-cast v1.0.24
  Downloaded raw-window-handle v0.6.2
  Downloaded r2d2_sqlite v0.25.0
  Downloaded r2d2 v0.8.10
  Downloaded objc-sys v0.3.5
  Downloaded objc v0.2.7
  Downloaded number_prefix v0.4.0
  Downloaded num_threads v0.1.7
  Downloaded num-rational v0.4.2
  Downloaded nibble_vec v0.1.0
  Downloaded new_debug_unreachable v1.0.6
  Downloaded muda v0.15.3
  Downloaded mockito v1.7.0
  Downloaded mio v1.0.3
  Downloaded miniz_oxide v0.8.5
  Downloaded minimal-lexical v0.2.1
  Downloaded mime v0.3.17
  Downloaded miette-derive v7.5.0
  Downloaded miette v7.5.0
  Downloaded memoffset v0.9.1
  Downloaded objc2-metal v0.2.2
  Downloaded objc2-core-image v0.2.2
  Downloaded multimap v0.10.0
  Downloaded miniz_oxide v0.7.4
  Downloaded mimalloc v0.1.46
  Downloaded memoffset v0.6.5
  Downloaded memmem v0.1.1
  Downloaded memchr v2.7.4
  Downloaded maybe-rayon v0.1.1
  Downloaded fs_extra v1.3.0
  Downloaded enumflags2 v0.7.11
  Downloaded endian-type v0.1.2
  Downloaded endi v1.1.0
  Downloaded either v1.13.0
  Downloaded dunce v1.0.5
  Downloaded dpi v0.1.1
  Downloaded downcast-rs v1.2.1
  Downloaded document-features v0.2.10
  Downloaded doc-comment v0.3.3
  Downloaded displaydoc v0.2.5
  Downloaded dispatch v0.2.0
  Downloaded yoke-derive v0.7.5
  Downloaded core-graphics-types v0.2.0
  Downloaded color-eyre v0.6.3
  Downloaded tiff v0.9.1
  Downloaded rav1e v0.7.1
  Downloaded aws-sdk-cognitoidentityprovider v1.63.0
  Downloaded pulldown-cmark v0.13.0
  Downloaded publicsuffix v2.3.0
  Downloaded prost-reflect v0.15.1
  Downloaded prost-reflect v0.14.7
  Downloaded clap_lex v0.7.4
  Downloaded yansi v1.0.1
  Downloaded qoi v0.4.1
  Downloaded prost-derive v0.13.5
  Downloaded prost v0.13.5
  Downloaded profiling-procmacros v1.0.16
  Downloaded pin-project-lite v0.2.16
  Downloaded pin-project-internal v1.1.10
  Downloaded pin-project v1.1.10
  Downloaded percent-encoding v2.3.1
  Downloaded paste v1.0.15
  Downloaded parking_lot_core v0.9.10
  Downloaded parking_lot v0.12.3
  Downloaded parking v2.2.1
  Downloaded owo-colors v4.2.0
  Downloaded owo-colors v3.5.0
  Downloaded overload v0.1.1
  Downloaded outref v0.5.1
  Downloaded clap_builder v4.5.32
  Downloaded zerovec v0.10.4
  Downloaded zerocopy v0.8.23
  Downloaded zerocopy v0.7.35
  Downloaded yoke v0.7.5
  Downloaded yaml-rust v0.4.5
  Downloaded xmlparser v0.13.6
  Downloaded serial-core v0.4.0
  Downloaded enumflags2_derive v0.7.11
  Downloaded utf16_iter v1.0.5
  Downloaded urlencoding v2.1.3
  Downloaded url v2.5.4
  Downloaded unsafe-libyaml v0.2.11
  Downloaded stable_deref_trait v1.2.0
  Downloaded spinners v4.1.1
  Downloaded serde_json v1.0.140
  Downloaded serde_derive v1.0.219
  Downloaded serde v1.0.219
  Downloaded rusqlite v0.32.1
  Downloaded libc v0.2.171
  Downloaded jpeg-decoder v0.3.1
  Downloaded bstr v1.12.0
  Downloaded cocoa-foundation v0.2.0
  Downloaded cocoa v0.26.0
  Downloaded cmake v0.1.52
  Downloaded clap_derive v4.5.32
  Downloaded clap_complete_fig v4.5.2
  Downloaded clap_complete v4.5.46
  Downloaded clap v4.5.32
  Downloaded clang-sys v1.8.1
  Downloaded zvariant_utils v2.1.0
  Downloaded zvariant_derive v4.2.0
  Downloaded zvariant v4.2.0
  Downloaded zune-jpeg v0.4.14
  Downloaded zune-inflate v0.2.54
  Downloaded zune-core v0.4.12
  Downloaded zerovec-derive v0.10.3
  Downloaded zeroize v1.8.1
  Downloaded zerofrom-derive v0.1.5
  Downloaded zerofrom v0.1.5
  Downloaded zerocopy-derive v0.7.35
  Downloaded zbus_xml v4.0.0
  Downloaded zbus_macros v4.4.0
  Downloaded strum_macros v0.27.1
  Downloaded spin v0.9.8
  Downloaded socket2 v0.5.9
  Downloaded skim v0.16.1
  Downloaded similar v2.7.0
  Downloaded shlex v1.3.0
  Downloaded sharded-slab v0.1.7
  Downloaded portable-atomic v1.10.0
  Downloaded png v0.17.16
  Downloaded plotters v0.3.7
  Downloaded exr v1.73.0
  Downloaded utf-8 v0.7.6
  Downloaded untrusted v0.9.0
  Downloaded termios v0.2.2
  Downloaded terminal_size v0.4.1
  Downloaded serde-value v0.7.0
  Downloaded rustc-hash v2.1.0
  Downloaded rustc-hash v1.1.0
  Downloaded rustc-demangle v0.1.24
  Downloaded ravif v0.11.11
  Downloaded rand_core v0.9.3
  Downloaded rand_core v0.6.4
  Downloaded rand_chacha v0.9.0
  Downloaded rand_chacha v0.3.1
  Downloaded prost-types v0.13.5
  Downloaded prost-reflect-derive v0.15.0
  Downloaded prost-reflect-derive v0.14.0
  Downloaded prost-reflect-build v0.14.0
  Downloaded prost-build v0.13.5
  Downloaded proc-macro-error2 v2.0.1
  Downloaded prettyplease v0.2.32
  Downloaded jiff v0.2.8
  Downloaded chrono v0.4.40
  Downloaded cc v1.2.16
  Downloaded bindgen v0.71.1
  Downloaded bindgen v0.70.1
  Downloaded aws-sdk-sts v1.54.0
  Downloaded aws-sdk-cognitoidentity v1.54.0
  Downloaded aws-lc-rs v1.12.0
  Downloaded supports-color v3.0.2
  Downloaded subtle v2.6.1
  Downloaded strum_macros v0.26.4
  Downloaded strum_macros v0.24.3
  Downloaded strum v0.27.1
  Downloaded smallvec v1.13.2
  Downloaded slab v0.4.9
  Downloaded simd_helpers v0.1.0
  Downloaded signal-hook-mio v0.2.4
  Downloaded signal-hook v0.3.17
  Downloaded shellexpand v3.1.1
  Downloaded shell-words v1.1.0
  Downloaded shell-quote v0.7.2
  Downloaded sha2 v0.10.8
  Downloaded sha1 v0.10.6
  Downloaded serial-unix v0.4.0
  Downloaded proc-macro2 v1.0.94
  Downloaded proc-macro-error v1.0.4
  Downloaded proc-macro-crate v3.2.0
  Downloaded pretty_assertions v1.4.1
  Downloaded predicates-tree v1.0.12
  Downloaded predicates-core v1.0.9
  Downloaded predicates v3.1.3
  Downloaded powerfmt v0.2.0
  Downloaded portable-pty v0.8.1
  Downloaded polling v3.7.4
  Downloaded plotters-backend v0.3.7
  Downloaded plist v1.7.1
  Downloaded pkg-config v0.3.31
  Downloaded piper v0.2.4
  Downloaded pin-utils v0.1.0
  Downloaded concurrent-queue v2.5.0
  Downloaded ppv-lite86 v0.2.20
  Downloaded ciborium v0.2.2
  Downloaded cfb v0.7.3
  Downloaded cexpr v0.6.0
  Downloaded cbor-diag v0.1.12
  Downloaded cast v0.3.0
  Downloaded camino v1.1.9
  Downloaded bytes v1.10.1
  Downloaded byteorder v1.5.0
  Downloaded bytemuck v1.21.0
  Downloaded bumpalo v3.16.0
  Downloaded built v0.7.5
  Downloaded bs58 v0.5.1
  Downloaded block2 v0.5.1
  Downloaded bitflags v2.9.0
  Downloaded bit-vec v0.8.0
  Downloaded bincode v1.3.3
  Downloaded base64-simd v0.8.0
  Downloaded base64 v0.22.1
  Downloaded base64 v0.21.7
  Downloaded backtrace v0.3.71
  Downloaded aws-smithy-xml v0.60.9
  Downloaded aws-smithy-types v1.2.11
  Downloaded aws-smithy-runtime-api v1.7.3
  Downloaded aws-smithy-http v0.60.11
  Downloaded aws-smithy-eventstream v0.60.5
  Downloaded aws-smithy-async v1.2.3
  Downloaded aws-sdk-ssooidc v1.54.0
  Downloaded aws-sdk-sso v1.53.0
  Downloaded proc-macro-error-attr2 v2.0.0
  Downloaded proc-macro-error-attr v1.0.4
  Downloaded plotters-svg v0.3.7
  Downloaded foreign-types-shared v0.3.1
  Downloaded fnv v1.0.7
  Downloaded flume v0.11.1
  Downloaded flate2 v1.1.1
  Downloaded filetime v0.2.25
  Downloaded filedescriptor v0.8.3
  Downloaded fdeflate v0.3.7
  Downloaded fd-lock v4.0.4
  Downloaded fastrand v2.3.0
  Downloaded fancy-regex v0.14.0
  Downloaded fallible-streaming-iterator v0.1.9
  Downloaded eyre v0.6.12
  Downloaded event-listener v5.4.0
  Downloaded errno v0.3.10
  Downloaded env_home v0.1.0
  Downloaded env_filter v0.1.3
  Downloaded color-spantrace v0.2.1
  Downloaded rustix v1.0.5
  Downloaded rustix v0.38.44
  Downloaded ciborium-io v0.2.2
  Downloaded chrono-humanize v0.2.3
  Downloaded cfg_aliases v0.2.1
  Downloaded cfg-if v1.0.0
  Downloaded bytes-utils v0.1.4
  Downloaded byteorder-lite v0.1.0
  Downloaded blocking v1.6.1
  Downloaded block-buffer v0.10.4
  Downloaded bitstream-io v2.6.0
  Downloaded bitflags v1.3.2
  Downloaded bit_field v0.10.2
  Downloaded beef v0.5.2
  Downloaded aws-types v1.3.3
  Downloaded aws-smithy-runtime v1.7.6
  Downloaded aws-smithy-query v0.60.7
  Downloaded aws-smithy-protocol-test v0.63.0
  Downloaded aws-smithy-json v0.61.1
  Downloaded aws-smithy-json v0.60.7
  Downloaded aws-sigv4 v1.2.6
  Downloaded aws-http v0.60.6
  Downloaded avif-serialize v0.8.2
  Downloaded av1-grain v0.2.3
  Downloaded foreign-types-macros v0.2.3
  Downloaded foreign-types v0.5.0
  Downloaded foldhash v0.1.4
  Downloaded float-cmp v0.10.0
  Downloaded fixedbitset v0.4.2
  Downloaded fallible-iterator v0.3.0
  Downloaded extend v0.1.2
  Downloaded event-listener-strategy v0.5.3
  Downloaded erased-serde v0.4.5
  Downloaded equivalent v1.0.1
  Downloaded env_logger v0.11.8
  Downloaded core-foundation-sys v0.8.7
  Downloaded core-foundation v0.10.0
  Downloaded core-foundation v0.9.4
  Downloaded cookie_store v0.21.1
  Downloaded cookie v0.18.1
  Downloaded convert_case v0.8.0
  Downloaded console v0.15.10
  Downloaded colored v2.2.0
  Downloaded colorchoice v1.0.3
  Downloaded color_quant v1.1.0
  Downloaded color-print-proc-macro v0.3.7
  Downloaded color-print v0.3.7
  Downloaded vcpkg v0.2.15
  Downloaded time v0.3.39
  Downloaded image v0.25.6
  Downloaded gimli v0.28.1
  Downloaded block v0.1.6
  Downloaded bit-set v0.8.0
  Downloaded aws-credential-types v1.2.1
  Downloaded aws-config v1.5.13
  Downloaded autocfg v1.4.0
  Downloaded vte v0.15.0
  Downloaded vte v0.14.1
  Downloaded vsimd v0.8.0
  Downloaded version_check v0.9.5
  Downloaded v_frame v0.3.8
  Downloaded uuid v1.15.1
  Downloaded utf8parse v0.2.2
  Downloaded utf8_iter v1.0.4
  Downloaded time-core v0.1.3
  Downloaded thiserror-impl v2.0.12
  Downloaded thiserror-impl v1.0.69
  Downloaded thiserror v2.0.12
  Downloaded thiserror v1.0.69
  Downloaded textwrap v0.16.1
  Downloaded test-log v0.2.17
  Downloaded libmimalloc-sys v0.1.42
  Downloaded itertools v0.13.0
  Downloaded icu_properties_data v1.5.0
  Downloaded hyper v1.6.0
  Downloaded hyper v0.14.32
  Downloaded h2 v0.4.7
  Downloaded h2 v0.3.26
  Downloaded futures-util v0.3.31
  Downloaded aws-runtime v1.5.3
  Downloaded test-log-macros v0.2.16
  Downloaded termtree v0.5.1
  Downloaded strum v0.26.3
  Downloaded strum v0.24.1
  Downloaded strsim v0.11.1
  Downloaded strip-ansi-escapes v0.2.1
  Downloaded static_assertions v1.1.0
  Downloaded serde_plain v1.0.2
  Downloaded libfuzzer-sys v0.4.9
  Downloaded itertools v0.12.1
  Downloaded itertools v0.10.5
  Downloaded insta v1.42.2
  Downloaded indicatif v0.17.11
  Downloaded indexmap v2.9.0
  Downloaded idna v1.0.3
  Downloaded icu_collections v1.5.0
  Downloaded hyper-util v0.1.11
  Downloaded http v1.2.0
  Downloaded http v0.2.12
  Downloaded hashbrown v0.15.2
  Downloaded hashbrown v0.14.5
  Downloaded signal-hook-registry v1.4.2
  Downloaded rustc_version v0.4.1
  Downloaded psl-types v2.0.11
  Downloaded log v0.4.27
  Downloaded litrs v0.4.1
  Downloaded libproc v0.14.10
  Downloaded imgref v1.11.0
  Downloaded image-webp v0.2.0
  Downloaded icu_provider v1.5.0
  Downloaded icu_properties v1.5.1
  Downloaded icu_normalizer_data v1.5.0
  Downloaded icu_normalizer v1.5.0
  Downloaded icu_locid_transform_data v1.5.0
  Downloaded icu_locid_transform v1.5.0
  Downloaded icu_locid v1.5.0
  Downloaded iana-time-zone v0.1.61
  Downloaded hyper-rustls v0.27.5
  Downloaded hyper-rustls v0.24.2
  Downloaded httparse v1.9.5
  Downloaded hmac v0.12.1
  Downloaded half v2.4.1
  Downloaded gif v0.13.1
  Downloaded getrandom v0.3.1
  Downloaded getrandom v0.2.15
  Downloaded fuzzy-matcher v0.3.7
  Downloaded futures-lite v2.6.0
  Downloaded futures-channel v0.3.31
  Downloaded futures v0.3.31
  Downloaded async-recursion v1.1.1
  Downloaded lru v0.12.5
  Downloaded lock_api v0.4.12
  Downloaded litemap v0.7.4
  Downloaded libloading v0.8.6
  Downloaded lazy_static v1.5.0
  Downloaded keyboard-types v0.7.0
  Downloaded jobserver v0.1.32
  Downloaded itoa v1.0.14
  Downloaded is_terminal_polyfill v1.70.1
  Downloaded ipnet v2.10.1
  Downloaded ioctl-rs v0.1.6
  Downloaded hashlink v0.9.1
  Downloaded globset v0.4.16
  Downloaded async-task v4.7.1
  Downloaded linked-hash-map v0.5.6
  Downloaded infer v0.19.0
  Downloaded indenter v0.3.3
  Downloaded idna_adapter v1.2.0
  Downloaded httpdate v1.0.3
  Downloaded futures-sink v0.3.31
  Downloaded futures-io v0.3.31
  Downloaded futures-executor v0.3.31
  Downloaded fsevent-sys v4.1.0
  Downloaded async-executor v1.13.1
  Downloaded assert-json-diff v2.0.2
  Downloaded assert-json-diff v1.1.0
  Downloaded anstyle v1.0.10
  Downloaded aligned-vec v0.5.0
  Downloaded aho-corasick v1.1.3
  Downloaded loop9 v0.1.5
  Downloaded lebe v0.5.2
  Downloaded is-terminal v0.4.13
  Downloaded inventory v0.3.17
  Downloaded indoc v2.0.6
  Downloaded icu_provider_macros v1.5.0
  Downloaded http-body v0.4.6
  Downloaded hex v0.4.3
  Downloaded heck v0.5.0
  Downloaded heck v0.4.1
  Downloaded futures-task v0.3.31
  Downloaded async-io v2.4.0
  Downloaded anyhow v1.0.98
  Downloaded generic-array v0.14.7
  Downloaded futures-macro v0.3.31
  Downloaded futures-core v0.3.31
  Downloaded ciborium-ll v0.2.2
  Downloaded atomic-waker v1.1.2
  Downloaded async-fs v2.1.2
  Downloaded glob v0.3.2
  Downloaded async-lock v3.4.0
  Downloaded arbitrary v1.4.1
  Downloaded anstyle-parse v0.2.6
  Downloaded adler2 v2.0.0
  Downloaded is_ci v1.2.0
  Downloaded ident_case v1.0.1
  Downloaded async-compression v0.4.18
  Downloaded async-channel v2.3.1
  Downloaded arrayvec v0.7.6
  Downloaded apple-bundle v0.1.4
  Downloaded async-signal v0.2.10
  Downloaded async-broadcast v0.7.2
  Downloaded assert_cmd v2.0.16
  Downloaded adler v1.0.2
  Downloaded addr2line v0.21.0
  Downloaded async-process v2.3.0
  Downloaded anstyle-query v1.1.2
  Downloaded anes v0.1.6
  Downloaded ahash v0.8.11
   Compiling proc-macro2 v1.0.94
   Compiling unicode-ident v1.0.14
   Compiling libc v0.2.171
   Compiling serde v1.0.219
   Compiling cfg-if v1.0.0
   Compiling autocfg v1.4.0
   Compiling quote v1.0.40
   Compiling syn v2.0.100
   Compiling memchr v2.7.4
   Compiling once_cell v1.20.2
   Compiling log v0.4.27
   Compiling itoa v1.0.14
   Compiling shlex v1.3.0
   Compiling pin-project-lite v0.2.16
   Compiling equivalent v1.0.1
   Compiling smallvec v1.13.2
   Compiling lock_api v0.4.12
   Compiling bytes v1.10.1
   Compiling scopeguard v1.2.0
   Compiling parking_lot_core v0.9.10
   Compiling jobserver v0.1.32
   Compiling allocator-api2 v0.2.21
   Compiling cc v1.2.16
   Compiling foldhash v0.1.4
   Compiling ryu v1.0.18
   Compiling hashbrown v0.15.2
   Compiling futures-core v0.3.31
   Compiling signal-hook-registry v1.4.2
   Compiling core-foundation-sys v0.8.7
   Compiling num-traits v0.2.19
   Compiling mio v1.0.3
   Compiling tracing-core v0.1.33
   Compiling socket2 v0.5.9
   Compiling either v1.13.0
   Compiling crossbeam-utils v0.8.21
   Compiling version_check v0.9.5
   Compiling fnv v1.0.7
   Compiling serde_json v1.0.140
   Compiling serde_derive v1.0.219
   Compiling tokio-macros v2.5.0
   Compiling tracing-attributes v0.1.28
   Compiling powerfmt v0.2.0
   Compiling minimal-lexical v0.2.1
   Compiling futures-sink v0.3.31
   Compiling nom v7.1.3
   Compiling tracing v0.1.41
   Compiling num-conv v0.1.0
   Compiling time-core v0.1.3
   Compiling regex-syntax v0.8.5
   Compiling aho-corasick v1.1.3
   Compiling futures-io v0.3.31
   Compiling regex-automata v0.4.9
   Compiling byteorder v1.5.0
   Compiling bitflags v2.9.0
   Compiling parking_lot v0.12.3
   Compiling indexmap v2.9.0
   Compiling tokio v1.44.2
   Compiling deranged v0.3.11
   Compiling time-macros v0.2.20
   Compiling zerocopy-derive v0.7.35
   Compiling num_threads v0.1.7
   Compiling time v0.3.39
   Compiling zerocopy v0.7.35
   Compiling getrandom v0.3.1
   Compiling getrandom v0.2.15
   Compiling thiserror v1.0.69
   Compiling ppv-lite86 v0.2.20
   Compiling thiserror-impl v1.0.69
   Compiling fastrand v2.3.0
   Compiling pin-utils v0.1.0
   Compiling regex v1.11.1
   Compiling slab v0.4.9
   Compiling zerocopy v0.8.23
   Compiling rand_core v0.9.3
   Compiling rand_chacha v0.9.0
   Compiling errno v0.3.10
   Compiling subtle v2.6.1
   Compiling typenum v1.17.0
   Compiling tokio-util v0.7.15
   Compiling generic-array v0.14.7
   Compiling futures-channel v0.3.31
   Compiling rand v0.9.0
   Compiling futures-macro v0.3.31
   Compiling crc32fast v1.4.2
   Compiling futures-task v0.3.31
   Compiling rayon-core v1.12.1
   Compiling futures-util v0.3.31
   Compiling crypto-common v0.1.6
   Compiling block-buffer v0.10.4
   Compiling itertools v0.13.0
   Compiling synstructure v0.13.1
   Compiling digest v0.10.7
   Compiling zerofrom-derive v0.1.5
   Compiling http v1.2.0
   Compiling cpufeatures v0.2.16
   Compiling zerofrom v0.1.5
   Compiling yoke-derive v0.7.5
   Compiling stable_deref_trait v1.2.0
   Compiling zerovec-derive v0.10.3
   Compiling rustix v0.38.44
   Compiling uuid v1.15.1
   Compiling yoke v0.7.5
   Compiling displaydoc v0.2.5
   Compiling memoffset v0.9.1
   Compiling zerovec v0.10.4
   Compiling cfg_aliases v0.2.1
   Compiling nix v0.29.0
   Compiling crossbeam-epoch v0.9.18
   Compiling hex v0.4.3
   Compiling glob v0.3.2
   Compiling clang-sys v1.8.1
   Compiling tinystr v0.7.6
   Compiling http-body v1.0.1
   Compiling writeable v0.5.5
   Compiling litemap v0.7.4
   Compiling icu_locid v1.5.0
   Compiling crossbeam-deque v0.8.6
   Compiling icu_provider_macros v1.5.0
   Compiling lazy_static v1.5.0
   Compiling icu_provider v1.5.0
   Compiling sha2 v0.10.8
   Compiling percent-encoding v2.3.1
   Compiling heck v0.5.0
   Compiling icu_locid_transform_data v1.5.0
   Compiling icu_locid_transform v1.5.0
   Compiling icu_collections v1.5.0
   Compiling ring v0.17.14
   Compiling libloading v0.8.6
   Compiling icu_properties_data v1.5.0
   Compiling icu_properties v1.5.1
   Compiling http-body-util v0.1.3
   Compiling cexpr v0.6.0
   Compiling num-integer v0.1.46
   Compiling utf8_iter v1.0.4
   Compiling write16 v1.0.0
   Compiling icu_normalizer_data v1.5.0
   Compiling utf16_iter v1.0.5
   Compiling thiserror v2.0.12
   Compiling zeroize v1.8.1
   Compiling icu_normalizer v1.5.0
   Compiling rayon v1.10.0
   Compiling form_urlencoded v1.2.1
   Compiling thiserror-impl v2.0.12
   Compiling paste v1.0.15
   Compiling idna_adapter v1.2.0
   Compiling thread_local v1.1.8
   Compiling httparse v1.9.5
   Compiling untrusted v0.9.0
   Compiling idna v1.0.3
   Compiling http v0.2.12
   Compiling iana-time-zone v0.1.61
   Compiling core-foundation v0.10.0
   Compiling unicase v2.8.1
   Compiling objc2-encode v4.1.0
   Compiling prettyplease v0.2.32
   Compiling regex-syntax v0.6.29
   Compiling pure-rust-locales v0.8.1
   Compiling rustix v1.0.5
   Compiling chrono v0.4.40
   Compiling regex-automata v0.1.10
   Compiling syn v1.0.109
   Compiling overload v0.1.1
   Compiling rustversion v1.0.19
   Compiling nu-ansi-term v0.46.0
   Compiling matchers v0.1.0
   Compiling http-body v0.4.6
   Compiling url v2.5.4
   Compiling sharded-slab v0.1.7
   Compiling terminal_size v0.4.1
   Compiling tracing-serde v0.2.0
   Compiling tracing-log v0.2.0
   Compiling try-lock v0.2.5
   Compiling want v0.3.1
   Compiling tracing-subscriber v0.3.19
   Compiling security-framework-sys v2.14.0
   Compiling tower-service v0.3.3
   Compiling outref v0.5.1
   Compiling vsimd v0.8.0
   Compiling option-ext v0.2.0
   Compiling httpdate v1.0.3
   Compiling dirs-sys v0.4.1
   Compiling base64-simd v0.8.0
   Compiling bytes-utils v0.1.4
   Compiling objc-sys v0.3.5
   Compiling half v2.4.1
   Compiling unicode-width v0.2.0
   Compiling aws-smithy-types v1.2.11
   Compiling dirs v5.0.1
   Compiling strsim v0.11.1
   Compiling objc2 v0.5.2
   Compiling core-graphics-types v0.2.0
   Compiling foreign-types-macros v0.2.3
   Compiling dispatch v0.2.0
   Compiling foreign-types-shared v0.3.1
   Compiling anstyle v1.0.10
   Compiling foreign-types v0.5.0
   Compiling block2 v0.5.1
   Compiling num-bigint v0.4.6
   Compiling malloc_buf v0.0.6
   Compiling utf8parse v0.2.2
   Compiling simd-adler32 v0.3.7
   Compiling objc v0.2.7
   Compiling objc2-foundation v0.2.2
   Compiling num-rational v0.4.2
   Compiling core-graphics v0.24.0
   Compiling aws-smithy-async v1.2.3
   Compiling ahash v0.8.11
   Compiling proc-macro-error-attr v1.0.4
   Compiling aws-smithy-runtime-api v1.7.3
   Compiling anstyle-parse v0.2.6
   Compiling proc-macro-error v1.0.4
   Compiling colorchoice v1.0.3
   Compiling semver v1.0.26
   Compiling anstyle-query v1.1.2
   Compiling bindgen v0.71.1
   Compiling pulldown-cmark v0.13.0
   Compiling adler2 v2.0.0
   Compiling is_terminal_polyfill v1.70.1
   Compiling anstream v0.6.18
   Compiling miniz_oxide v0.8.5
   Compiling objc2-app-kit v0.2.2
   Compiling core-foundation v0.9.4
   Compiling ciborium-io v0.2.2
   Compiling block v0.1.6
   Compiling data-encoding v2.6.0
   Compiling rustls v0.21.12
   Compiling rustc-hash v2.1.0
   Compiling cocoa-foundation v0.2.0
   Compiling ciborium-ll v0.2.2
   Compiling hashbrown v0.14.5
   Compiling rustls-webpki v0.101.7
   Compiling sct v0.7.1
   Compiling anyhow v1.0.98
   Compiling base64 v0.21.7
   Compiling clap_lex v0.7.4
   Compiling xmlparser v0.13.6
   Compiling rustls-pemfile v1.0.4
   Compiling appkit-nsworkspace-bindings v1.8.1 (/Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/crates/macos-utils/appkit-nsworkspace-bindings)
   Compiling clap_builder v4.5.32
   Compiling clap_derive v4.5.32
   Compiling rustc_version v0.4.1
   Compiling extend v0.1.2
   Compiling ciborium v0.2.2
   Compiling cocoa v0.26.0
   Compiling security-framework v2.11.1
   Compiling tempfile v3.18.0
   Compiling aws-smithy-eventstream v0.60.5
   Compiling h2 v0.3.26
   Compiling yansi v1.0.1
   Compiling camino v1.1.9
   Compiling bs58 v0.5.1
   Compiling separator v0.4.1
   Compiling diff v0.1.13
   Compiling cbor-diag v0.1.12
   Compiling pretty_assertions v1.4.1
   Compiling aws-smithy-http v0.60.11
   Compiling rustls-native-certs v0.6.3
   Compiling assert-json-diff v1.1.0
   Compiling aws-types v1.3.3
   Compiling tokio-rustls v0.24.1
   Compiling clap v4.5.32
   Compiling hyper v0.14.32
   Compiling roxmltree v0.14.1
   Compiling flate2 v1.1.1
   Compiling aws-credential-types v1.2.1
   Compiling accessibility-sys v0.1.3 (/Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/crates/macos-utils/accessibility-master/accessibility-sys)
   Compiling regex-lite v0.1.6
   Compiling aws-smithy-protocol-test v0.63.0
   Compiling hyper-rustls v0.24.2
   Compiling hmac v0.12.1
   Compiling nanorand v0.7.0
   Compiling spin v0.9.8
   Compiling aws-sigv4 v1.2.6
   Compiling flume v0.11.1
   Compiling aws-smithy-runtime v1.7.6
   Compiling accessibility v0.1.6 (/Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/crates/macos-utils/accessibility-master/accessibility)
   Compiling dashmap v6.1.0
   Compiling sysinfo v0.32.1
error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:575262
  |
3 | ...> boolean_t { unsafe { :: std :: mem :: transmute (self . _bitfield_1 . get (2usize , 30u8) as u32) } } # [inline] pub fn set_pad1 (& ...
  |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `u32::cast_signed(self . _bitfield_1 . get (2usize , 30u8) as u32)`
  |
  = note: `-D unnecessary-transmutes` implied by `-D warnings`
  = help: to override `-D warnings` add `#[allow(unnecessary_transmutes)]`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:575428
  |
3 | ...unsafe { let val : u32 = :: std :: mem :: transmute (val) ; self . _bitfield_1 . set (2usize , 30u8 , val as u64) } } # [inline] pub u...
  |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `i32::cast_unsigned(val)`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:575601
  |
3 | ... { :: std :: mem :: transmute (< __BindgenBitfieldUnit < [u8 ; 4usize] > > :: raw_get (:: std :: ptr :: addr_of ! ((* this) . _bitfield_1) , 2usize , 30u8 ,) as u32) } ...
  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `u32::cast_signed(< __BindgenBitfieldUnit < [u8 ; 4usize] > > :: raw_get (:: std :: ptr :: addr_of ! ((* this) . _bitfield_1) , 2usize , 30u8 ,) as u32)`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:575871
  |
3 | ...unsafe { let val : u32 = :: std :: mem :: transmute (val) ; < __BindgenBitfieldUnit < [u8 ; 4usize] > > :: raw_set (:: std :: ptr :: a...
  |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `i32::cast_unsigned(val)`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:576678
  |
3 | ...t pad1 : u32 = unsafe { :: std :: mem :: transmute (pad1) } ; pad1 as u64 }) ; __bindgen_bitfield_unit } } pub type mach_port_qos_t = ...
  |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `i32::cast_unsigned(pad1)`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:684825
  |
3 | ...> boolean_t { unsafe { :: std :: mem :: transmute (self . _bitfield_1 . get (0usize , 8u8) as u32) } } # [inline] pub fn set_deallocat...
  |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `u32::cast_signed(self . _bitfield_1 . get (0usize , 8u8) as u32)`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:684996
  |
3 | ...unsafe { let val : u32 = :: std :: mem :: transmute (val) ; self . _bitfield_1 . set (0usize , 8u8 , val as u64) } } # [inline] pub un...
  |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `i32::cast_unsigned(val)`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:685174
  |
3 | ... { :: std :: mem :: transmute (< __BindgenBitfieldUnit < [u8 ; 4usize] > > :: raw_get (:: std :: ptr :: addr_of ! ((* this) . _bitfield_1) , 0usize , 8u8 ,) as u32) } ...
  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `u32::cast_signed(< __BindgenBitfieldUnit < [u8 ; 4usize] > > :: raw_get (:: std :: ptr :: addr_of ! ((* this) . _bitfield_1) , 0usize , 8u8 ,) as u32)`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:685449
  |
3 | ...unsafe { let val : u32 = :: std :: mem :: transmute (val) ; < __BindgenBitfieldUnit < [u8 ; 4usize] > > :: raw_set (:: std :: ptr :: a...
  |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `i32::cast_unsigned(val)`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:688769
  |
3 | ... : u32 = unsafe { :: std :: mem :: transmute (deallocate) } ; deallocate as u64 }) ; __bindgen_bitfield_unit . set (8usize , 8u8 , { l...
  |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `i32::cast_unsigned(deallocate)`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:690203
  |
3 | ...> boolean_t { unsafe { :: std :: mem :: transmute (self . _bitfield_1 . get (0usize , 8u8) as u32) } } # [inline] pub fn set_deallocat...
  |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `u32::cast_signed(self . _bitfield_1 . get (0usize , 8u8) as u32)`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:690374
  |
3 | ...unsafe { let val : u32 = :: std :: mem :: transmute (val) ; self . _bitfield_1 . set (0usize , 8u8 , val as u64) } } # [inline] pub un...
  |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `i32::cast_unsigned(val)`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:690552
  |
3 | ... { :: std :: mem :: transmute (< __BindgenBitfieldUnit < [u8 ; 4usize] > > :: raw_get (:: std :: ptr :: addr_of ! ((* this) . _bitfield_1) , 0usize , 8u8 ,) as u32) } ...
  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `u32::cast_signed(< __BindgenBitfieldUnit < [u8 ; 4usize] > > :: raw_get (:: std :: ptr :: addr_of ! ((* this) . _bitfield_1) , 0usize , 8u8 ,) as u32)`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:690827
  |
3 | ...unsafe { let val : u32 = :: std :: mem :: transmute (val) ; < __BindgenBitfieldUnit < [u8 ; 4usize] > > :: raw_set (:: std :: ptr :: a...
  |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `i32::cast_unsigned(val)`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:694147
  |
3 | ... : u32 = unsafe { :: std :: mem :: transmute (deallocate) } ; deallocate as u64 }) ; __bindgen_bitfield_unit . set (8usize , 8u8 , { l...
  |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `i32::cast_unsigned(deallocate)`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:695593
  |
3 | ...> boolean_t { unsafe { :: std :: mem :: transmute (self . _bitfield_1 . get (0usize , 8u8) as u32) } } # [inline] pub fn set_deallocat...
  |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `u32::cast_signed(self . _bitfield_1 . get (0usize , 8u8) as u32)`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:695764
  |
3 | ...unsafe { let val : u32 = :: std :: mem :: transmute (val) ; self . _bitfield_1 . set (0usize , 8u8 , val as u64) } } # [inline] pub un...
  |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `i32::cast_unsigned(val)`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:695942
  |
3 | ... { :: std :: mem :: transmute (< __BindgenBitfieldUnit < [u8 ; 4usize] > > :: raw_get (:: std :: ptr :: addr_of ! ((* this) . _bitfield_1) , 0usize , 8u8 ,) as u32) } ...
  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `u32::cast_signed(< __BindgenBitfieldUnit < [u8 ; 4usize] > > :: raw_get (:: std :: ptr :: addr_of ! ((* this) . _bitfield_1) , 0usize , 8u8 ,) as u32)`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:696217
  |
3 | ...unsafe { let val : u32 = :: std :: mem :: transmute (val) ; < __BindgenBitfieldUnit < [u8 ; 4usize] > > :: raw_set (:: std :: ptr :: a...
  |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `i32::cast_unsigned(val)`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:699537
  |
3 | ... : u32 = unsafe { :: std :: mem :: transmute (deallocate) } ; deallocate as u64 }) ; __bindgen_bitfield_unit . set (8usize , 8u8 , { l...
  |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `i32::cast_unsigned(deallocate)`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:701020
  |
3 | ...> boolean_t { unsafe { :: std :: mem :: transmute (self . _bitfield_1 . get (0usize , 8u8) as u32) } } # [inline] pub fn set_deallocat...
  |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `u32::cast_signed(self . _bitfield_1 . get (0usize , 8u8) as u32)`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:701191
  |
3 | ...unsafe { let val : u32 = :: std :: mem :: transmute (val) ; self . _bitfield_1 . set (0usize , 8u8 , val as u64) } } # [inline] pub un...
  |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `i32::cast_unsigned(val)`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:701369
  |
3 | ... { :: std :: mem :: transmute (< __BindgenBitfieldUnit < [u8 ; 4usize] > > :: raw_get (:: std :: ptr :: addr_of ! ((* this) . _bitfield_1) , 0usize , 8u8 ,) as u32) } ...
  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `u32::cast_signed(< __BindgenBitfieldUnit < [u8 ; 4usize] > > :: raw_get (:: std :: ptr :: addr_of ! ((* this) . _bitfield_1) , 0usize , 8u8 ,) as u32)`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:701644
  |
3 | ...unsafe { let val : u32 = :: std :: mem :: transmute (val) ; < __BindgenBitfieldUnit < [u8 ; 4usize] > > :: raw_set (:: std :: ptr :: a...
  |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `i32::cast_unsigned(val)`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:704954
  |
3 | ... : u32 = unsafe { :: std :: mem :: transmute (deallocate) } ; deallocate as u64 }) ; __bindgen_bitfield_unit . set (8usize , 8u8 , { l...
  |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `i32::cast_unsigned(deallocate)`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:706472
  |
3 | ...> boolean_t { unsafe { :: std :: mem :: transmute (self . _bitfield_1 . get (0usize , 8u8) as u32) } } # [inline] pub fn set_deallocat...
  |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `u32::cast_signed(self . _bitfield_1 . get (0usize , 8u8) as u32)`

   Compiling strum_macros v0.27.1
error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:706643
  |
3 | ...unsafe { let val : u32 = :: std :: mem :: transmute (val) ; self . _bitfield_1 . set (0usize , 8u8 , val as u64) } } # [inline] pub un...
  |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `i32::cast_unsigned(val)`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:706821
  |
3 | ... { :: std :: mem :: transmute (< __BindgenBitfieldUnit < [u8 ; 4usize] > > :: raw_get (:: std :: ptr :: addr_of ! ((* this) . _bitfield_1) , 0usize , 8u8 ,) as u32) } ...
  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `u32::cast_signed(< __BindgenBitfieldUnit < [u8 ; 4usize] > > :: raw_get (:: std :: ptr :: addr_of ! ((* this) . _bitfield_1) , 0usize , 8u8 ,) as u32)`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:707096
  |
3 | ...unsafe { let val : u32 = :: std :: mem :: transmute (val) ; < __BindgenBitfieldUnit < [u8 ; 4usize] > > :: raw_set (:: std :: ptr :: a...
  |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `i32::cast_unsigned(val)`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:710406
  |
3 | ... : u32 = unsafe { :: std :: mem :: transmute (deallocate) } ; deallocate as u64 }) ; __bindgen_bitfield_unit . set (8usize , 8u8 , { l...
  |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `i32::cast_unsigned(deallocate)`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:711936
  |
3 | ...> boolean_t { unsafe { :: std :: mem :: transmute (self . _bitfield_1 . get (0usize , 8u8) as u32) } } # [inline] pub fn set_deallocat...
  |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `u32::cast_signed(self . _bitfield_1 . get (0usize , 8u8) as u32)`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:712107
  |
3 | ...unsafe { let val : u32 = :: std :: mem :: transmute (val) ; self . _bitfield_1 . set (0usize , 8u8 , val as u64) } } # [inline] pub un...
  |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `i32::cast_unsigned(val)`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:712285
  |
3 | ... { :: std :: mem :: transmute (< __BindgenBitfieldUnit < [u8 ; 4usize] > > :: raw_get (:: std :: ptr :: addr_of ! ((* this) . _bitfield_1) , 0usize , 8u8 ,) as u32) } ...
  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `u32::cast_signed(< __BindgenBitfieldUnit < [u8 ; 4usize] > > :: raw_get (:: std :: ptr :: addr_of ! ((* this) . _bitfield_1) , 0usize , 8u8 ,) as u32)`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:712560
  |
3 | ...unsafe { let val : u32 = :: std :: mem :: transmute (val) ; < __BindgenBitfieldUnit < [u8 ; 4usize] > > :: raw_set (:: std :: ptr :: a...
  |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `i32::cast_unsigned(val)`

error: unnecessary transmute
 --> /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target/debug/build/appkit-nsworkspace-bindings-83c164f3176ad361/out/nsworkspace.rs:3:715870
  |
3 | ... : u32 = unsafe { :: std :: mem :: transmute (deallocate) } ; deallocate as u64 }) ; __bindgen_bitfield_unit . set (8usize , 8u8 , { l...
  |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this with: `i32::cast_unsigned(deallocate)`

error: could not compile `appkit-nsworkspace-bindings` (lib) due to 35 previous errors
warning: build failed, waiting for other jobs to finish...
error: process didn't exit successfully: `/Users/runner/.rustup/toolchains/nightly-aarch64-apple-darwin/bin/cargo test --tests --manifest-path /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/Cargo.toml --target-dir /Users/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/target/llvm-cov-target --locked --workspace` (exit status: 101)
Error: Process completed with exit code 1.


```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
