### PR TITLE
fix: clean up formatting before prompting for input

### DIFF
--- a/crates/q_chat/src/lib.rs
+++ b/crates/q_chat/src/lib.rs
@@ -824,6 +824,7 @@ impl ChatContext {
             if self.interactive {
                 execute!(
                     self.output,
+                    style::SetAttribute(Attribute::Reset),
                     style::SetForegroundColor(Color::Magenta),
                     style::Print("> "),
                     style::SetAttribute(Attribute::Reset),
@@ -1281,7 +1282,11 @@ impl ChatContext {
             self.input_source
                 .put_skim_command_selector(Arc::new(context_manager.clone()), tool_names);
         }
-
+        execute!(
+            self.output,
+            style::SetForegroundColor(Color::Reset),
+            style::SetAttribute(Attribute::Reset)
+        )?;
         let user_input = match self.read_user_input(&self.generate_tool_trust_prompt(), false) {
             Some(input) => input,
             None => return Ok(ChatState::Exit),
@@ -1479,6 +1484,7 @@ impl ChatContext {
                             // Display the content as if the user typed it
                             execute!(
                                 self.output,
+                                style::SetAttribute(Attribute::Reset),
                                 style::SetForegroundColor(Color::Magenta),
                                 style::Print("> "),
                                 style::SetAttribute(Attribute::Reset),


### PR DESCRIPTION
#1376 

Fixed:
<img width="451" alt="Screenshot 2025-04-29 at 1 35 48 PM" src="https://github.com/user-attachments/assets/64486856-ea0e-4840-b41e-73b578e07bc8" />
