### PR TITLE
fix: spawns task to ignore sigint in parent process when spawning chat

### DIFF
--- a/crates/q_cli/src/cli/mod.rs
+++ b/crates/q_cli/src/cli/mod.rs
@@ -63,6 +63,7 @@ use fig_util::{
 };
 use internal::InternalSubcommand;
 use serde::Serialize;
+use tokio::signal::ctrl_c;
 use tracing::{
     Level,
     debug,
@@ -351,9 +352,20 @@ impl Cli {
             cmd.args(args);
         }
 
-        cmd.status().await?;
+        // Because we are spawning chat as a child process, we need the parent process (this one)
+        // to ignore sigint that are meant for chat (i.e. all of them)
+        tokio::spawn(async move {
+            loop {
+                let _ = ctrl_c().await;
+            }
+        });
 
-        Ok(ExitCode::SUCCESS)
+        let exit_status = cmd.status().await?;
+        let exit_code = exit_status
+            .code()
+            .map_or(ExitCode::FAILURE, |e| ExitCode::from(e as u8));
+
+        Ok(exit_code)
     }
 
     async fn send_telemetry(&self) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Spawns task to ignore sigint in parent process when spawning chat. 
This is to fix when chat is invoked from q_cli (as opposed to a standalone bin), sigint will kill the parent process that spawns the chat, thus also killing chat (even though chat is properly handling the sigint). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
