### PR TITLE
fix: /save and /load in feed.json

### DIFF
--- a/feed.json
+++ b/feed.json
@@ -38,7 +38,7 @@
         },
         {
           "type": "added",
-          "description": "Commands `/import` and `/export` for saving and importing conversation state in `q chat` - [#1762](https://github.com/aws/amazon-q-developer-cli/pull/1762)"
+          "description": "Commands `/save` and `/load` for saving and loading conversation state in `q chat` - [#1762](https://github.com/aws/amazon-q-developer-cli/pull/1762)"
         },
         {
           "type": "added",


### PR DESCRIPTION
*Description of changes:*
- Updating `/import` and `/export` to `/save` and `/load` in `feed.json`, since those are the correct command names.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
