### PR TITLE
fix: Add newline after directory depth message in fs_read tool output

### DIFF
--- a/crates/cli/src/cli/chat/tools/fs_read.rs
+++ b/crates/cli/src/cli/chat/tools/fs_read.rs
@@ -368,7 +368,7 @@ impl FsDirectory {
         let depth = self.depth.unwrap_or_default();
         Ok(queue!(
             updates,
-            style::Print(format!("with maximum depth of {}", depth))
+            style::Print(format!("with maximum depth of {}\n", depth))
         )?)
     }
 


### PR DESCRIPTION
## Description
This PR adds a missing newline character after the directory depth message in the fs_read tool's output formatting. The change improves readability by ensuring proper line breaks between the depth information and subsequent directory content listings.

## Changes
- Modified the `queue_description` method in the `FsDirectory` struct to include a newline character at the end of the depth message output

**Before:**
Reading directory: /amazon-q-developer-cli/crates/cli/src/cli/chat/tools with maximum depth of 0Reading: crates/cli/src/cli/chat/tools
 
 **After:**
Reading directory: /amazon-q-developer-cli/crates/cli/src/cli/chat/tools with maximum depth of 0
Reading: crates/cli/src/cli/chat/tools

## Testing
Verified that the output now correctly displays with proper line breaks when using the fs_read tool in directory mode with depth parameter.

## Related Issues
N/A