### PR TITLE
fix: modal not closing during login after selecting a profile

### DIFF
--- a/packages/dashboard-app/src/components/installs/modal/login/index.tsx
+++ b/packages/dashboard-app/src/components/installs/modal/login/index.tsx
@@ -172,6 +172,7 @@ export default function LoginModal({ next }: { next: () => void }) {
       next={() => {
         refreshAuth();
         setLoginState("logged in");
+        setShowProfileTab(false);
       }}
       back={() => {
         setLoginState("not started");


### PR DESCRIPTION
*Description of changes:*
- Fixes the issue with the profile modal not closing after selecting a profile

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
