### PR TITLE
fix(chat): Remove duplicate /context command help text

### DIFF
--- a/crates/q_chat/src/lib.rs
+++ b/crates/q_chat/src/lib.rs
@@ -254,7 +254,6 @@ const HELP_TEXT: &str = color_print::cstr! {"
   <em>help</em>        <black!>Show prompts help</black!>
   <em>list</em>        <black!>List or search available prompts</black!>
   <em>get</em>         <black!>Retrieve and send a prompt</black!>
-<em>/context</em>      <black!>Manage context files for the chat session</black!>
 <em>/context</em>      <black!>Manage context files and hooks for the chat session</black!>
   <em>help</em>        <black!>Show context help</black!>
   <em>show</em>        <black!>Display current context rules configuration [--expand]</black!>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixed a bug where the /context command description appeared twice in the help text
displayed by the /help command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
