### PR TITLE
chore: Update CLI binary name references in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,14 +146,14 @@ pnpm install --ignore-scripts
 ### 3. Start Local Development
 To compile and view changes made to `q chat`:
 ```shell
-cargo run --bin chat_cli
+cargo run --bin cli
 ```
 
-> If you are working on other q commands, just append `-- <command name>`. For example, to run `q login`, you can run `cargo run --bin chat_cli -- login`
+> If you are working on other q commands, just append `-- <command name>`. For example, to run `q login`, you can run `cargo run --bin cli -- login`
 
 To run tests for the Q CLI crate:
 ```shell
-cargo test -p chat_cli
+cargo test -p cli
 ```
 
 To format Rust files:


### PR DESCRIPTION
*Issue #, if available:* 
None (should I create one for this type of change?)

*Description of changes:*

Update references from 'chat_cli' to 'cli' in the README.md development instructions to reflect the current binary name. This ensures developers follow the correct commands for local development and testing.

Before this change, I got the following output when running the commands as per the README.md file:
```bash
$ cargo run --bin chat_cli
error: no bin target named `chat_cli`.
Available bin targets:
    cli
    test_mcp_server

$ cargo test -p chat_cli
error: package ID specification `chat_cli` did not match any package
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
