### PR TITLE
Add terminal notification tip to rotating tips

### DIFF
--- a/crates/q_chat/src/lib.rs
+++ b/crates/q_chat/src/lib.rs
@@ -199,7 +199,8 @@ const SMALL_SCREEN_WECLOME_TEXT: &str = color_print::cstr! {"
 <em>Welcome to <cyan!>Amazon Q</cyan!>!</em>
 "};
 
-const ROTATING_TIPS: [&str; 8] = [
+const ROTATING_TIPS: [&str; 9] = [
+    color_print::cstr! {"You can enable terminal notifications with command <green!>q settings chat.enableNotifications true</green!>"},
     color_print::cstr! {"You can use <green!>/editor</green!> to edit your prompt with a vim-like experience"},
     color_print::cstr! {"You can execute bash commands by typing <green!>!</green!> followed by the command"},
     color_print::cstr! {"Q can use tools without asking for confirmation every time. Give <green!>/tools trust</green!> a try"},

--- a/crates/q_chat/src/lib.rs
+++ b/crates/q_chat/src/lib.rs
@@ -200,7 +200,7 @@ const SMALL_SCREEN_WECLOME_TEXT: &str = color_print::cstr! {"
 "};
 
 const ROTATING_TIPS: [&str; 9] = [
-    color_print::cstr! {"You can enable terminal notifications with command <green!>q settings chat.enableNotifications true</green!>"},
+    color_print::cstr! {"Get notified when Q CLI generates a response or requires permission. Just tell me, or run <green!>q settings chat.enableNotifications true</green!>"},
     color_print::cstr! {"You can use <green!>/editor</green!> to edit your prompt with a vim-like experience"},
     color_print::cstr! {"You can execute bash commands by typing <green!>!</green!> followed by the command"},
     color_print::cstr! {"Q can use tools without asking for confirmation every time. Give <green!>/tools trust</green!> a try"},

--- a/crates/q_chat/src/lib.rs
+++ b/crates/q_chat/src/lib.rs
@@ -200,7 +200,7 @@ const SMALL_SCREEN_WECLOME_TEXT: &str = color_print::cstr! {"
 "};
 
 const ROTATING_TIPS: [&str; 9] = [
-    color_print::cstr! {"Get notified when Q CLI generates a response or requires permission. Just tell me, or run <green!>q settings chat.enableNotifications true</green!>"},
+    color_print::cstr! {"Get notified whenever Q CLI generates a response or requests permission. Just ask me, or run <green!>q settings chat.enableNotifications true</green!>"},
     color_print::cstr! {"You can use <green!>/editor</green!> to edit your prompt with a vim-like experience"},
     color_print::cstr! {"You can execute bash commands by typing <green!>!</green!> followed by the command"},
     color_print::cstr! {"Q can use tools without asking for confirmation every time. Give <green!>/tools trust</green!> a try"},


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*

Add a new tip to the rotating tips array that informs users about enabling terminal notifications with the settings command.

<img width="571" alt="Screenshot 2025-05-01 at 11 40 00 AM" src="https://github.com/user-attachments/assets/3ff56bf1-d5ad-45b9-9c40-ec305131f2e5" />


🤖 Assisted by [Amazon Q Developer](https://aws.amazon.com/q/developer)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
