### PR TITLE
feat(chat): Add Shift+Enter for newlines (#1212)

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -220,9 +220,9 @@ const ROTATING_TIPS: [&str; 12] = [
 
 const GREETING_BREAK_POINT: usize = 80;
 
-const POPULAR_SHORTCUTS: &str = color_print::cstr! {"<black!><green!>/help</green!> all commands  <em>•</em>  <green!>ctrl + j</green!> new lines  <em>•</em>  <green!>ctrl + s</green!> fuzzy search</black!>"};
+const POPULAR_SHORTCUTS: &str = color_print::cstr! {"<black!><green!>/help</green!> all commands  <em>•</em>  <green!>ctrl + j</green!> or <green!>shift + enter</green!> new lines  <em>•</em>  <green!>ctrl + s</green!> fuzzy search</black!>"};
 const SMALL_SCREEN_POPULAR_SHORTCUTS: &str = color_print::cstr! {"<black!><green!>/help</green!> all commands
-<green!>ctrl + j</green!> new lines
+<green!>ctrl + j</green!> or <green!>shift + enter</green!> new lines
 <green!>ctrl + s</green!> fuzzy search
 </black!>"};
 
@@ -272,7 +272,7 @@ const HELP_TEXT: &str = color_print::cstr! {"
 
 <cyan,em>Tips:</cyan,em>
 <em>!{command}</em>            <black!>Quickly execute a command in your current session</black!>
-<em>Ctrl(^) + j</em>           <black!>Insert new-line to provide multi-line prompt. Alternatively, [Alt(⌥) + Enter(⏎)]</black!>
+<em>Ctrl(^) + j</em>           <black!>Insert new-line to provide multi-line prompt. Alternatively, [Alt(⌥) + Enter(⏎) or Shift + Enter(⏎)]</black!>
 <em>Ctrl(^) + s</em>           <black!>Fuzzy search commands and context files. Use Tab to select multiple items.</black!>
                       <black!>Change the keybind to ctrl+x with: q settings chat.skimCommandKey x (where x is any key)</black!>
 

--- a/crates/chat-cli/src/cli/chat/prompt.rs
+++ b/crates/chat-cli/src/cli/chat/prompt.rs
@@ -294,6 +294,12 @@ pub fn rl(
         EventHandler::Simple(Cmd::Insert(1, "\n".to_string())),
     );
 
+    // Add custom keybinding for Shift+Enter to insert a newline
+    rl.bind_sequence(
+        KeyEvent(KeyCode::Enter, Modifiers::SHIFT),
+        EventHandler::Simple(Cmd::Insert(1, "\n".to_string())),
+    );
+
     // Add custom keybinding for Ctrl+J to insert a newline
     rl.bind_sequence(
         KeyEvent(KeyCode::Char('j'), Modifiers::CTRL),


### PR DESCRIPTION
*Issue #:* https://github.com/aws/amazon-q-developer-cli/issues/1212

*Description of changes:*

Add Shift+Enter as an additional keyboard shortcut for inserting newlines in chat prompts, alongside the existing Ctrl+J and Alt+Enter options. This follows common conventions in web interfaces and improves user experience.
