### PR TITLE
Fix: Make shell command purpose display more natural

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -284,6 +284,7 @@ const TRUST_ALL_TEXT: &str = color_print::cstr! {"<green!>All tools are now trus
 
 const TOOL_BULLET: &str = " ● ";
 const CONTINUATION_LINE: &str = " ⋮ ";
+const PURPOSE_ARROW: &str = " ↳ ";
 
 pub async fn launch_chat(database: &mut Database, telemetry: &TelemetryThread, args: cli::Chat) -> Result<ExitCode> {
     let trust_tools = args.trust_tools.map(|mut tools| {

--- a/crates/chat-cli/src/cli/chat/tools/execute_bash.rs
+++ b/crates/chat-cli/src/cli/chat/tools/execute_bash.rs
@@ -26,8 +26,11 @@ use super::{
     MAX_TOOL_RESPONSE_SIZE,
     OutputKind,
 };
+use crate::cli::chat::{
+    CONTINUATION_LINE,
+    PURPOSE_ARROW}
+;
 use crate::platform::Context;
-
 const READONLY_COMMANDS: &[&str] = &["ls", "cat", "echo", "pwd", "which", "head", "tail", "find", "grep"];
 
 #[derive(Debug, Clone, Deserialize)]
@@ -127,8 +130,11 @@ impl ExecuteBash {
         if let Some(summary) = &self.summary {
             queue!(
                 updates,
+                style::Print(CONTINUATION_LINE),
+                style::Print("\n"), 
+                style::Print(PURPOSE_ARROW),
                 style::SetForegroundColor(Color::Blue),
-                style::Print("\nPurpose: "),
+                style::Print("Purpose: "),
                 style::ResetColor,
                 style::Print(summary),
                 style::Print("\n"),

--- a/crates/chat-cli/src/cli/chat/tools/execute_bash.rs
+++ b/crates/chat-cli/src/cli/chat/tools/execute_bash.rs
@@ -28,8 +28,8 @@ use super::{
 };
 use crate::cli::chat::{
     CONTINUATION_LINE,
-    PURPOSE_ARROW}
-;
+    PURPOSE_ARROW,
+};
 use crate::platform::Context;
 const READONLY_COMMANDS: &[&str] = &["ls", "cat", "echo", "pwd", "which", "head", "tail", "find", "grep"];
 
@@ -131,7 +131,7 @@ impl ExecuteBash {
             queue!(
                 updates,
                 style::Print(CONTINUATION_LINE),
-                style::Print("\n"), 
+                style::Print("\n"),
                 style::Print(PURPOSE_ARROW),
                 style::SetForegroundColor(Color::Blue),
                 style::Print("Purpose: "),


### PR DESCRIPTION
*Issue #, if available:*

This change aligns the purpose message with the command output and removes visual misalignment by rendering the purpose inline using a consistent arrow symbol.
**before**:
![image](https://github.com/user-attachments/assets/e79c7eaf-7d0b-4460-93ff-233754eaddec)

**now**:
<img width="627" alt="Screenshot 2025-05-13 at 3 46 56 PM" src="https://github.com/user-attachments/assets/fd3c34da-a0d1-4f73-b408-cf91c215ce71" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
