### PR TITLE
fix(chat): Prevent guide text output in no-interactive mode

### DIFF
--- a/crates/q_chat/src/lib.rs
+++ b/crates/q_chat/src/lib.rs
@@ -789,20 +789,22 @@ impl ChatContext {
                 .set_value("chat.greeting.rotating_tips_current_index", next_tip_index)?;
         }
 
-        execute!(
-            self.output,
-            style::Print(if is_small_screen {
-                SMALL_SCREEN_POPULAR_SHORTCUTS
-            } else {
-                POPULAR_SHORTCUTS
-            }),
-            style::Print(
-                "━"
-                    .repeat(if is_small_screen { 0 } else { GREETING_BREAK_POINT })
-                    .dark_grey()
-            )
-        )?;
-        execute!(self.output, style::Print("\n"), style::SetForegroundColor(Color::Reset))?;
+        if self.interactive {
+            execute!(
+                self.output,
+                style::Print(if is_small_screen {
+                    SMALL_SCREEN_POPULAR_SHORTCUTS
+                } else {
+                    POPULAR_SHORTCUTS
+                }),
+                style::Print(
+                    "━"
+                        .repeat(if is_small_screen { 0 } else { GREETING_BREAK_POINT })
+                        .dark_grey()
+                )
+            )?;
+            execute!(self.output, style::Print("\n"), style::SetForegroundColor(Color::Reset))?;
+        }
         if self.interactive && self.all_tools_trusted() {
             queue!(
                 self.output,


### PR DESCRIPTION
*Issue #, if available:*

#1373 

*Description of changes:*

Fixed an issue where the guide text (shortcuts and separator line) was being output in no-interactive mode. 
Modified the code in crates/q_chat/src/lib.rs to wrap the UI guide text display code with `self.interactive`, ensuring that guide text is only displayed in interactive mode.

This change fixes the issue, however, I think we should create a follow-up task to review and refactor interactive mode handling more comprehensively.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
