### PR TITLE
feat: QCHAT_PROCESS_ID and pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,9 @@
+# Check if Amazon Q chat is active
+if [ -n "$QCHAT_PROCESS_ID" ]; then
+  echo "ERROR: Git push blocked while Amazon Q chat is active (QCHAT_PROCESS_ID=$QCHAT_PROCESS_ID)"
+  echo "Please exit Amazon Q chat with '/quit' before pushing changes."
+  exit 1
+fi
+
+# Continue with push if QCHAT_PROCESS_ID is not set
+exit 0

--- a/crates/chat-cli/src/cli/chat/consts.rs
+++ b/crates/chat-cli/src/cli/chat/consts.rs
@@ -26,3 +26,6 @@ pub const MAX_NUMBER_OF_IMAGES_PER_REQUEST: usize = 10;
 
 /// In bytes - 10 MB
 pub const MAX_IMAGE_SIZE: usize = 10 * 1024 * 1024;
+
+/// Environment variable containing the pid of the chat session.
+pub const QCHAT_PROCESS_ID: &str = "QCHAT_PROCESS_ID";

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -1,6 +1,6 @@
 pub mod cli;
 mod command;
-mod consts;
+pub mod consts;
 mod context;
 mod conversation_state;
 mod hooks;

--- a/crates/chat-cli/src/cli/mod.rs
+++ b/crates/chat-cli/src/cli/mod.rs
@@ -1,4 +1,4 @@
-mod chat;
+pub mod chat;
 mod debug;
 mod diagnostics;
 mod feed;


### PR DESCRIPTION
*Description of changes:*
- Adding the code from #1368 except setting the env var in main before we launch a multi-threaded runtime.

In the future, we could decide to prevent launching chat altogether if this env var is already set in order to prevent nesting.

Credit to @jsamuel1 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
