### PR TITLE
feat: integrate git-aware file selection in fuzzy finder

### DIFF
--- a/crates/fig_os_shim/src/fs.rs
+++ b/crates/fig_os_shim/src/fs.rs
@@ -3,8 +3,14 @@ use std::fs::Permissions;
 use std::io;
 #[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;
-use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::path::{
+    Path,
+    PathBuf,
+};
+use std::sync::{
+    Arc,
+    Mutex,
+};
 
 use tempfile::TempDir;
 use tokio::fs;
@@ -17,7 +23,10 @@ pub struct Fs(inner::Inner);
 mod inner {
     use std::collections::HashMap;
     use std::path::PathBuf;
-    use std::sync::{Arc, Mutex};
+    use std::sync::{
+        Arc,
+        Mutex,
+    };
 
     use tempfile::TempDir;
 
@@ -365,8 +374,9 @@ impl Fs {
     /// On Windows, it automatically detects whether the target is a file or directory
     /// and uses the appropriate system call.
     ///
-    /// This is a proxy to [`std::os::windows::fs::symlink_file`] or [`std::os::windows::fs::symlink_dir`] on Windows,
-    /// and [`std::os::unix::fs::symlink`] on Unix.
+    /// This is a proxy to [`std::os::windows::fs::symlink_file`] or
+    /// [`std::os::windows::fs::symlink_dir`] on Windows, and [`std::os::unix::fs::symlink`] on
+    /// Unix.
     #[cfg(windows)]
     pub fn symlink_sync(&self, original: impl AsRef<Path>, link: impl AsRef<Path>) -> io::Result<()> {
         use inner::Inner;

--- a/crates/fig_os_shim/src/process_info/pid.rs
+++ b/crates/fig_os_shim/src/process_info/pid.rs
@@ -1,16 +1,34 @@
 use std::path::PathBuf;
 use std::sync::Weak;
-use std::{fmt, str};
+use std::{
+    fmt,
+    str,
+};
 
 use cfg_if::cfg_if;
 
 // Platform-specific implementations
 #[cfg(target_os = "linux")]
-use super::linux::{cmdline, current, exe, parent};
+use super::linux::{
+    cmdline,
+    current,
+    exe,
+    parent,
+};
 #[cfg(target_os = "macos")]
-use super::macos::{cmdline, current, exe, parent};
+use super::macos::{
+    cmdline,
+    current,
+    exe,
+    parent,
+};
 #[cfg(windows)]
-use super::windows::{cmdline, current, exe, parent};
+use super::windows::{
+    cmdline,
+    current,
+    exe,
+    parent,
+};
 use crate::Context;
 
 #[derive(Default, Debug, Clone)]

--- a/crates/fig_os_shim/src/process_info/windows.rs
+++ b/crates/fig_os_shim/src/process_info/windows.rs
@@ -1,9 +1,15 @@
 use std::path::PathBuf;
 use std::sync::Weak;
 
-use sysinfo::{ProcessesToUpdate, System};
+use sysinfo::{
+    ProcessesToUpdate,
+    System,
+};
 
-use super::pid::{Pid, RawPid};
+use super::pid::{
+    Pid,
+    RawPid,
+};
 use crate::Context;
 
 pub fn current(ctx: Weak<Context>) -> Pid {


### PR DESCRIPTION
## Description of changes:

Hello. I actively use the amazon-q-developer CLI and find the Agent Coding features very helpful. While trying out the recently added `/context add` fuzzy finder(skim) feature, I noticed one issue that could be improved, which led me to open this Pull Request.

When opening the fuzzy finder, I found that files and directories listed in `.gitignore` — such as `node_modules`, `dist`, and `build` — were still appearing in the file list. I believe that only valid files authored by developers should appear in the fuzzy finder’s list. Since files under `dist`, `node_modules`, `build` are typically generated or compiled artifacts rather than developer-authored source code, it would be helpful to exclude them from the fuzzy finder. Especially in the case of TypeScript, **the transpiled JavaScript file names are very similar to the original TypeScript file names**. As a result, **if developers don’t carefully check the paths in the fuzzy finder, they may accidentally select the wrong file** when using `/context add`.

## Changed feature:

This Pull Request modifies the code so that files specified in `.gitignore` are ignored by the fuzzy finder(skim), as shown in the image below. Here are two images showing the results of searching for `build/` using the fuzzy finder in the amazon-q-developer-cli project.

**[AS-IS]**

<img src="https://github.com/user-attachments/assets/99ec9d62-1741-4d61-a49e-fc647bea2279" width="500" />

**[TO-BE]**

<img src="https://github.com/user-attachments/assets/e10e3cc0-150f-49fb-919d-19f46f859ba5" width="500" />



If my code needs any adjustments, please feel free to modify it.

## Linked Issue
https://github.com/aws/amazon-q-developer-cli/issues/1650

