### PR TITLE
fix: add profile arn in user profile subcommand and dashboard

### DIFF
--- a/crates/q_cli/src/cli/user.rs
+++ b/crates/q_cli/src/cli/user.rs
@@ -411,7 +411,10 @@ async fn select_profile_interactive(whoami: bool) -> Result<()> {
         )?);
     }
 
-    let mut items: Vec<String> = profiles.iter().map(|p| p.profile_name.clone()).collect();
+    let mut items: Vec<String> = profiles
+        .iter()
+        .map(|p| format!("{} (arn: {})", p.profile_name, p.arn))
+        .collect();
     let active_profile: Option<Profile> = fig_settings::state::get("api.codewhisperer.profile")?;
 
     if let Some(default_idx) = active_profile

--- a/packages/dashboard-app/src/components/ui/select.tsx
+++ b/packages/dashboard-app/src/components/ui/select.tsx
@@ -75,7 +75,7 @@ SelectLabel.displayName = SelectPrimitive.Label.displayName;
 const SelectItem = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item> & {
-    description?: string         
+    description?: string;
   }
 >(({ className, children, description, ...props }, ref) => (
   <SelectPrimitive.Item

--- a/packages/dashboard-app/src/components/ui/select.tsx
+++ b/packages/dashboard-app/src/components/ui/select.tsx
@@ -74,8 +74,10 @@ SelectLabel.displayName = SelectPrimitive.Label.displayName;
 
 const SelectItem = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item> & {
+    description?: string         
+  }
+>(({ className, children, description, ...props }, ref) => (
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
@@ -91,6 +93,11 @@ const SelectItem = React.forwardRef<
     </span>
 
     <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    {description && (
+      <span className="pl-1 text-xs text-muted-foreground break-all">
+        {description}
+      </span>
+    )}
   </SelectPrimitive.Item>
 ));
 SelectItem.displayName = SelectPrimitive.Item.displayName;

--- a/packages/dashboard-app/src/pages/settings/preferences.tsx
+++ b/packages/dashboard-app/src/pages/settings/preferences.tsx
@@ -116,7 +116,7 @@ export default function Page() {
                           <SelectItem
                             key={p.arn}
                             value={p.arn}
-                            description={p.arn}  
+                            description={p.arn}
                           >
                             {p.profileName}
                           </SelectItem>

--- a/packages/dashboard-app/src/pages/settings/preferences.tsx
+++ b/packages/dashboard-app/src/pages/settings/preferences.tsx
@@ -113,7 +113,11 @@ export default function Page() {
                     <SelectContent>
                       {profiles &&
                         profiles.map((p) => (
-                          <SelectItem key={p.arn} value={p.arn}>
+                          <SelectItem
+                            key={p.arn}
+                            value={p.arn}
+                            description={p.arn}  
+                          >
                             {p.profileName}
                           </SelectItem>
                         ))}


### PR DESCRIPTION
*Issue #, if available:*

- Updated the `SelectItem` component to accept an optional `description` prop.
- In the profile dropdown, passed `profile.arn` as the description

This helps users distinguish between profiles with the same name but different ARNs, especially in multi-account or multi-region setups.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
