### PR TITLE
fixes draw_tip_box

### DIFF
--- a/crates/q_chat/src/lib.rs
+++ b/crates/q_chat/src/lib.rs
@@ -689,8 +689,21 @@ impl ChatContext {
                 }
                 line.push_str(word);
             } else {
-                wrapped_lines.push(line);
-                line = word.to_string();
+                // Here we need to account for words that are too long as well
+                if word.len() >= inner_width {
+                    let mut start = 0_usize;
+                    for (i, _) in word.chars().enumerate() {
+                        if i - start >= inner_width {
+                            wrapped_lines.push(word[start..i].to_string());
+                            start = i;
+                        }
+                    }
+                    wrapped_lines.push(word[start..].to_string());
+                    line = String::new();
+                } else {
+                    wrapped_lines.push(line);
+                    line = word.to_string();
+                }
             }
         }
 
@@ -725,7 +738,7 @@ impl ChatContext {
         // Centered wrapped content
         for line in wrapped_lines {
             let visible_line_len = strip_ansi_escapes::strip(&line).len();
-            let left_pad = (box_width - 4 - visible_line_len) / 2;
+            let left_pad = box_width.saturating_sub(4).saturating_sub(visible_line_len) / 2;
 
             let content = format!(
                 "│ {: <pad$}{}{: <rem$} │",
@@ -733,7 +746,10 @@ impl ChatContext {
                 line,
                 "",
                 pad = left_pad,
-                rem = box_width - 4 - left_pad - visible_line_len
+                rem = box_width
+                    .saturating_sub(4)
+                    .saturating_sub(left_pad)
+                    .saturating_sub(visible_line_len),
             );
             execute!(self.output, style::Print(format!("{}\n", content)))?;
         }
@@ -3443,6 +3459,9 @@ fn create_stream(model_responses: serde_json::Value) -> StreamingClient {
 
 #[cfg(test)]
 mod tests {
+    use bstr::ByteSlice;
+    use shared_writer::TestWriterWithSink;
+
     use super::*;
 
     #[tokio::test]
@@ -3823,6 +3842,88 @@ mod tests {
         for (input, expected) in cases {
             let processed = input.trim().to_string();
             assert_eq!(processed, expected.trim().to_string(), "Failed for input: {}", input);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_draw_tip_box() {
+        let ctx = Context::builder().with_test_home().await.unwrap().build_fake();
+        let buf = Arc::new(std::sync::Mutex::new(Vec::<u8>::new()));
+        let test_writer = TestWriterWithSink { sink: buf.clone() };
+        let output = SharedWriter::new(test_writer.clone());
+        let tool_manager = ToolManager::default();
+        let tool_config = serde_json::from_str::<HashMap<String, ToolSpec>>(include_str!("tools/tool_index.json"))
+            .expect("Tools failed to load");
+        let test_client = create_stream(serde_json::json!([]));
+
+        let mut chat_context = ChatContext::new(
+            Arc::clone(&ctx),
+            "fake_conv_id",
+            Settings::new_fake(),
+            State::new_fake(),
+            output,
+            None,
+            InputSource::new_mock(vec![]),
+            true,
+            test_client,
+            || Some(80),
+            tool_manager,
+            None,
+            tool_config,
+            ToolPermissions::new(0),
+        )
+        .await
+        .unwrap();
+
+        // Test with a short tip
+        let short_tip = "This is a short tip";
+        chat_context.draw_tip_box(short_tip).expect("Failed to draw tip box");
+
+        // Test with a longer tip that should wrap
+        let long_tip = "This is a much longer tip that should wrap to multiple lines because it exceeds the inner width of the tip box which is calculated based on the GREETING_BREAK_POINT constant";
+        chat_context.draw_tip_box(long_tip).expect("Failed to draw tip box");
+
+        // Test with a long tip with two long words that should wrap
+        let long_tip_with_one_long_word = {
+            let mut s = "a".repeat(200);
+            s.push(' ');
+            s.push_str(&"a".repeat(200));
+            s
+        };
+        chat_context
+            .draw_tip_box(long_tip_with_one_long_word.as_str())
+            .expect("Failed to draw tip box");
+
+        // Test with a long tip with two long words that should wrap
+        let long_tip_with_two_long_words = "a".repeat(200);
+        chat_context
+            .draw_tip_box(long_tip_with_two_long_words.as_str())
+            .expect("Failed to draw tip box");
+
+        // Get the output and verify it contains expected formatting elements
+        let content = test_writer.get_content();
+        let output_str = content.to_str_lossy();
+
+        // Check for box drawing characters
+        assert!(output_str.contains("╭"), "Output should contain top-left corner");
+        assert!(output_str.contains("╮"), "Output should contain top-right corner");
+        assert!(output_str.contains("│"), "Output should contain vertical lines");
+        assert!(output_str.contains("╰"), "Output should contain bottom-left corner");
+        assert!(output_str.contains("╯"), "Output should contain bottom-right corner");
+
+        // Check for the label
+        assert!(
+            output_str.contains("Did you know?"),
+            "Output should contain the 'Did you know?' label"
+        );
+
+        // Check that both tips are present
+        assert!(output_str.contains(short_tip), "Output should contain the short tip");
+
+        // For the long tip, we check for substrings since it will be wrapped
+        let long_tip_parts: Vec<&str> = long_tip.split_whitespace().collect();
+        for part in long_tip_parts.iter().take(3) {
+            assert!(output_str.contains(part), "Output should contain parts of the long tip");
         }
     }
 }

--- a/crates/q_chat/src/shared_writer.rs
+++ b/crates/q_chat/src/shared_writer.rs
@@ -64,3 +64,26 @@ impl Write for NullWriter {
         Ok(())
     }
 }
+
+#[derive(Debug, Clone)]
+pub struct TestWriterWithSink {
+    pub sink: Arc<Mutex<Vec<u8>>>,
+}
+
+impl TestWriterWithSink {
+    #[allow(dead_code)]
+    pub fn get_content(&self) -> Vec<u8> {
+        self.sink.lock().unwrap().clone()
+    }
+}
+
+impl Write for TestWriterWithSink {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.sink.lock().unwrap().append(&mut buf.to_vec());
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
This is a follow up fix for the overflow subtraction encountered when tip in tip boxes contain single words that are longer than the box width (e.g. a link) on the release of 1.9.0.

*Description of changes:*
- `draw_tip_box` now accounts for single words that are longer than the inner width of the tip box.

Long single words are now also wrapped:
![image](https://github.com/user-attachments/assets/f5794549-22ab-42e3-b98c-46add07716ec)

Normal tips are displayed as usual:
![image](https://github.com/user-attachments/assets/0b6a3010-2d6d-4380-b56c-746c637d6801)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
