### PR TITLE
feat(chat): Add current UTC time to user messages

### DIFF
--- a/crates/q_chat/Cargo.toml
+++ b/crates/q_chat/Cargo.toml
@@ -49,6 +49,7 @@ url.workspace = true
 uuid.workspace = true
 winnow.workspace = true
 strip-ansi-escapes = "0.2.1"
+chrono = "0.4.41"
 
 [dev-dependencies]
 tracing-subscriber.workspace = true

--- a/crates/q_chat/src/conversation_state.rs
+++ b/crates/q_chat/src/conversation_state.rs
@@ -195,7 +195,10 @@ impl ConversationState {
             warn!("input must not be empty when adding new messages");
             "Empty prompt".to_string()
         } else {
-            input
+            // Add current UTC time in XML tags at the end of the message
+            let now = chrono::Utc::now();
+            let formatted_time = now.format("%Y-%m-%d %H:%M:%S").to_string();
+            format!("{}\n\n<currentTimeUTC>\n{}\n</currentTimeUTC>", input, formatted_time)
         };
 
         let msg = UserMessage::new_prompt(input);


### PR DESCRIPTION
Add current UTC time in <currentTimeUTC> XML tags at the end of user prompts. This allows the model to have access to the current time when needed for date/time related queries.
This helps us enable prompt caching.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
