### PR TITLE
chore: bump sysinfo to 0.33.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2740,7 +2740,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shellexpand",
- "sysinfo 0.32.1",
+ "sysinfo",
  "system-configuration",
  "tao",
  "tempfile",
@@ -2821,7 +2821,7 @@ dependencies = [
  "fig_util",
  "serde",
  "serde_json",
- "sysinfo 0.32.1",
+ "sysinfo",
  "time",
  "tokio",
  "toml",
@@ -2914,7 +2914,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sysinfo 0.32.1",
+ "sysinfo",
  "tempfile",
  "thiserror 2.0.12",
  "tokio",
@@ -2965,7 +2965,7 @@ dependencies = [
  "dirs",
  "nix 0.29.0",
  "serde",
- "sysinfo 0.32.1",
+ "sysinfo",
  "tempfile",
  "tokio",
 ]
@@ -3168,7 +3168,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "strum 0.27.1",
- "sysinfo 0.32.1",
+ "sysinfo",
  "thiserror 2.0.12",
  "time",
  "tokio",
@@ -3230,7 +3230,7 @@ dependencies = [
  "shell-words",
  "shellexpand",
  "shlex",
- "sysinfo 0.32.1",
+ "sysinfo",
  "tempfile",
  "time",
  "tokio",
@@ -5560,7 +5560,7 @@ dependencies = [
  "nix 0.29.0",
  "ntapi",
  "procfs",
- "sysinfo 0.33.1",
+ "sysinfo",
  "web-time",
  "windows 0.56.0",
 ]
@@ -6914,7 +6914,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spinners",
- "sysinfo 0.32.1",
+ "sysinfo",
  "tempfile",
  "thiserror 2.0.12",
  "time",
@@ -8432,20 +8432,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "sysinfo"
-version = "0.32.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c33cd241af0f2e9e3b5c32163b873b29956890b5342e6745b917ce9d490f4af"
-dependencies = [
- "core-foundation-sys",
- "libc",
- "memchr",
- "ntapi",
- "rayon",
- "windows 0.57.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,7 @@ shlex = "1.3.0"
 similar = "2.7.0"
 spinners = "4.1.0"
 strum = { version = "0.27.1", features = ["derive"] }
-sysinfo = "0.32.0"
+sysinfo = "0.33.1"
 thiserror = "2.0.12"
 tempfile = "3.18.0"
 time = { version = "0.3.39", features = [

--- a/crates/fig_desktop/src/install.rs
+++ b/crates/fig_desktop/src/install.rs
@@ -742,7 +742,7 @@ async fn launch_ibus(ctx: &Context) {
     use tokio::process::Command;
 
     let system = tokio::task::block_in_place(|| {
-        System::new_with_specifics(RefreshKind::new().with_processes(ProcessRefreshKind::new()))
+        System::new_with_specifics(RefreshKind::nothing().with_processes(ProcessRefreshKind::nothing()))
     });
     let ibus_daemon = OsString::from("ibus-daemon");
     if system.processes_by_name(&ibus_daemon).next().is_none() {

--- a/crates/fig_desktop/src/main.rs
+++ b/crates/fig_desktop/src/main.rs
@@ -244,7 +244,7 @@ async fn allow_multiple_running_check(
     }
 
     let system = System::new_with_specifics(
-        RefreshKind::new().with_processes(ProcessRefreshKind::new().with_user(sysinfo::UpdateKind::Always)),
+        RefreshKind::nothing().with_processes(ProcessRefreshKind::nothing().with_user(sysinfo::UpdateKind::Always)),
     );
     let app_process_name = OsString::from(APP_PROCESS_NAME);
     let processes = system.processes_by_exact_name(&app_process_name);
@@ -299,7 +299,7 @@ async fn allow_multiple_running_check(
     use std::ffi::OsString;
 
     let app_process_name = OsString::from(APP_PROCESS_NAME);
-    let system = System::new_with_specifics(RefreshKind::new().with_processes(ProcessRefreshKind::new()));
+    let system = System::new_with_specifics(RefreshKind::nothing().with_processes(ProcessRefreshKind::nothing()));
     let processes = system.processes_by_name(&app_process_name);
     let current_uid = nix::unistd::getuid().as_raw();
 

--- a/crates/fig_diagnostic/src/lib.rs
+++ b/crates/fig_diagnostic/src/lib.rs
@@ -103,7 +103,7 @@ pub struct SystemInfo {
 impl SystemInfo {
     fn new() -> SystemInfo {
         let system = sysinfo::System::new_with_specifics(
-            RefreshKind::new()
+            RefreshKind::nothing()
                 .with_cpu(CpuRefreshKind::everything())
                 .with_memory(MemoryRefreshKind::everything()),
         );

--- a/crates/q_cli/src/cli/doctor/checks/linux.rs
+++ b/crates/q_cli/src/cli/doctor/checks/linux.rs
@@ -306,7 +306,8 @@ impl DoctorCheck<LinuxContext> for IBusRunningCheck {
             RefreshKind,
         };
 
-        let system = sysinfo::System::new_with_specifics(RefreshKind::new().with_processes(ProcessRefreshKind::new()));
+        let system =
+            sysinfo::System::new_with_specifics(RefreshKind::nothing().with_processes(ProcessRefreshKind::nothing()));
         let ibus_daemon = OsString::from("ibus-daemon");
 
         if system.processes_by_exact_name(&ibus_daemon).next().is_none() {

--- a/crates/q_cli/src/cli/internal/mod.rs
+++ b/crates/q_cli/src/cli/internal/mod.rs
@@ -626,7 +626,7 @@ impl InternalSubcommand {
                 use tokio::process::Command;
 
                 let system = tokio::task::block_in_place(|| {
-                    System::new_with_specifics(RefreshKind::new().with_processes(ProcessRefreshKind::new()))
+                    System::new_with_specifics(RefreshKind::nothing().with_processes(ProcessRefreshKind::nothing()))
                 });
                 let ibus_daemon = OsString::from("ibus-daemon");
                 if system.processes_by_name(&ibus_daemon).next().is_none() {

--- a/crates/q_cli/src/util/desktop.rs
+++ b/crates/q_cli/src/util/desktop.rs
@@ -49,7 +49,7 @@ pub fn desktop_app_running() -> bool {
 
     // Fallback to process name check
     let app_process_name = OsString::from(APP_PROCESS_NAME);
-    let system = System::new_with_specifics(RefreshKind::new().with_processes(ProcessRefreshKind::new()));
+    let system = System::new_with_specifics(RefreshKind::nothing().with_processes(ProcessRefreshKind::nothing()));
     let mut processes = system.processes_by_exact_name(&app_process_name);
     processes.next().is_some()
 }
@@ -83,7 +83,7 @@ pub fn desktop_app_running() -> bool {
         System,
     };
 
-    let s = System::new_with_specifics(RefreshKind::new().with_processes(ProcessRefreshKind::new()));
+    let s = System::new_with_specifics(RefreshKind::nothing().with_processes(ProcessRefreshKind::nothing()));
     let app_process_name = OsString::from(APP_PROCESS_NAME);
     let mut processes = s.processes_by_exact_name(&app_process_name);
     processes.next().is_some()

--- a/crates/q_cli/src/util/mod.rs
+++ b/crates/q_cli/src/util/mod.rs
@@ -346,7 +346,7 @@ mod tests {
         };
 
         let app_process_name = OsString::from(APP_PROCESS_NAME);
-        let system = System::new_with_specifics(RefreshKind::new().with_processes(ProcessRefreshKind::new()));
+        let system = System::new_with_specifics(RefreshKind::nothing().with_processes(ProcessRefreshKind::nothing()));
         cfg_if! {
             if #[cfg(windows)] {
                 let mut processes = system.processes_by_name(&app_process_name);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Bumping sysinfo to `0.33.1`
- `new` is equivalent to `nothing`
0.32.0 - https://docs.rs/sysinfo/0.32.0/src/sysinfo/common/system.rs.html#2238-2240
0.33.1 - https://docs.rs/sysinfo/0.33.1/src/sysinfo/common/system.rs.html#2086-2088

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
