### PR TITLE
chore: copy infer license to new chat cli, rust cargo +nightly fmt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9873,9 +9873,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.10"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37493cadf42a2a939ed404698ded7fb378bf301b5011f973361779a3a74f8c93"
+checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,7 @@ winnow = "0.6.2"
 # https://github.com/seanmonstar/reqwest/blob/v0.12.12/Cargo.toml
 rustls = "0.23.23"
 rustls-native-certs = "0.8.1"
-webpki-roots = "0.26.8"
+webpki-roots = "=0.26.8"
 
 
 [workspace.lints.rust]

--- a/crates/chat-cli/Cargo.toml
+++ b/crates/chat-cli/Cargo.toml
@@ -147,7 +147,7 @@ unicode-width = "0.2.0"
 url = "2.5.4"
 uuid = { version = "1.15.1", features = ["v4", "serde"] }
 walkdir = "2.5.0"
-webpki-roots = "0.26.8"
+webpki-roots = "=0.26.8"
 whoami = "1.6.0"
 winnow = "=0.6.2"
 

--- a/crates/chat-cli/src/cli/user.rs
+++ b/crates/chat-cli/src/cli/user.rs
@@ -227,13 +227,19 @@ pub async fn login_interactive(args: LoginArgs) -> Result<()> {
         Some(LicenseType::Free) => AuthMethod::BuilderId,
         Some(LicenseType::Pro) => AuthMethod::IdentityCenter,
         None => {
-            // No license specified, prompt the user to choose
-            let options = [AuthMethod::BuilderId, AuthMethod::IdentityCenter];
-            let i = match choose("Select login method", &options)? {
-                Some(i) => i,
-                None => bail!("No login method selected"),
-            };
-            options[i]
+            if args.identity_provider.is_some() && args.region.is_some() {
+                // If license is specified and --identity-provider and --region are specified,
+                // the license is determined to be pro
+                AuthMethod::IdentityCenter
+            } else {
+                // --license is not specified, prompt the user to choose
+                let options = [AuthMethod::BuilderId, AuthMethod::IdentityCenter];
+                let i = match choose("Select login method", &options)? {
+                    Some(i) => i,
+                    None => bail!("No login method selected"),
+                };
+                options[i]
+            }
         },
     };
 

--- a/crates/fig_os_shim/src/fs.rs
+++ b/crates/fig_os_shim/src/fs.rs
@@ -3,8 +3,14 @@ use std::fs::Permissions;
 use std::io;
 #[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;
-use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::path::{
+    Path,
+    PathBuf,
+};
+use std::sync::{
+    Arc,
+    Mutex,
+};
 
 use tempfile::TempDir;
 use tokio::fs;
@@ -17,7 +23,10 @@ pub struct Fs(inner::Inner);
 mod inner {
     use std::collections::HashMap;
     use std::path::PathBuf;
-    use std::sync::{Arc, Mutex};
+    use std::sync::{
+        Arc,
+        Mutex,
+    };
 
     use tempfile::TempDir;
 
@@ -365,8 +374,9 @@ impl Fs {
     /// On Windows, it automatically detects whether the target is a file or directory
     /// and uses the appropriate system call.
     ///
-    /// This is a proxy to [`std::os::windows::fs::symlink_file`] or [`std::os::windows::fs::symlink_dir`] on Windows,
-    /// and [`std::os::unix::fs::symlink`] on Unix.
+    /// This is a proxy to [`std::os::windows::fs::symlink_file`] or
+    /// [`std::os::windows::fs::symlink_dir`] on Windows, and [`std::os::unix::fs::symlink`] on
+    /// Unix.
     #[cfg(windows)]
     pub fn symlink_sync(&self, original: impl AsRef<Path>, link: impl AsRef<Path>) -> io::Result<()> {
         use inner::Inner;

--- a/crates/fig_os_shim/src/process_info/pid.rs
+++ b/crates/fig_os_shim/src/process_info/pid.rs
@@ -1,16 +1,34 @@
 use std::path::PathBuf;
 use std::sync::Weak;
-use std::{fmt, str};
+use std::{
+    fmt,
+    str,
+};
 
 use cfg_if::cfg_if;
 
 // Platform-specific implementations
 #[cfg(target_os = "linux")]
-use super::linux::{cmdline, current, exe, parent};
+use super::linux::{
+    cmdline,
+    current,
+    exe,
+    parent,
+};
 #[cfg(target_os = "macos")]
-use super::macos::{cmdline, current, exe, parent};
+use super::macos::{
+    cmdline,
+    current,
+    exe,
+    parent,
+};
 #[cfg(windows)]
-use super::windows::{cmdline, current, exe, parent};
+use super::windows::{
+    cmdline,
+    current,
+    exe,
+    parent,
+};
 use crate::Context;
 
 #[derive(Default, Debug, Clone)]

--- a/crates/fig_os_shim/src/process_info/windows.rs
+++ b/crates/fig_os_shim/src/process_info/windows.rs
@@ -1,9 +1,15 @@
 use std::path::PathBuf;
 use std::sync::Weak;
 
-use sysinfo::{ProcessesToUpdate, System};
+use sysinfo::{
+    ProcessesToUpdate,
+    System,
+};
 
-use super::pid::{Pid, RawPid};
+use super::pid::{
+    Pid,
+    RawPid,
+};
 use crate::Context;
 
 pub fn current(ctx: Weak<Context>) -> Pid {


### PR DESCRIPTION
*Description of changes:*
- Copying over #1369 to the new `chat_cli` binary
- Setting `webpki-roots` to `0.26.8` since later versions have the license `CDLA-Permissive-2.0` which is prohibited.
- Run `cargo +nightly fmt`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
