### PR TITLE
fix: default chat edit mode to Emacs, feed.json mcp subcommand copy

### DIFF
--- a/crates/chat-cli/src/cli/chat/prompt.rs
+++ b/crates/chat-cli/src/cli/chat/prompt.rs
@@ -273,7 +273,7 @@ pub fn rl(
 ) -> Result<Editor<ChatHelper, DefaultHistory>> {
     let edit_mode = match database.settings.get_string(Setting::ChatEditMode).as_deref() {
         Some("vi" | "vim") => EditMode::Vi,
-        _ => EditMode::Vi,
+        _ => EditMode::Emacs,
     };
     let config = Config::builder()
         .history_ignore_space(true)

--- a/feed.json
+++ b/feed.json
@@ -22,7 +22,7 @@
         },
         {
           "type": "added",
-          "description": "Persistent conversations by working directory in `q chat` - [#1767](https://github.com/aws/amazon-q-developer-cli/pull/1767)"
+          "description": "Persistent conversations by working directory with `q chat --resume` - [#1767](https://github.com/aws/amazon-q-developer-cli/pull/1767)"
         },
         {
           "type": "added",
@@ -39,6 +39,10 @@
         {
           "type": "added",
           "description": "Commands `/save` and `/load` for saving and loading conversation state in `q chat` - [#1762](https://github.com/aws/amazon-q-developer-cli/pull/1762)"
+        },
+        {
+          "type": "added",
+          "description": "A new subcommand `q mcp` for updating MCP server configuration - [#1836](https://github.com/aws/amazon-q-developer-cli/pull/1836)"
         },
         {
           "type": "added",


### PR DESCRIPTION
*Description of changes:*
- Changing the default edit mode back to `Emacs` since using `Vi` is causing some confusion with copy/paste and `ctrl+j` where the cursor is not at the end of the line.
- Adding `feed.json` entries for the `mcp` subcommand.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
