### PR TITLE
Fix mcp loading status

### DIFF
--- a/crates/chat-cli/src/cli/chat/command.rs
+++ b/crates/chat-cli/src/cli/chat/command.rs
@@ -58,6 +58,7 @@ pub enum Command {
         path: String,
         force: bool,
     },
+    Mcp,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -837,6 +838,7 @@ impl Command {
                     }
                     Self::Save { path, force }
                 },
+                "mcp" => Self::Mcp,
                 unknown_command => {
                     let looks_like_path = {
                         let after_slash_command_str = parts[1..].join(" ");

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -107,6 +107,7 @@ use token_counter::{
 use tokio::signal::ctrl_c;
 use tool_manager::{
     GetPromptError,
+    LoadingRecord,
     McpServerConfig,
     PromptBundle,
     ToolManager,
@@ -2961,6 +2962,15 @@ impl ChatContext {
                     .collect::<Vec<_>>()
                     .join("");
                 for (server_name, msg) in loaded_servers.iter() {
+                    let msg = msg
+                        .iter()
+                        .map(|record| match record {
+                            LoadingRecord::Err(content)
+                            | LoadingRecord::Warn(content)
+                            | LoadingRecord::Success(content) => content.clone(),
+                        })
+                        .collect::<Vec<_>>()
+                        .join("\n--- tools refreshed ---\n");
                     queue!(
                         self.output,
                         style::Print(server_name),

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -205,7 +205,7 @@ const WELCOME_TEXT: &str = color_print::cstr! {"<cyan!>
 const SMALL_SCREEN_WELCOME_TEXT: &str = color_print::cstr! {"<em>Welcome to <cyan!>Amazon Q</cyan!>!</em>"};
 const RESUME_TEXT: &str = color_print::cstr! {"<em>Picking up where we left off...</em>"};
 
-const ROTATING_TIPS: [&str; 12] = [
+const ROTATING_TIPS: [&str; 13] = [
     color_print::cstr! {"You can resume the last conversation from your current directory by launching with <green!>q chat --resume</green!>"},
     color_print::cstr! {"Get notified whenever Q CLI finishes responding. Just run <green!>q settings chat.enableNotifications true</green!>"},
     color_print::cstr! {"You can use <green!>/editor</green!> to edit your prompt with a vim-like experience"},
@@ -218,6 +218,7 @@ const ROTATING_TIPS: [&str; 12] = [
     color_print::cstr! {"If you want to file an issue to the Q CLI team, just tell me, or run <green!>q issue</green!>"},
     color_print::cstr! {"You can enable custom tools with <green!>MCP servers</green!>. Learn more with /help"},
     color_print::cstr! {"You can specify wait time (in ms) for mcp server loading with <green!>q settings mcp.initTimeout {timeout in int}</green!>. Servers that takes longer than the specified time will continue to load in the background. Use /tools to see pending servers."},
+    color_print::cstr! {"You can see the server load status as well as any warnings or errors associated with <green!>/mcp</green!>"},
 ];
 
 const GREETING_BREAK_POINT: usize = 80;
@@ -247,6 +248,7 @@ const HELP_TEXT: &str = color_print::cstr! {"
   <em>untrust</em>     <black!>Revert a tool or tools to per-request confirmation</black!>
   <em>trustall</em>    <black!>Trust all tools (equivalent to deprecated /acceptall)</black!>
   <em>reset</em>       <black!>Reset all tools to default permission levels</black!>
+<em>/mcp</em>          <black!>See mcp server loaded</black!>
 <em>/profile</em>      <black!>Manage profiles</black!>
   <em>help</em>        <black!>Show profile help</black!>
   <em>list</em>        <black!>List profiles</black!>

--- a/crates/chat-cli/src/cli/chat/server_messenger.rs
+++ b/crates/chat-cli/src/cli/chat/server_messenger.rs
@@ -14,23 +14,23 @@ use crate::mcp_client::{
 };
 
 #[allow(dead_code)]
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum UpdateEventMessage {
     ToolsListResult {
         server_name: String,
-        result: ToolsListResult,
+        result: eyre::Result<ToolsListResult>,
     },
     PromptsListResult {
         server_name: String,
-        result: PromptsListResult,
+        result: eyre::Result<PromptsListResult>,
     },
     ResourcesListResult {
         server_name: String,
-        result: ResourcesListResult,
+        result: eyre::Result<ResourcesListResult>,
     },
     ResourceTemplatesListResult {
         server_name: String,
-        result: ResourceTemplatesListResult,
+        result: eyre::Result<ResourceTemplatesListResult>,
     },
     InitStart {
         server_name: String,
@@ -67,7 +67,7 @@ pub struct ServerMessenger {
 
 #[async_trait::async_trait]
 impl Messenger for ServerMessenger {
-    async fn send_tools_list_result(&self, result: ToolsListResult) -> Result<(), MessengerError> {
+    async fn send_tools_list_result(&self, result: eyre::Result<ToolsListResult>) -> Result<(), MessengerError> {
         Ok(self
             .update_event_sender
             .send(UpdateEventMessage::ToolsListResult {
@@ -78,7 +78,7 @@ impl Messenger for ServerMessenger {
             .map_err(|e| MessengerError::Custom(e.to_string()))?)
     }
 
-    async fn send_prompts_list_result(&self, result: PromptsListResult) -> Result<(), MessengerError> {
+    async fn send_prompts_list_result(&self, result: eyre::Result<PromptsListResult>) -> Result<(), MessengerError> {
         Ok(self
             .update_event_sender
             .send(UpdateEventMessage::PromptsListResult {
@@ -89,7 +89,10 @@ impl Messenger for ServerMessenger {
             .map_err(|e| MessengerError::Custom(e.to_string()))?)
     }
 
-    async fn send_resources_list_result(&self, result: ResourcesListResult) -> Result<(), MessengerError> {
+    async fn send_resources_list_result(
+        &self,
+        result: eyre::Result<ResourcesListResult>,
+    ) -> Result<(), MessengerError> {
         Ok(self
             .update_event_sender
             .send(UpdateEventMessage::ResourcesListResult {
@@ -102,7 +105,7 @@ impl Messenger for ServerMessenger {
 
     async fn send_resource_templates_list_result(
         &self,
-        result: ResourceTemplatesListResult,
+        result: eyre::Result<ResourceTemplatesListResult>,
     ) -> Result<(), MessengerError> {
         Ok(self
             .update_event_sender

--- a/crates/chat-cli/src/cli/chat/tool_manager.rs
+++ b/crates/chat-cli/src/cli/chat/tool_manager.rs
@@ -858,13 +858,15 @@ impl ToolManager {
                     let still_loading = self.pending_clients.read().await.iter().cloned().collect::<Vec<_>>();
                     let _ = tx.send(LoadingMsg::Terminate { still_loading }).await;
                 }
-                let _ = queue!(
-                    output,
-                    style::Print(
-                        "Not all mcp servers loaded. Configure no-interactive timeout with q settings mcp.noInteractiveTimeout"
-                    ),
-                    style::Print("\n------\n")
-                );
+                if !self.clients.is_empty() {
+                    let _ = queue!(
+                        output,
+                        style::Print(
+                            "Not all mcp servers loaded. Configure no-interactive timeout with q settings mcp.noInteractiveTimeout"
+                        ),
+                        style::Print("\n------\n")
+                    );
+                }
             },
             _ = server_loading_fut => {
                 if let Some(tx) = tx {

--- a/crates/chat-cli/src/cli/chat/tool_manager.rs
+++ b/crates/chat-cli/src/cli/chat/tool_manager.rs
@@ -855,8 +855,7 @@ impl ToolManager {
                     let still_loading = self.pending_clients.read().await.iter().cloned().collect::<Vec<_>>();
                     let _ = tx.send(LoadingMsg::Terminate { still_loading }).await;
                 }
-                error!("## timeout: timed out");
-                if !self.clients.is_empty() {
+                if !self.clients.is_empty() && !self.is_interactive {
                     let _ = queue!(
                         output,
                         style::Print(
@@ -867,14 +866,12 @@ impl ToolManager {
                 }
             },
             _ = server_loading_fut => {
-                error!("## timeout: server load finish");
                 if let Some(tx) = tx {
                     let still_loading = self.pending_clients.read().await.iter().cloned().collect::<Vec<_>>();
                     let _ = tx.send(LoadingMsg::Terminate { still_loading }).await;
                 }
             }
             _ = ctrl_c() => {
-                error!("## timeout: ctrl c");
                 if self.is_interactive {
                     if let Some(tx) = tx {
                         let still_loading = self.pending_clients.read().await.iter().cloned().collect::<Vec<_>>();

--- a/crates/chat-cli/src/mcp_client/client.rs
+++ b/crates/chat-cli/src/mcp_client/client.rs
@@ -573,28 +573,27 @@ where
 {
     // TODO: decouple pagination logic from request and have page fetching logic here
     // instead
-    let resp = match client.request("tools/list", None).await {
-        Ok(resp) => resp,
-        Err(e) => {
-            tracing::error!("Failed to retrieve tool list from {}: {:?}", client.server_name, e);
-            return;
-        },
-    };
-    if let Some(error) = resp.error {
-        let msg = format!("Failed to retrieve tool list for {}: {:?}", client.server_name, error);
-        tracing::error!("{}", &msg);
-        return;
-    }
-    let Some(result) = resp.result else {
-        tracing::error!("Tool list response from {} is missing result", client.server_name);
-        return;
-    };
-    let tool_list_result = match serde_json::from_value::<ToolsListResult>(result) {
-        Ok(result) => result,
-        Err(e) => {
-            tracing::error!("Failed to deserialize tool result from {}: {:?}", client.server_name, e);
-            return;
-        },
+    let tool_list_result = 'tool_list_result: {
+        let resp = match client.request("tools/list", None).await {
+            Ok(resp) => resp,
+            Err(e) => break 'tool_list_result Err(e.into()),
+        };
+        if let Some(error) = resp.error {
+            let msg = format!("Failed to retrieve tool list for {}: {:?}", client.server_name, error);
+            break 'tool_list_result Err(eyre::eyre!(msg));
+        }
+        let Some(result) = resp.result else {
+            let msg = format!("Tool list response from {} is missing result", client.server_name);
+            break 'tool_list_result Err(eyre::eyre!(msg));
+        };
+        let tool_list_result = match serde_json::from_value::<ToolsListResult>(result) {
+            Ok(result) => result,
+            Err(e) => {
+                let msg = format!("Failed to deserialize tool result from {}: {:?}", client.server_name, e);
+                break 'tool_list_result Err(eyre::eyre!(msg));
+            },
+        };
+        Ok::<ToolsListResult, eyre::Report>(tool_list_result)
     };
     if let Some(messenger) = messenger {
         let _ = messenger

--- a/crates/chat-cli/src/mcp_client/messenger.rs
+++ b/crates/chat-cli/src/mcp_client/messenger.rs
@@ -16,21 +16,22 @@ use super::{
 pub trait Messenger: std::fmt::Debug + Send + Sync + 'static {
     /// Sends the result of a tools list operation to the consumer
     /// This function is used to deliver information about available tools
-    async fn send_tools_list_result(&self, result: ToolsListResult) -> Result<(), MessengerError>;
+    async fn send_tools_list_result(&self, result: eyre::Result<ToolsListResult>) -> Result<(), MessengerError>;
 
     /// Sends the result of a prompts list operation to the consumer
     /// This function is used to deliver information about available prompts
-    async fn send_prompts_list_result(&self, result: PromptsListResult) -> Result<(), MessengerError>;
+    async fn send_prompts_list_result(&self, result: eyre::Result<PromptsListResult>) -> Result<(), MessengerError>;
 
     /// Sends the result of a resources list operation to the consumer
     /// This function is used to deliver information about available resources
-    async fn send_resources_list_result(&self, result: ResourcesListResult) -> Result<(), MessengerError>;
+    async fn send_resources_list_result(&self, result: eyre::Result<ResourcesListResult>)
+    -> Result<(), MessengerError>;
 
     /// Sends the result of a resource templates list operation to the consumer
     /// This function is used to deliver information about available resource templates
     async fn send_resource_templates_list_result(
         &self,
-        result: ResourceTemplatesListResult,
+        result: eyre::Result<ResourceTemplatesListResult>,
     ) -> Result<(), MessengerError>;
 
     /// Signals to the orchestrator that a server has started initializing
@@ -52,21 +53,24 @@ pub struct NullMessenger;
 
 #[async_trait::async_trait]
 impl Messenger for NullMessenger {
-    async fn send_tools_list_result(&self, _result: ToolsListResult) -> Result<(), MessengerError> {
+    async fn send_tools_list_result(&self, _result: eyre::Result<ToolsListResult>) -> Result<(), MessengerError> {
         Ok(())
     }
 
-    async fn send_prompts_list_result(&self, _result: PromptsListResult) -> Result<(), MessengerError> {
+    async fn send_prompts_list_result(&self, _result: eyre::Result<PromptsListResult>) -> Result<(), MessengerError> {
         Ok(())
     }
 
-    async fn send_resources_list_result(&self, _result: ResourcesListResult) -> Result<(), MessengerError> {
+    async fn send_resources_list_result(
+        &self,
+        _result: eyre::Result<ResourcesListResult>,
+    ) -> Result<(), MessengerError> {
         Ok(())
     }
 
     async fn send_resource_templates_list_result(
         &self,
-        _result: ResourceTemplatesListResult,
+        _result: eyre::Result<ResourceTemplatesListResult>,
     ) -> Result<(), MessengerError> {
         Ok(())
     }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/amazon-q-developer-cli/issues/1856
The TLDR is that because tool list calls are now done passively, early errors with mcp server load is terminating the mcp server loading status task prematurely.

*Description of changes:*
- Precompuates total number of servers (which are used to determine when to terminate the mcp loading status task) prior to spawning the task
- Changes display task to use async task as opposed to spawning a dedicated blocking thread. This was previously needed because we were holding onto a stdout lock. But we are no longer doing that, thus rendering the dedicated blocking thread unnecessary.
- Adds `/mcp` slash command to show server load records.

*Testing some workflows:*
- [x] *Load in interactive mode with correct config with timeout set to max*
	- Everything should be loaded before conversation starts
<img width="2154" alt="image" src="https://github.com/user-attachments/assets/72b00427-847c-407c-bfa6-2fda714706d7" />

- [x] *Load in interactive mode with incorrect config with timeout set to max*
	- Status should still show
	- Error associated with incorrect config should be shown 
	- Fast returning error (i.e. incorrect bin name) should not terminate status display
<img width="2154" alt="image" src="https://github.com/user-attachments/assets/9f1a7bc3-71b6-4181-a4fd-cc16f1d8ad88" />

- [x] *Load in interactive mode with correct config with timeout set to default (5s)*
	- Servers that do not load within the timeout should be displayed under "servers still loading" section
<img width="2154" alt="image" src="https://github.com/user-attachments/assets/3771e8e8-cff9-42b2-894e-bad6710ff73f" />

- [x] *Load in interactive mode with incorrect config with timeout set to default (5s)*
	- Servers that do not load within the timeout should be displayed under "servers still loading" section
	- Errors should be displayed in the status
<img width="2154" alt="image" src="https://github.com/user-attachments/assets/d3a56083-f322-45c5-a847-ad9874e6953f" />

- [x] *Load in no-interactive mode with correct config with no-interactive timeout set to max*
	- Status should not show
	- Everything should be loaded before conversation starts
<img width="2154" alt="image" src="https://github.com/user-attachments/assets/6fe5f1b5-46c4-48c3-991a-780f7848d110" />

- [x] *Load in no-interactive mode with incorrect config with no-interactive timeout set to max*
	- Status should only show errors 
<img width="2154" alt="image" src="https://github.com/user-attachments/assets/b625be03-c1af-4b4c-9b78-0c04ddde3269" />

- [x] *Load in no-interactive mode with correct config with timeout set to a shorter time (5s)*
	- Success status should not show
	- Warning should show for that the fact that some servers did not load 
	- Actual servers should be logged
<img width="2154" alt="image" src="https://github.com/user-attachments/assets/65873e40-bca0-4eeb-a0c2-fecb9ad2ddf7" />

- [x] *Load in no-interactive mode with incorrect config with timeout set to a shorter time (5s)*
	- Success status should not show
	- Errors should show to notify users that some servers did not load properly
	- Actual servers should be logged
<img width="2154" alt="image" src="https://github.com/user-attachments/assets/a59f42a3-8581-416b-94c2-e73775aad3f7" />

Added tip:
<img width="739" alt="image" src="https://github.com/user-attachments/assets/d99909f3-4532-4c1c-ad70-28ad5b67721b" />

`/mcp` with partial loaded servers:
<img width="2154" alt="image" src="https://github.com/user-attachments/assets/087a00dc-d778-4474-8bb2-40dda903b0ef" />

`/mcp` with all servers loaded:
<img width="2154" alt="image" src="https://github.com/user-attachments/assets/b3aa8a2d-5c61-4d42-8736-1624f9b5789b" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
