### PR TITLE
Fix: Allow --trust-tools to work on MCP servers

### DIFF
--- a/crates/cli/src/cli/chat/mod.rs
+++ b/crates/cli/src/cli/chat/mod.rs
@@ -435,6 +435,14 @@ pub async fn chat(
         }
     } else if let Some(trusted) = trust_tools.map(|vec| vec.into_iter().collect::<HashSet<_>>()) {
         // --trust-all-tools takes precedence over --trust-tools=...
+        for tool_name in &trusted {
+            if !tool_name.is_empty() {
+                // Store the original trust settings for later use with MCP tools
+                tool_permissions.add_pending_trust_pattern(tool_name.clone());
+            }
+        }
+
+        // Apply to currently known tools
         for tool in tool_config.values() {
             if trusted.contains(&tool.name) {
                 tool_permissions.trust_tool(&tool.name);
@@ -1292,7 +1300,8 @@ impl ChatContext {
             style::SetForegroundColor(Color::Reset),
             style::SetAttribute(Attribute::Reset)
         )?;
-        let user_input = match self.read_user_input(&self.generate_tool_trust_prompt(), false) {
+        let prompt = self.generate_tool_trust_prompt();
+        let user_input = match self.read_user_input(&prompt, false) {
             Some(input) => input,
             None => return Ok(ChatState::Exit),
         };
@@ -2428,12 +2437,14 @@ impl ChatContext {
                                     .iter()
                                     .fold(String::new(), |mut acc, FigTool::ToolSpecification(spec)| {
                                         let width = longest - spec.name.len() + 4;
+                                        let trust_status = self.tool_permissions.display_label(&spec.name);
+
                                         acc.push_str(
                                             format!(
                                                 "- {}{:>width$}{}\n",
                                                 spec.name,
                                                 "",
-                                                self.tool_permissions.display_label(&spec.name),
+                                                trust_status,
                                                 width = width
                                             )
                                             .as_str(),
@@ -3628,8 +3639,10 @@ impl ChatContext {
     }
 
     /// Helper function to generate a prompt based on the current context
-    fn generate_tool_trust_prompt(&self) -> String {
-        prompt::generate_prompt(self.conversation_state.current_profile(), self.all_tools_trusted())
+    fn generate_tool_trust_prompt(&mut self) -> String {
+        let profile = self.conversation_state.current_profile().map(|s| s.to_string());
+        let all_trusted = self.all_tools_trusted();
+        prompt::generate_prompt(profile.as_deref(), all_trusted)
     }
 
     async fn send_tool_use_telemetry(&mut self, telemetry: &TelemetryThread) {
@@ -3648,7 +3661,7 @@ impl ChatContext {
         (self.terminal_width_provider)().unwrap_or(80)
     }
 
-    fn all_tools_trusted(&self) -> bool {
+    fn all_tools_trusted(&mut self) -> bool {
         self.conversation_state.tools.values().flatten().all(|t| match t {
             FigTool::ToolSpecification(t) => self.tool_permissions.is_trusted(&t.name),
         })

--- a/crates/cli/src/cli/chat/tools/mod.rs
+++ b/crates/cli/src/cli/chat/tools/mod.rs
@@ -6,7 +6,10 @@ pub mod gh_issue;
 pub mod thinking;
 pub mod use_aws;
 
-use std::collections::HashMap;
+use std::collections::{
+    HashMap,
+    HashSet,
+};
 use std::io::Write;
 use std::path::{
     Path,
@@ -125,6 +128,8 @@ pub struct ToolPermissions {
     // We need this field for any stragglers
     pub trust_all: bool,
     pub permissions: HashMap<String, ToolPermission>,
+    // Store pending trust patterns for MCP tools that may be loaded later
+    pub pending_trusted_patterns: HashSet<String>,
 }
 
 impl ToolPermissions {
@@ -132,23 +137,30 @@ impl ToolPermissions {
         Self {
             trust_all: false,
             permissions: HashMap::with_capacity(capacity),
+            pending_trusted_patterns: HashSet::new(),
         }
     }
 
-    pub fn is_trusted(&self, tool_name: &str) -> bool {
-        self.trust_all || self.permissions.get(tool_name).is_some_and(|perm| perm.trusted)
+    pub fn is_trusted(&mut self, tool_name: &str) -> bool {
+        // Check if we should trust from pending patterns first
+        if self.should_trust_from_pending(tool_name) {
+            self.trust_tool(tool_name);
+            self.pending_trusted_patterns.remove(tool_name);
+        }
+        
+        self.trust_all ||
+        self.permissions.get(tool_name).is_some_and(|perm| perm.trusted)
     }
 
     /// Returns a label to describe the permission status for a given tool.
-    pub fn display_label(&self, tool_name: &str) -> String {
-        if self.has(tool_name) || self.trust_all {
-            if self.is_trusted(tool_name) {
-                format!("  {}", "trusted".dark_green().bold())
-            } else {
-                format!("  {}", "not trusted".dark_grey())
-            }
-        } else {
-            self.default_permission_label(tool_name)
+    pub fn display_label(&mut self, tool_name: &str) -> String {
+        let is_trusted = self.is_trusted(tool_name);
+        let has_setting = self.has(tool_name) || self.trust_all;
+
+        match (has_setting, is_trusted) {
+            (true, true) => format!("  {}", "trusted".dark_green().bold()),
+            (true, false) => format!("  {}", "not trusted".dark_grey()),
+            _ => self.default_permission_label(tool_name),
         }
     }
 
@@ -159,6 +171,7 @@ impl ToolPermissions {
 
     pub fn untrust_tool(&mut self, tool_name: &str) {
         self.trust_all = false;
+        self.pending_trusted_patterns.remove(tool_name);
         self.permissions
             .insert(tool_name.to_string(), ToolPermission { trusted: false });
     }
@@ -166,6 +179,7 @@ impl ToolPermissions {
     pub fn reset(&mut self) {
         self.trust_all = false;
         self.permissions.clear();
+        self.pending_trusted_patterns.clear();
     }
 
     pub fn reset_tool(&mut self, tool_name: &str) {
@@ -173,7 +187,24 @@ impl ToolPermissions {
         self.permissions.remove(tool_name);
     }
 
-    pub fn has(&self, tool_name: &str) -> bool {
+    /// Add a pending trust pattern for tools that may be loaded later
+    pub fn add_pending_trust_pattern(&mut self, pattern: String) {
+        self.pending_trusted_patterns.insert(pattern);
+    }
+
+    /// Check if a tool should be trusted based on preceding trust declarations
+    pub fn should_trust_from_pending(&self, tool_name: &str) -> bool {
+        // Check for exact match
+        self.pending_trusted_patterns.contains(tool_name)
+    }
+
+    pub fn has(&mut self, tool_name: &str) -> bool {
+        // Check if we should trust from pending patterns first
+        if self.should_trust_from_pending(tool_name) {
+            self.trust_tool(tool_name);
+            self.pending_trusted_patterns.remove(tool_name);
+        }
+
         self.permissions.contains_key(tool_name)
     }
 


### PR DESCRIPTION
*Issue #, if available:*

Currently if you call `--trust-tools` with tools that will be vended by MCP servers, the configuration doesn't take effect.

Reproduction steps:
1. Run `q chat --trust-tools=<tool>` (e.g. `clear_thought___sequentialthinking`)
2. Wait for the MCP server to start up
3. Run `/tools` to check trust status
4. Validate the (incorrectly untrusted) trust status by asking Q to run the tool for some trivial purpose.

*Description of changes:*

This PR modifies the `ToolPermissions` implementation to track tools from the `--trust-tools` config that don't exist yet, and triggers adding them to `permissions` when they're available. It also configures `untrust_tool` to modify this pending config as well as `permissions`, to avoid edge-cases where a tool can't be untrusted due to being in the pending list.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Disclaimer: Any opinions or communications in this pull request are entirely my own, and do not reflect those of AWS or its other employees.
