### PR TITLE
feat(chat): Add current UTC time to user messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1437,9 +1437,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -6783,6 +6783,7 @@ dependencies = [
  "anstream",
  "aws-smithy-types",
  "bstr",
+ "chrono",
  "clap",
  "color-print",
  "convert_case 0.8.0",

--- a/crates/q_chat/Cargo.toml
+++ b/crates/q_chat/Cargo.toml
@@ -51,6 +51,7 @@ url.workspace = true
 uuid.workspace = true
 winnow.workspace = true
 strip-ansi-escapes = "0.2.1"
+chrono = "0.4.41"
 
 [dev-dependencies]
 tracing-subscriber.workspace = true

--- a/crates/q_chat/src/conversation_state.rs
+++ b/crates/q_chat/src/conversation_state.rs
@@ -195,7 +195,10 @@ impl ConversationState {
             warn!("input must not be empty when adding new messages");
             "Empty prompt".to_string()
         } else {
-            input
+            // Add current UTC time in XML tags at the end of the message
+            let now = chrono::Utc::now();
+            let formatted_time = now.format("%Y-%m-%d %H:%M:%S").to_string();
+            format!("{}\n\n<currentTimeUTC>\n{}\n</currentTimeUTC>", input, formatted_time)
         };
 
         let msg = UserMessage::new_prompt(input);


### PR DESCRIPTION
Add current UTC time in <currentTimeUTC> XML tags at the end of user prompts. This allows the model to have access to the current time when needed for date/time related queries.
This lets us enable prompt caching in the backend.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
