### PR TITLE
fix: sets custom tool flag for custom tools

### DIFF
--- a/crates/q_chat/src/lib.rs
+++ b/crates/q_chat/src/lib.rs
@@ -2760,6 +2760,7 @@ impl ChatContext {
                 tool_telemetry = tool_telemetry.and_modify(|ev| {
                     ev.custom_tool_call_latency = Some(tool_time.as_secs() as usize);
                     ev.input_token_size = Some(ct.get_input_token_size());
+                    ev.is_custom_tool = true;
                 });
             }
             let tool_time = format!("{}.{}", tool_time.as_secs(), tool_time.subsec_millis());


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Sets the custom tool flag to true for custom tools. 
This is done to correctly reflect the number of custom tool invocation in the telemetry.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
