### PR TITLE
fix: tool calls with incorrect name corrupts conversation

### DIFF
--- a/crates/chat-cli/src/cli/chat/consts.rs
+++ b/crates/chat-cli/src/cli/chat/consts.rs
@@ -17,3 +17,5 @@ pub const MAX_USER_MESSAGE_SIZE: usize = 600_000;
 pub const CONTEXT_WINDOW_SIZE: usize = 200_000;
 
 pub const MAX_CHARS: usize = TokenCounter::token_to_chars(CONTEXT_WINDOW_SIZE); // Character-based warning threshold
+
+pub const DUMMY_TOOL_NAME: &str = "dummy";

--- a/crates/chat-cli/src/cli/chat/conversation_state.rs
+++ b/crates/chat-cli/src/cli/chat/conversation_state.rs
@@ -11,6 +11,7 @@ use tracing::{
 };
 
 use super::consts::{
+    DUMMY_TOOL_NAME,
     MAX_CHARS,
     MAX_CONVERSATION_STATE_HISTORY_LEN,
 };
@@ -46,6 +47,7 @@ use crate::api_client::model::{
     ToolInputSchema,
     ToolResult,
     ToolResultContentBlock,
+    ToolResultStatus,
     ToolSpecification,
     ToolUse,
     UserInputMessage,
@@ -271,9 +273,9 @@ impl ConversationState {
 
         // If the last message from the assistant contains tool uses AND next_message is set, we need to
         // ensure that next_message contains tool results.
-        if let (Some((_, AssistantMessage::ToolUse { tool_uses, .. })), Some(user_msg)) = (
+        if let (Some((_, AssistantMessage::ToolUse { ref mut tool_uses, .. })), Some(user_msg)) = (
             self.history
-                .range(self.valid_history_range.0..self.valid_history_range.1)
+                .range_mut(self.valid_history_range.0..self.valid_history_range.1)
                 .last(),
             &mut self.next_message,
         ) {
@@ -285,6 +287,34 @@ impl ConversationState {
                     user_msg.prompt().map(|p| p.to_string()),
                     tool_uses.iter().map(|t| t.id.as_str()),
                 );
+            }
+
+            // Here we also need to make sure that the tool result corresponds to one of the tools
+            // in the list. Otherwise we will see validation error from the backend. We would only
+            // do this if the last message is a tool call that has failed.
+            let tool_use_results = user_msg.tool_use_results();
+            if let Some(tool_use_results) = tool_use_results {
+                let tool_name_list = self
+                    .tools
+                    .values()
+                    .flatten()
+                    .map(|Tool::ToolSpecification(spec)| spec.name.as_str())
+                    .collect::<Vec<_>>();
+                for result in tool_use_results {
+                    if let ToolResultStatus::Error = result.status {
+                        let tool_use_id = result.tool_use_id.as_str();
+                        let _ = tool_uses
+                            .iter_mut()
+                            .filter(|tool_use| tool_use.id == tool_use_id)
+                            .map(|tool_use| {
+                                let tool_name = tool_use.name.as_str();
+                                if !tool_name_list.contains(&tool_name) {
+                                    tool_use.name = DUMMY_TOOL_NAME.to_string();
+                                }
+                            })
+                            .collect::<Vec<_>>();
+                    }
+                }
             }
         }
     }

--- a/crates/chat-cli/src/cli/chat/tool_manager.rs
+++ b/crates/chat-cli/src/cli/chat/tool_manager.rs
@@ -680,6 +680,48 @@ impl ToolManager {
             "q_think_tool" => Tool::Thinking(serde_json::from_value::<Thinking>(value.args).map_err(map_err)?),
             // Note that this name is namespaced with server_name{DELIMITER}tool_name
             name => {
+                error!("## resolution: name supplied: {name}");
+                // Note: tn_map also has tools that underwent no transformation. In otherwords, if
+                // it is a valid tool name, we should get a hit.
+                let name = match self.tn_map.get(name) {
+                    Some(name) => Ok::<&str, ToolResult>(name.as_str()),
+                    None => {
+                        // There are three possibilities:
+                        // - The tool name supplied is valid, it's just missing the server name
+                        // prefix.
+                        // - The tool name supplied is valid, it's missing the server name prefix
+                        // and there are more than one possible tools that fit this description.
+                        // - No server has a tool with this name.
+                        let candidates = self.tn_map.keys().filter(|n| n.ends_with(name)).collect::<Vec<_>>();
+                        #[allow(clippy::comparison_chain)]
+                        if candidates.len() == 1 {
+                            Ok(candidates.first().map(|s| s.as_str()).unwrap())
+                        } else if candidates.len() > 1 {
+                            let mut content = candidates.iter().fold(
+                                "There are multilple tools with given tool name: ".to_string(),
+                                |mut acc, name| {
+                                    acc.push_str(name);
+                                    acc.push_str(", ");
+                                    acc
+                                },
+                            );
+                            content.push_str("specify a tool with its full name.");
+                            Err(ToolResult {
+                                tool_use_id: value.id.clone(),
+                                content: vec![ToolResultContentBlock::Text(content)],
+                                status: ToolResultStatus::Error,
+                            })
+                        } else {
+                            Err(ToolResult {
+                                tool_use_id: value.id.clone(),
+                                content: vec![ToolResultContentBlock::Text(format!(
+                                    "The tool, \"{name}\" is supplied with incorrect name"
+                                ))],
+                                status: ToolResultStatus::Error,
+                            })
+                        }
+                    },
+                }?;
                 let name = self.tn_map.get(name).map_or(name, String::as_str);
                 let (server_name, tool_name) = name.split_once(NAMESPACE_DELIMITER).ok_or(ToolResult {
                     tool_use_id: value.id.clone(),

--- a/crates/chat-cli/src/cli/chat/tools/tool_index.json
+++ b/crates/chat-cli/src/cli/chat/tools/tool_index.json
@@ -1,4 +1,13 @@
 {
+  "dummy": {
+    "name": "dummy",
+    "description": "This is a dummy tool. If you are seeing this that means the tool associated with this tool call is not in the list of available tools. This could be because a wrong tool name was supplied or the list of tools has changed since the conversation has started. Do not show this when user asks you to list tools.",
+    "input_schema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
   "execute_bash": {
     "name": "execute_bash",
     "description": "Execute the specified bash command.",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Adds a dummy tool in the tool schema
- Adds check in the conversation invariant check to replace failed tool calls with names that do not exist in the tool list
- Adds logic in get tools to include a retry message for the model to call tools by its full name

![image](https://github.com/user-attachments/assets/20431c83-15ad-4d0e-aa24-bd79c28c8a6e)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
