### PR TITLE
feat: add /import and /export commands

### DIFF
--- a/crates/chat-cli/src/cli/chat/command.rs
+++ b/crates/chat-cli/src/cli/chat/command.rs
@@ -51,6 +51,13 @@ pub enum Command {
         subcommand: Option<PromptsSubcommand>,
     },
     Usage,
+    Import {
+        path: String,
+    },
+    Export {
+        path: String,
+        force: bool,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -810,6 +817,25 @@ impl Command {
                     }
                 },
                 "usage" => Self::Usage,
+                "import" => {
+                    let Some(path) = parts.get(1) else {
+                        return Err("path is required".to_string());
+                    };
+                    Self::Import {
+                        path: (*path).to_string(),
+                    }
+                },
+                "export" => {
+                    let force = parts.contains(&"-f") || parts.contains(&"--force");
+                    let Some(path) = parts.get(1) else {
+                        return Err("path is required".to_string());
+                    };
+                    let mut path = (*path).to_string();
+                    if !path.ends_with(".json") {
+                        path.push_str(".json");
+                    }
+                    Self::Export { path, force }
+                },
                 _unknown_command => Self::Ask {
                     prompt: input.to_string(),
                 },

--- a/crates/chat-cli/src/cli/chat/context.rs
+++ b/crates/chat-cli/src/cli/chat/context.rs
@@ -42,8 +42,10 @@ pub struct ContextConfig {
 
 #[allow(dead_code)]
 /// Manager for context files and profiles.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContextManager {
+    #[serde(skip)]
+    #[serde(default = "default_context")]
     ctx: Arc<Context>,
 
     max_context_files_size: usize,
@@ -796,6 +798,10 @@ fn validate_profile_name(name: &str) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn default_context() -> Arc<Context> {
+    Context::new()
 }
 
 #[cfg(test)]

--- a/crates/chat-cli/src/cli/chat/conversation_state.rs
+++ b/crates/chat-cli/src/cli/chat/conversation_state.rs
@@ -9,6 +9,10 @@ use crossterm::{
     execute,
     style,
 };
+use serde::{
+    Deserialize,
+    Serialize,
+};
 use tracing::{
     debug,
     error,
@@ -42,8 +46,8 @@ use super::tools::{
     QueuedTool,
     ToolOrigin,
     ToolSpec,
-    serde_value_to_document,
 };
+use super::util::serde_value_to_document;
 use crate::api_client::model::{
     AssistantResponseMessage,
     ChatMessage,
@@ -67,7 +71,7 @@ const CONTEXT_ENTRY_START_HEADER: &str = "--- CONTEXT ENTRY BEGIN ---\n";
 const CONTEXT_ENTRY_END_HEADER: &str = "--- CONTEXT ENTRY END ---\n\n";
 
 /// Tracks state related to an ongoing conversation.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConversationState {
     /// Randomly generated on creation.
     conversation_id: String,
@@ -89,7 +93,8 @@ pub struct ConversationState {
     context_message_length: Option<usize>,
     /// Stores the latest conversation summary created by /compact
     latest_summary: Option<String>,
-    updates: Option<SharedWriter>,
+    #[serde(skip)]
+    pub updates: Option<SharedWriter>,
 }
 
 impl ConversationState {
@@ -793,7 +798,7 @@ pub enum TokenWarningLevel {
 impl From<InputSchema> for ToolInputSchema {
     fn from(value: InputSchema) -> Self {
         Self {
-            json: Some(serde_value_to_document(value.0)),
+            json: Some(serde_value_to_document(value.0).into()),
         }
     }
 }

--- a/crates/chat-cli/src/cli/chat/hooks.rs
+++ b/crates/chat-cli/src/cli/chat/hooks.rs
@@ -119,14 +119,15 @@ pub enum HookTrigger {
     PerPrompt,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CachedHook {
     output: String,
+    #[serde(skip)]
     expiry: Option<Instant>,
 }
 
 /// Maps a hook name to a [`CachedHook`]
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct HookExecutor {
     pub global_cache: HashMap<String, CachedHook>,
     pub profile_cache: HashMap<String, CachedHook>,

--- a/crates/chat-cli/src/cli/chat/message.rs
+++ b/crates/chat-cli/src/cli/chat/message.rs
@@ -10,10 +10,12 @@ use super::consts::MAX_CURRENT_WORKING_DIRECTORY_LEN;
 use super::tools::{
     InvokeOutput,
     OutputKind,
+};
+use super::util::{
     document_to_serde_value,
     serde_value_to_document,
+    truncate_safe,
 };
-use super::util::truncate_safe;
 use crate::api_client::model::{
     AssistantResponseMessage,
     EnvState,
@@ -355,7 +357,7 @@ impl From<AssistantToolUse> for ToolUse {
         Self {
             tool_use_id: value.id,
             name: value.name,
-            input: serde_value_to_document(value.args),
+            input: serde_value_to_document(value.args).into(),
         }
     }
 }
@@ -365,7 +367,7 @@ impl From<ToolUse> for AssistantToolUse {
         Self {
             id: value.tool_use_id,
             name: value.name,
-            args: document_to_serde_value(value.input),
+            args: document_to_serde_value(value.input.into()),
         }
     }
 }

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -269,7 +269,9 @@ const HELP_TEXT: &str = color_print::cstr! {"
   <em>rm</em>          <black!>Remove file(s) from context [--global]</black!>
   <em>clear</em>       <black!>Clear all files from current context [--global]</black!>
   <em>hooks</em>       <black!>View and manage context hooks</black!>
-<em>/usage</em>      <black!>Show current session's context window usage</black!>
+<em>/usage</em>        <black!>Show current session's context window usage</black!>
+<em>/import</em>       <black!>Import conversation state from a JSON file</black!>
+<em>/export</em>       <black!>Export conversation state to a JSON file</black!>
 
 <cyan,em>MCP:</cyan,em>
 <black!>You can now configure the Amazon Q CLI to use MCP servers. \nLearn how: https://docs.aws.amazon.com/en_us/amazonq/latest/qdeveloper-ug/command-line-mcp.html</black!>

--- a/crates/chat-cli/src/cli/chat/prompt.rs
+++ b/crates/chat-cli/src/cli/chat/prompt.rs
@@ -73,6 +73,8 @@ pub const COMMANDS: &[&str] = &[
     "/compact",
     "/compact help",
     "/usage",
+    "/import",
+    "/export",
 ];
 
 pub fn generate_prompt(current_profile: Option<&str>, warning: bool) -> String {

--- a/crates/chat-cli/src/cli/chat/tools/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/mod.rs
@@ -13,10 +13,6 @@ use std::path::{
     PathBuf,
 };
 
-use aws_smithy_types::{
-    Document,
-    Number as SmithyNumber,
-};
 use crossterm::style::Stylize;
 use custom_tool::CustomTool;
 use execute_bash::ExecuteBash;
@@ -205,7 +201,7 @@ pub struct ToolSpec {
     pub tool_origin: ToolOrigin,
 }
 
-#[derive(Debug, Clone, Deserialize, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Hash)]
 pub enum ToolOrigin {
     Native,
     McpServer(String),
@@ -263,58 +259,6 @@ pub enum OutputKind {
 impl Default for OutputKind {
     fn default() -> Self {
         Self::Text(String::new())
-    }
-}
-
-pub fn serde_value_to_document(value: serde_json::Value) -> Document {
-    match value {
-        serde_json::Value::Null => Document::Null,
-        serde_json::Value::Bool(bool) => Document::Bool(bool),
-        serde_json::Value::Number(number) => {
-            if let Some(num) = number.as_u64() {
-                Document::Number(SmithyNumber::PosInt(num))
-            } else if number.as_i64().is_some_and(|n| n < 0) {
-                Document::Number(SmithyNumber::NegInt(number.as_i64().unwrap()))
-            } else {
-                Document::Number(SmithyNumber::Float(number.as_f64().unwrap_or_default()))
-            }
-        },
-        serde_json::Value::String(string) => Document::String(string),
-        serde_json::Value::Array(vec) => {
-            Document::Array(vec.clone().into_iter().map(serde_value_to_document).collect::<_>())
-        },
-        serde_json::Value::Object(map) => Document::Object(
-            map.into_iter()
-                .map(|(k, v)| (k, serde_value_to_document(v)))
-                .collect::<_>(),
-        ),
-    }
-}
-
-pub fn document_to_serde_value(value: Document) -> serde_json::Value {
-    use serde_json::Value;
-    match value {
-        Document::Object(map) => Value::Object(
-            map.into_iter()
-                .map(|(k, v)| (k, document_to_serde_value(v)))
-                .collect::<_>(),
-        ),
-        Document::Array(vec) => Value::Array(vec.clone().into_iter().map(document_to_serde_value).collect::<_>()),
-        Document::Number(number) => {
-            if let Ok(v) = TryInto::<u64>::try_into(number) {
-                Value::Number(v.into())
-            } else if let Ok(v) = TryInto::<i64>::try_into(number) {
-                Value::Number(v.into())
-            } else {
-                Value::Number(
-                    serde_json::Number::from_f64(number.to_f64_lossy())
-                        .unwrap_or(serde_json::Number::from_f64(0.0).expect("converting from 0.0 will not fail")),
-                )
-            }
-        },
-        Document::String(s) => serde_json::Value::String(s),
-        Document::Bool(b) => serde_json::Value::Bool(b),
-        Document::Null => serde_json::Value::Null,
     }
 }
 

--- a/crates/chat-cli/src/cli/chat/util/mod.rs
+++ b/crates/chat-cli/src/cli/chat/util/mod.rs
@@ -6,6 +6,10 @@ pub mod ui;
 use std::io::Write;
 use std::time::Duration;
 
+use aws_smithy_types::{
+    Document,
+    Number as SmithyNumber,
+};
 use eyre::Result;
 
 use super::ChatError;
@@ -125,6 +129,58 @@ pub fn drop_matched_context_files(files: &mut [(String, String)], limit: usize) 
         }
     }
     Ok(dropped_files)
+}
+
+pub fn serde_value_to_document(value: serde_json::Value) -> Document {
+    match value {
+        serde_json::Value::Null => Document::Null,
+        serde_json::Value::Bool(bool) => Document::Bool(bool),
+        serde_json::Value::Number(number) => {
+            if let Some(num) = number.as_u64() {
+                Document::Number(SmithyNumber::PosInt(num))
+            } else if number.as_i64().is_some_and(|n| n < 0) {
+                Document::Number(SmithyNumber::NegInt(number.as_i64().unwrap()))
+            } else {
+                Document::Number(SmithyNumber::Float(number.as_f64().unwrap_or_default()))
+            }
+        },
+        serde_json::Value::String(string) => Document::String(string),
+        serde_json::Value::Array(vec) => {
+            Document::Array(vec.clone().into_iter().map(serde_value_to_document).collect::<_>())
+        },
+        serde_json::Value::Object(map) => Document::Object(
+            map.into_iter()
+                .map(|(k, v)| (k, serde_value_to_document(v)))
+                .collect::<_>(),
+        ),
+    }
+}
+
+pub fn document_to_serde_value(value: Document) -> serde_json::Value {
+    use serde_json::Value;
+    match value {
+        Document::Object(map) => Value::Object(
+            map.into_iter()
+                .map(|(k, v)| (k, document_to_serde_value(v)))
+                .collect::<_>(),
+        ),
+        Document::Array(vec) => Value::Array(vec.clone().into_iter().map(document_to_serde_value).collect::<_>()),
+        Document::Number(number) => {
+            if let Ok(v) = TryInto::<u64>::try_into(number) {
+                Value::Number(v.into())
+            } else if let Ok(v) = TryInto::<i64>::try_into(number) {
+                Value::Number(v.into())
+            } else {
+                Value::Number(
+                    serde_json::Number::from_f64(number.to_f64_lossy())
+                        .unwrap_or(serde_json::Number::from_f64(0.0).expect("converting from 0.0 will not fail")),
+                )
+            }
+        },
+        Document::String(s) => serde_json::Value::String(s),
+        Document::Bool(b) => serde_json::Value::Bool(b),
+        Document::Null => serde_json::Value::Null,
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
*Description of changes:*
- Implementing `/import` and `/export` builtin commands for importing and exporting conversation state to/from a JSON file.
- Derive `Serialize` and `Deserialize` for `ConversationState`
- Adding a wrapper around `aws_smithy_types::Document` that implements `Serialize` and `Deserialize`
- Fixing `/help` text spacing for `/usage`, and adding text for `/import` and `/export`

The goal here is to improve debuggability of the current chat session. There's more improvements to be made around saving request metadata and persistence options (e.g. including context files) but for now this is a good first pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
