### PR TITLE
Added support for non-interactive login option (--no-interactive)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,14 +146,14 @@ pnpm install --ignore-scripts
 ### 3. Start Local Development
 To compile and view changes made to `q chat`:
 ```shell
-cargo run --bin chat_cli
+cargo run --bin cli
 ```
 
-> If you are working on other q commands, just append `-- <command name>`. For example, to run `q login`, you can run `cargo run --bin chat_cli -- login`
+> If you are working on other q commands, just append `-- <command name>`. For example, to run `q login`, you can run `cargo run --bin cli -- login`
 
 To run tests for the Q CLI crate:
 ```shell
-cargo test -p chat_cli
+cargo test -p cli
 ```
 
 To format Rust files:


### PR DESCRIPTION
Update to README.md (removed references to chat_cli and updated to cli)

*Issue #, if available:*
N/A
*Description of changes:*
Added a non-interactive login option to remove undesired behaviour whereby user will need to validate the parameters provided using q login arguments.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
