### PR TITLE
RFC: Add persistent chat history with workspace-based sessions

### DIFF
--- a/docs/rfcs/persistent-chat-history.md
+++ b/docs/rfcs/persistent-chat-history.md
@@ -1,0 +1,1448 @@
+# RFC: Persistent Chat History with Workspace-Based Sessions
+
+## Summary
+
+Add workspace-based persistent chat history that enables multi-persona development workflows, cross-session knowledge sharing, and comprehensive project context management. This system automatically detects project boundaries (git repositories or current directories), maintains conversation history across terminal sessions, and provides powerful session management, search, and export/import capabilities for individual and team collaboration.
+
+Key capabilities include:
+- **Multi-persona workflows**: Different sessions for implementation, review, architecture, and operations perspectives within the same project
+- **Cross-session context**: Reference and build upon previous conversations through context integration and import/export
+- **Team collaboration**: Export successful debugging sessions for knowledge sharing and import solutions from other projects or team members
+- **Comprehensive search**: Find sessions by topic/metadata or search within conversation content across all workspace history
+- **Professional workflows**: Support complex, multi-step problem-solving that spans multiple conversations with systematic validation processes
+
+## Motivation
+
+Currently, Amazon Q CLI chat sessions are ephemeral, creating significant limitations for professional development workflows:
+
+### Basic Workflow Limitations
+
+- **Session Loss**: Accidental terminal closure loses entire conversation context during complex problem-solving sessions
+- **No Project Context**: Conversations aren't tied to specific codebases or projects, making it difficult to maintain relevant context
+- **Limited Collaboration**: No way to share AI-assisted problem-solving sessions with team members or reference successful solutions
+- **Restart Overhead**: Users must re-establish context and repeat explanations after session loss, wasting time and breaking flow
+
+### Missing Advanced Capabilities
+
+- **Multi-Perspective Analysis**: No way to approach the same problem from different angles (implementation vs security vs operations perspectives)
+- **Systematic Validation**: Cannot build something in one session and critically review it in another, missing opportunities for self-validation
+- **Knowledge Transfer**: Successful debugging sessions and architectural solutions cannot be easily shared, documented, or reused across projects
+- **Cross-Session Learning**: No ability to build upon previous conversations or reference past solutions when working on related problems
+
+### Professional Development Impact
+
+This is particularly limiting for complex workflows like infrastructure management, architectural decisions, and multi-step debugging where:
+
+- **Context Accumulation**: Understanding complex problems requires building context over multiple interactions
+- **Multiple Perspectives**: Thorough analysis needs different viewpoints (developer, reviewer, architect, operations)
+- **Team Collaboration**: Sharing problem-solving approaches and successful solutions accelerates team learning
+- **Learning from Past Solutions**: Referencing previous work prevents repeating analysis and enables building on past insights
+- **Systematic Problem-Solving**: Professional development requires structured approaches to validation and review
+
+### Competitive Disadvantage
+
+Other AI development tools (like Cursor, Cline) provide persistent conversation history, putting Amazon Q CLI at a disadvantage for:
+- Complex, multi-session development workflows
+- Team collaboration and knowledge sharing
+- Professional development practices that require conversation continuity
+
+The workspace-based persistent chat history system addresses these limitations while enabling entirely new workflows like multi-persona development, systematic validation processes, and structured knowledge sharing that transform how developers interact with AI assistance from a simple Q&A tool into a comprehensive development workflow platform.
+
+## Guide-level explanation
+
+### Overview
+
+The workspace-based chat history system automatically detects your project context and maintains conversation history tied to that workspace. When you start `q chat` in a project directory, it either continues your previous conversation or starts a new session within that project's context.
+
+### Workspace Detection
+
+The system automatically detects workspaces using this simple priority order:
+1. **Git repository root**: Walk up directory tree to find `.git` directory
+2. **Current directory**: If no git repository found, use current working directory
+
+Each workspace gets a unique identity based on its canonical path, ensuring conversations remain tied to the correct project even if accessed from different subdirectories.
+
+### Session Management
+
+Within each workspace, you can have multiple conversation sessions:
+
+- **Default behavior**: Each `q chat` invocation creates a new session automatically
+- **Session resume**: Use explicit commands to resume previous sessions when needed
+- **Multiple sessions**: Maintain separate conversation threads for different topics or approaches
+- **Session switching**: Move between different conversation threads within the same workspace
+
+### Basic Usage
+
+#### Automatic New Sessions
+```bash
+# Each invocation creates a new session
+cd /my-project
+q chat
+# Creates session-20250621-143022 automatically (YYYYMMDD-HHMMSS format)
+
+# Later invocation
+q chat  
+# Creates session-20250621-150000 automatically
+```
+
+#### Session Management Commands
+```bash
+# List and navigate sessions
+/sessions list                          # List sessions with first prompt preview (10 most recent)
+/sessions list --limit 20               # Show 20 sessions
+/sessions list --page 2                 # Show next page of sessions
+/sessions list --global                 # List sessions across all workspaces  
+/sessions list --workspace /path/to/project # List sessions for specific workspace
+
+# Search sessions by metadata
+/sessions search "kubernetes"           # Search sessions by first prompt and session names
+/sessions search "deployment" --global  # Search session metadata across all workspaces
+
+# Resume sessions
+/sessions resume 1                      # Resume session by list number
+/sessions resume session-20250621-143022 # Resume by session ID
+/sessions resume latest                 # Resume most recent session
+/sessions resume latest --global        # Resume most recent session globally
+
+# Manage sessions
+/sessions new "Bug fixing"              # Create a named session (optional)
+/sessions rename session-20250621-143022 "New name" # Rename a session
+/sessions delete session-20250621-143022           # Delete a session
+/sessions archive session-20250621-143022          # Archive old session
+/sessions info                          # Show workspace session statistics
+/sessions cleanup --dry-run             # Preview cleanup actions
+
+# Export and import
+/sessions export session-20250621-143022 --format json --path ./session.json      # Export for import/backup
+/sessions export session-20250621-143022 --format markdown --path ./session.md    # Export for documentation
+/sessions import ./session.json         # Import conversation into current session
+```
+
+**Example `/sessions list` output:**
+```
+Current Workspace: /home/user/my-project (3 sessions)
+
+[1] session-20250621-143022 (2 hours ago, 15 messages)
+    → "How do I fix this Kubernetes deployment error with ImagePullBackOff?"
+    
+[2] session-20250621-091500 (5 hours ago, 8 messages)  
+    → "Can you help me set up CloudWatch monitoring for my Lambda function?"
+    
+[3] session-20250620-160000 (1 day ago, 23 messages)
+    → "I need to migrate this database schema, what's the safest approach?"
+
+Use '/sessions resume 1' or '/sessions resume session-20250621-143022' to continue a session.
+```
+
+#### Cross-Session Context
+```bash
+# Reference previous sessions
+/history search "deployment error"      # Search across all workspace sessions
+/context add-session session-20250621-143022   # Add another session's full chat history as context
+/context list-sessions                  # Show sessions currently added to context
+/context remove-session session-20250621-143022 # Remove session from current context
+```
+
+### Workspace Organization and Cross-Session Context
+
+#### Storage Structure
+```
+~/.amazon-q/workspaces/
+├── workspace-hash-abc123/      # Hash of /home/user/my-project
+│   ├── workspace.json          # Workspace metadata
+│   ├── workspace.db           # All sessions + messages for this workspace
+│   └── exports/               # Exported conversations
+└── workspace-hash-def456/      # Hash of /home/user/other-project
+    ├── workspace.json
+    ├── workspace.db
+    └── exports/
+```
+
+#### Cross-Session Context Commands
+```bash
+# Reference previous sessions
+/history search "deployment error"      # Search across all workspace sessions
+/context add-session session-20250621-143022   # Add another session's full chat history as context
+/context list-sessions                  # Show sessions currently added to context
+/context remove-session session-20250621-143022 # Remove session from current context
+```
+
+### Cross-Session Context Integration
+
+One of the most powerful features of workspace-based chat history is the ability to reference and build upon previous conversations. The `/context add-session` command allows you to bring the full context of previous chat sessions into your current conversation.
+
+#### How Cross-Session Context Works
+
+When you use `/context add-session <session-id>`, the system:
+
+1. **Loads Complete History**: Retrieves all messages from the specified session (user messages, AI responses, tool executions, and results)
+2. **Adds to Current Context**: Incorporates that conversation history into your current session's context window
+3. **Maintains References**: Tracks which external sessions are being referenced for context management
+4. **Enables AI Reasoning**: Allows the AI to reference solutions, patterns, and context from previous conversations
+
+#### Practical Examples
+
+**Scenario 1: Continuing Previous Work**
+```bash
+# Yesterday's session: Debugging a deployment issue
+Session-20250620-143022:
+You: "My Kubernetes deployment is failing with ImagePullBackOff"
+Q: "Let's check your image registry settings..."
+[... conversation continues with solution ...]
+
+# Today's session: Similar issue
+You: "I'm getting another deployment error, different service"
+/context add-session session-20250620-143022
+Q: "Based on yesterday's session, this looks similar to the ImagePullBackOff issue. 
+   Let me check if it's the same registry authentication problem..."
+```
+
+**Scenario 2: Building on Previous Solutions**
+```bash
+# Previous session: Setting up monitoring
+Session-20250619-091500:
+You: "How do I set up CloudWatch monitoring for my Lambda?"
+Q: "Here's how to configure CloudWatch metrics..."
+[... detailed setup conversation ...]
+
+# Current session: Extending monitoring
+You: "I want to add alerting to the monitoring we set up"
+/context add-session session-20250619-091500
+Q: "Great! Since we already set up CloudWatch monitoring in your previous session,
+   let's add SNS alerts to those existing metrics..."
+```
+
+### Session Display and Identification
+
+#### Task-Oriented Session Listing
+
+Sessions are treated as "tasks" and displayed with meaningful context rather than just timestamps. The `/sessions list` command shows:
+
+1. **Chronological order**: Latest sessions first (most recent activity)
+2. **First prompt preview**: The initial user message that started the session
+3. **Session metadata**: Timestamp, message count, and activity indicators
+4. **Quick access**: Numbered list for easy resume commands
+
+#### Session List Format and Pagination
+
+**Default Display**: Shows 10 most recent sessions per workspace  
+**Ordering**: Sessions ordered by `last_active` timestamp (most recent first)
+
+```
+Current Workspace: /home/user/my-project (25 sessions total, showing 10 most recent)
+
+[1] session-20250621-143022 (2 hours ago, 15 messages) ⚡ Active
+    → "How do I fix this Kubernetes deployment error with ImagePullBackOff?"
+    
+[2] session-20250621-091500 (5 hours ago, 8 messages)
+    → "Can you help me set up CloudWatch monitoring for my Lambda function?"
+    
+[3] session-20250620-160000 (1 day ago, 23 messages)
+    → "I need to migrate this database schema, what's the safest approach?"
+    
+[4] "Database Migration" (2 days ago, 45 messages) 📌 Named
+    → "Let's plan the migration from PostgreSQL 12 to 14 for the production system"
+    
+[5] session-20250619-140000 (3 days ago, 12 messages)
+    → "Why is my Docker build failing with permission denied errors?"
+
+... 5 more sessions shown ...
+
+[10] session-20250618-090000 (5 days ago, 8 messages)
+     → "How do I configure SSL certificates for my nginx setup?"
+
+Showing 1-10 of 25 sessions. Use '/sessions list --page 2' for more.
+Use '/sessions resume <number>' to continue a session.
+```
+
+**Pagination Commands**:
+```bash
+/sessions list                    # Show first 10 sessions (default)
+/sessions list --limit 20         # Show 20 sessions
+/sessions list --page 2           # Show sessions 11-20
+/sessions list --all              # Show all sessions (up to workspace limit)
+```
+
+#### First Prompt Processing Rules
+
+**Truncation Logic**:
+- **Single line prompts**: Show in full (up to 80 characters)
+- **Multi-line prompts**: Show first line only + "..." if truncated
+- **Long single lines**: Truncate at word boundary + "..."
+- **Code-heavy prompts**: Show descriptive part, truncate code blocks
+
+**Examples**:
+```bash
+# Original: "How do I fix this error?"
+# Display: → "How do I fix this error?"
+
+# Original: "I'm getting this error:\n```\nERROR: connection refused\n```\nHow do I debug this?"
+# Display: → "I'm getting this error: ERROR: connection refused... How do I debug this?"
+
+# Original: "Can you help me write a function that processes user data and validates email addresses according to RFC standards?"
+# Display: → "Can you help me write a function that processes user data and validates..."
+```
+
+#### Global Session Listing with Pagination
+
+```bash
+/sessions list --global
+/sessions list --global --limit 15  # Show 15 sessions across all workspaces
+/sessions list --global --page 2     # Show next page of global sessions
+```
+
+**Ordering**: Sessions ordered by `last_active` timestamp (most recent first) across all workspaces
+
+```
+All Workspaces (47 sessions across 6 workspaces, showing 12 most recent)
+
+[1] session-20250621-150000 (1 hour ago) - /home/user/infrastructure
+    → "Help me troubleshoot this Terraform deployment failing on AWS..."
+    
+[2] session-20250621-143022 (2 hours ago, 15 messages) - /home/user/my-project ⚡ Active
+    → "How do I fix this Kubernetes deployment error with ImagePullBackOff?"
+    
+[3] session-20250621-120000 (3 hours ago, 8 messages) - /home/user/other-project
+    → "Why is my React component not re-rendering after state change..."
+    
+[4] session-20250621-091500 (5 hours ago, 8 messages) - /home/user/my-project
+    → "Can you help me set up CloudWatch monitoring for my Lambda function?"
+    
+[5] session-20250621-080000 (6 hours ago, 12 messages) - /home/user/infrastructure
+    → "What's the best way to set up AWS VPC with multiple subnets..."
+    
+[6] session-20250620-160000 (1 day ago, 23 messages) - /home/user/my-project
+    → "I need to migrate this database schema, what's the safest approach?"
+    
+[7] session-20250620-140000 (1 day ago, 18 messages) - /home/user/other-project
+    → "How do I optimize this SQL query performance for large datasets..."
+    
+[8] session-20250620-110000 (1 day ago, 6 messages) - /tmp/quick-test
+    → "Can you explain this error message I'm getting in Python..."
+    
+[9] session-20250619-170000 (2 days ago, 31 messages) - /home/user/infrastructure  
+    → "I need to configure auto-scaling for my ECS service cluster..."
+    
+[10] session-20250619-140000 (3 days ago, 12 messages) - /home/user/infrastructure
+     → "How do I set up monitoring for my RDS instance with CloudWatch..."
+     
+[11] session-20250619-100000 (4 hours ago, 9 messages) - /tmp/quick-test
+     → "Quick test of this API endpoint behavior with different headers..."
+     
+[12] "Database Migration Planning" (2 days ago, 45 messages) - /home/user/my-project 📌 Named
+     → "Let's plan the migration from PostgreSQL 12 to 14 for production..."
+
+Showing 1-12 of 47 sessions across all workspaces.
+Use '/sessions list --global --page 2' for more sessions.
+Use '/sessions resume <number>' to continue any session.
+Use '/sessions resume session-20250621-143022' to resume by session ID.
+```
+
+**Key Features**:
+- **Global chronological order**: All sessions sorted by last activity regardless of workspace
+- **Consistent session IDs**: Session IDs shown in both local and global views
+- **Workspace context**: Each session shows which workspace it belongs to
+- **Named sessions highlighted**: Sessions with custom names shown with 📌 icon
+- **Flexible resume**: Resume by number OR session ID from either view
+
+#### Enhanced Resume Commands
+
+```bash
+# Resume by number (from list output)
+/sessions resume 1          # Resume session [1] from the list
+/sessions resume 3          # Resume session [3] from the list
+
+# Resume by session ID (traditional)
+/sessions resume session-20250621-143022
+
+# Resume latest in current workspace
+/sessions resume latest
+
+# Resume latest globally
+/sessions resume latest --global
+```
+
+#### Search-Then-Resume Workflow
+
+For finding specific sessions, use the search-then-resume pattern:
+
+```bash
+# Step 1: Search for sessions
+/sessions search "Kubernetes"
+# Output:
+# Found 3 matching sessions in current workspace:
+# [1] session-20250621-143022 → "How do I fix this Kubernetes deployment error..."
+# [2] session-20250620-091500 → "Kubernetes deployment is failing, need help..."
+# [3] session-20250619-160000 → "Can you help with Kubernetes deployment best..."
+
+# Step 2: Resume by number from search results
+/sessions resume 1  # Resumes the first search result
+```
+
+#### Context Management
+```bash
+/context add-session session-20250620-143022  # Add debugging session
+/context add-session session-20250619-091500  # Add monitoring session
+# Now Q can reference both conversations
+```
+
+**Viewing Current Context**
+```bash
+/context list-sessions
+# Output:
+# Current session context includes:
+# [1] session-20250620-143022 (Kubernetes debugging, 45 messages)
+#     → "How do I fix this Kubernetes deployment error with ImagePullBackOff?"
+# [2] session-20250619-091500 (CloudWatch setup, 32 messages)
+#     → "Can you help me set up CloudWatch monitoring for my Lambda function?"
+# Current session: 12 messages
+# Total context: 89 messages
+```
+
+**Adding Multiple Sessions**
+```bash
+/context remove-session session-20250619-091500  # Remove if context gets too large
+```
+
+**Managing Context Size**
+
+**Automatic Summarization**: When adding large sessions, the system may automatically summarize older parts of the conversation to fit within token limits while preserving key information.
+
+**Smart Context Selection**: The system prioritizes:
+- Recent messages from added sessions
+- Messages containing solutions or important decisions
+- Tool execution results that might be relevant
+- Error messages and their resolutions
+
+**Context Window Optimization**: 
+- Maintains a balance between current session and added session content
+- Warns users when context is approaching limits
+- Suggests removing less relevant sessions when needed
+
+#### Privacy and Security Considerations
+
+**Session Access Control**: Users can only add sessions from:
+- The same workspace (default behavior)
+- Workspaces they have explicit access to
+
+**Local Storage Only**: All conversation data is stored locally in the user's home directory and never transmitted to external services.
+
+#### Use Cases
+
+**Debugging Workflows**
+```bash
+# Add the session where you first encountered and solved this error
+/context add-session session-20250615-102030
+# Q can now reference the previous solution approach
+```
+
+**Learning and Documentation**
+```bash
+# Add sessions where you learned about specific technologies
+/context add-session session-20250610-140000  # Docker setup session
+/context add-session session-20250612-160000  # Kubernetes basics session
+# Q can reference your learning progression and previous explanations
+```
+
+**Project Continuity**
+```bash
+# Add the session where project architecture was discussed
+/context add-session session-20250601-090000
+# Q understands the project structure and previous decisions
+```
+
+### Export and Import Functionality
+
+#### Export Capabilities
+
+The system supports exporting chat sessions in two formats, each optimized for different use cases:
+
+**JSON Format** (Complete Data):
+- Preserves all conversation metadata, timestamps, and context
+- Includes tool calls, parameters, and complete results
+- Maintains session information and workspace context
+- Required format for import functionality
+- Ideal for backup, sharing for import, and programmatic processing
+
+**Markdown Format** (Human-Readable):
+- Clean, readable format for documentation and sharing
+- Shows conversation flow with clear user/assistant distinction
+- Includes tool executions and results in readable format
+- Perfect for team wikis, documentation, and code review context
+- Cannot be imported back (data loss during conversion)
+
+#### Export Commands
+
+```bash
+# Export specific session for import/backup
+/sessions export session-20250621-143022 --format json --path ./debugging-session.json
+
+# Export for documentation/sharing
+/sessions export session-20250621-143022 --format markdown --path ./k8s-troubleshooting.md
+
+# Export by session number from list
+/sessions list
+/sessions export 3 --format json --path ./session-backup.json
+
+# Export to specific directory
+/sessions export session-20250621-091500 --format markdown --path ./docs/solutions/cloudwatch-setup.md
+```
+
+#### JSON Export Structure
+
+```json
+{
+  "session_metadata": {
+    "session_id": "session-20250621-143022",
+    "workspace_path": "/home/user/my-project",
+    "workspace_name": "my-project",
+    "created_at": "2025-06-21T14:30:22Z",
+    "last_active": "2025-06-21T16:45:30Z",
+    "message_count": 15,
+    "first_prompt": "How do I fix this Kubernetes deployment error with ImagePullBackOff?",
+    "context_files": ["/home/user/my-project/k8s/deployment.yaml"]
+  },
+  "messages": [
+    {
+      "id": "msg-001",
+      "message_type": "user",
+      "content": "How do I fix this Kubernetes deployment error with ImagePullBackOff?",
+      "timestamp": "2025-06-21T14:30:22Z"
+    },
+    {
+      "id": "msg-002", 
+      "message_type": "assistant",
+      "content": "ImagePullBackOff errors typically occur when Kubernetes can't pull the container image...",
+      "timestamp": "2025-06-21T14:30:25Z"
+    },
+    {
+      "id": "msg-003",
+      "message_type": "tool_call",
+      "content": "Let me check the pod status to get more details.",
+      "timestamp": "2025-06-21T14:30:30Z",
+      "tool_calls": [
+        {
+          "tool": "execute_bash",
+          "parameters": {
+            "command": "kubectl describe pod myapp-deployment-abc123"
+          }
+        }
+      ]
+    },
+    {
+      "id": "msg-004",
+      "message_type": "tool_result", 
+      "timestamp": "2025-06-21T14:30:32Z",
+      "tool_results": [
+        {
+          "tool": "execute_bash",
+          "status": "success",
+          "exit_code": 0,
+          "stdout": "Events:\n  Warning  Failed     2m    kubelet  Failed to pull image...",
+          "stderr": ""
+        }
+      ]
+    }
+  ]
+}
+```
+
+#### Import Functionality
+
+**Simple Import Process**:
+The import functionality is designed to be straightforward - it loads an exported conversation into your current chat session, making the imported conversation part of your current context.
+
+```bash
+# Import a previously exported session
+/sessions import ./debugging-session.json
+
+# The imported conversation becomes part of current session
+# Q can now reference the imported conversation immediately
+# Continue your current conversation with added context
+```
+
+**Import Requirements**:
+- **JSON format only**: Import requires JSON format for complete data preservation
+- **Data integrity**: All original metadata, tool calls, and results are preserved
+- **Context integration**: Imported messages become part of current session history
+- **Immediate availability**: Q can reference imported conversation right away
+
+#### Use Cases and Workflows
+
+**Team Collaboration**:
+```bash
+# Developer A solves a complex issue
+/history export session-20250621-143022 --format json --path ./k8s-imagepull-fix.json
+
+# Share file with Developer B
+# Developer B working on similar issue
+q chat
+"I'm having a similar ImagePullBackOff error..."
+
+# Load the solution into current conversation
+/sessions import ./k8s-imagepull-fix.json
+
+# Q can now reference the previous solution
+# Continue conversation building on imported knowledge
+```
+
+**Documentation and Learning**:
+```bash
+# Export successful debugging session for team documentation
+/sessions export session-20250621-143022 --format markdown --path ./docs/troubleshooting/k8s-imagepull-errors.md
+
+# Export same session for future import/reference
+/sessions export session-20250621-143022 --format json --path ./solutions/k8s-imagepull-solution.json
+```
+
+**Cross-Project Knowledge Transfer**:
+```bash
+# Working on similar issue in different project
+cd /home/user/new-project
+q chat
+"I need to set up similar monitoring as in my previous project..."
+
+# Import solution from previous project
+/sessions import ./previous-project-monitoring-setup.json
+
+# Q now has context from previous project's solution
+# Can adapt the solution to current project
+```
+
+**Backup and Reference**:
+```bash
+# Create backups of important debugging sessions
+/sessions export session-20250621-143022 --format json --path ./backups/k8s-debugging-$(date +%Y%m%d).json
+
+# Later, reference the solution in new context
+/sessions import ./backups/k8s-debugging-20250621.json
+```
+
+#### Why JSON-Only for Import
+
+**Complete Data Preservation**:
+- Tool execution metadata and parameters preserved
+- Exact timestamps and session context maintained
+- No data loss during export/import round-trip
+
+**Efficient Processing**:
+```rust
+// JSON: Direct deserialization - fast and reliable
+let imported_messages: Vec<ChatMessage> = serde_json::from_str(&file_content)?;
+
+// Markdown: Would require complex parsing - slow and error-prone
+// let messages = parse_markdown_conversation(&file_content)?; // Not supported
+```
+
+**Data Integrity**:
+- Structured data ensures reliable import
+- Tool calls and results maintain their relationships
+- Context snapshots preserve conversation state
+
+### Command Structure and Separation
+
+The chat history system uses two primary command groups that serve distinct purposes and mental models:
+
+#### `/sessions` Commands - Session Management
+The `/sessions` command group focuses on **managing conversation sessions as discrete units**. Think of sessions as "conversation topics" or "work sessions" that you want to organize, resume, or share.
+
+**Mental Model**: "Which conversation do I want to work with?"
+
+**Primary Use Cases**:
+- **Discovery**: "What conversations have I had about this topic?"
+- **Organization**: "I want to resume my debugging session from yesterday"
+- **Sharing**: "Let me export this successful troubleshooting session for the team"
+- **Management**: "Clean up old sessions or rename important ones"
+
+**Search Behavior**: `/sessions search "kubernetes"`
+- Searches **session metadata**: first prompts, session names, session descriptions
+- Returns **sessions** that are about the search topic
+- Result: List of sessions you can resume or export
+- Example: Finds sessions titled "Kubernetes deployment debugging" or starting with "How do I fix Kubernetes..."
+
+#### `/history` Commands - Content Search and Display
+The `/history` command group focuses on **finding specific content within conversations**. Think of this as searching through the actual words, commands, and responses in your chat history.
+
+**Mental Model**: "What was said in my conversations?"
+
+**Primary Use Cases**:
+- **Content Discovery**: "Where did I use that specific kubectl command?"
+- **Reference Lookup**: "What was the exact error message I encountered?"
+- **Solution Retrieval**: "How did Q suggest I fix that deployment issue?"
+- **Conversation Review**: "Show me the recent conversation history"
+
+**Search Behavior**: `/history search "kubectl get pods"`
+- Searches **message content**: actual user messages, AI responses, tool outputs
+- Returns **specific messages/exchanges** containing the search terms
+- Result: Conversation snippets showing where that content appeared
+- Example: Shows the exact messages where "kubectl get pods" was mentioned, with context
+
+#### Practical Examples
+
+**Scenario 1: Finding a Debugging Session**
+```bash
+# User wants to continue working on Kubernetes issues
+/sessions search "kubernetes"
+# Returns: [1] session-20250621-143022 → "How do I fix Kubernetes deployment error..."
+# User can then: /sessions resume 1
+```
+
+**Scenario 2: Finding a Specific Command**
+```bash
+# User remembers running a specific command but can't remember the exact syntax
+/history search "kubectl describe"
+# Returns: Found in session-20250621-143022: "kubectl describe pod myapp-deployment-abc123"
+#          Found in session-20250620-091500: "kubectl describe service myapp-service"
+# User can see the exact commands and their context
+```
+
+**Scenario 3: Sharing a Solution**
+```bash
+# User wants to share a successful debugging session
+/sessions list
+# [1] session-20250621-143022 → "How do I fix Kubernetes deployment error..."
+/sessions export session-20250621-143022 --format markdown --path ./k8s-solution.md
+# Exports the entire session for team documentation
+```
+
+#### Why Two Command Groups?
+
+**Different Data Targets**:
+- **Sessions**: Operate on session metadata and session-level actions
+- **History**: Operate on message content and conversation details
+
+**Different User Intents**:
+- **Sessions**: "I want to manage my conversations as units of work"
+- **History**: "I want to find specific information within conversations"
+
+**Different Result Types**:
+- **Sessions**: Returns sessions (which you can resume, export, delete)
+- **History**: Returns message content (which you can read and reference)
+
+**Logical Grouping**:
+- **Sessions**: List, search, resume, export, import, manage → All session-level operations
+- **History**: Show, search → All content-level operations
+
+#### Command Consolidation Rationale
+
+**Import/Export moved to `/sessions`**:
+- **Logical fit**: Import/export operates on entire sessions, not individual messages
+- **Workflow alignment**: Export session → Share → Import session (session-level operations)
+- **Consistency**: All session management in one command group
+- **User expectation**: "I want to export this session" maps naturally to `/sessions export`
+
+**Search separation maintained**:
+- **Different purposes**: Session discovery vs content discovery
+- **Different search targets**: Metadata vs message content
+- **Different result actions**: Resume session vs reference content
+- **Clear user intent**: The type of search indicates what the user is trying to accomplish
+
+### Multi-Persona Workflows and Role-Based Sessions
+
+One of the most powerful capabilities of workspace-based chat history is the ability to maintain multiple sessions with different personas or roles within the same project. This enables users to approach their work from different perspectives, validate their decisions, and maintain separation between different types of thinking.
+
+#### Different Personas in Same Workspace
+
+**Developer vs Reviewer Sessions**:
+Users can maintain separate sessions for implementation work and critical review, allowing them to switch between "building" and "critiquing" mindsets without context confusion.
+
+```bash
+# Current workspace: /home/user/payment-service
+
+# Implementation-focused session
+/sessions new "Feature Development"
+"Help me implement payment retry logic with exponential backoff..."
+# Q provides implementation guidance, code examples, best practices
+
+# Critical review session
+/sessions new "Security & Code Review"  
+"Let me review this payment retry implementation critically. What security vulnerabilities or edge cases should I consider?"
+# Q takes a critical stance, focuses on potential issues
+```
+
+**Multiple Expertise Perspectives**:
+Different sessions can focus on different aspects of the same codebase, each with specialized context and concerns.
+
+```bash
+# Frontend development session
+/sessions new "UI/UX Implementation"
+"How do I create a smooth user experience for payment failures and retries?"
+
+# Backend architecture session
+/sessions new "Backend Design"
+"What's the optimal database schema and API design for payment retry tracking?"
+
+# DevOps and operations session
+/sessions new "Deployment & Monitoring"
+"How should we deploy this payment service and monitor retry patterns in production?"
+
+# Performance optimization session
+/sessions new "Performance Analysis"
+"What are the performance implications of our retry strategy at scale?"
+```
+
+#### Cross-Session Validation and Learning
+
+**Developer-Reviewer Dialogue Pattern**:
+Users can build something in one session, then critically examine it in another, creating a comprehensive development and validation workflow.
+
+```bash
+# Step 1: Development session
+/sessions new "Payment Integration Development"
+"I need to integrate with Stripe's payment API. Help me implement error handling..."
+# Develop the implementation with Q's guidance
+
+# Step 2: Export development context
+/sessions export session-payment-dev --format json --path ./payment-implementation.json
+
+# Step 3: Critical review session
+/sessions new "Payment Integration Review"
+/sessions import ./payment-implementation.json
+"Now let's critically review this Stripe integration. What could go wrong? What edge cases are we missing?"
+# Q can reference the implementation but take a critical, security-focused perspective
+```
+
+**Architecture Validation Workflow**:
+```bash
+# Design session
+/sessions new "System Architecture Design"
+"Let's design a microservices architecture for our e-commerce platform..."
+
+# Implementation reality check session
+/sessions new "Implementation Feasibility"
+/context add-session session-architecture-design
+"Given this architecture design, what are the practical implementation challenges? What would be difficult to build or maintain?"
+
+# Operations perspective session
+/sessions new "Operational Concerns"
+/context add-session session-architecture-design
+"From an operations standpoint, how would we deploy, monitor, and troubleshoot this architecture?"
+```
+
+#### Team Collaboration with Role-Based Sessions
+
+**Shared Expertise Patterns**:
+Team members can share sessions that represent different expertise areas, allowing knowledge transfer and collaborative problem-solving.
+
+```bash
+# Senior developer creates architecture session
+/sessions new "Database Schema Design"
+"Let's design the optimal database schema for our user management system..."
+/sessions export session-db-design --format json --path ./db-architecture.json
+
+# Junior developer imports and learns
+/sessions import ./db-architecture.json
+/sessions new "Implementation Questions"
+/context add-session session-imported-db-design
+"I'm implementing this database design. Can you help me understand the reasoning behind these schema choices?"
+```
+
+**Code Review Enhancement**:
+```bash
+# Developer preparing for code review
+/sessions new "Pre-Review Self-Assessment"
+"Before submitting this code for review, help me identify potential issues..."
+
+# Reviewer session
+/sessions new "Code Review Analysis"
+/sessions import ./developer-implementation.json
+"Let's thoroughly review this implementation. Focus on security, performance, and maintainability concerns..."
+```
+
+#### Specialized Problem-Solving Modes
+
+**Debugging vs Root Cause Analysis**:
+```bash
+# Immediate problem-solving session
+/sessions new "Production Issue Debugging"
+"Our payment service is failing. Help me debug this immediately..."
+
+# Deeper analysis session
+/sessions new "Root Cause Analysis"
+/context add-session session-debugging
+"Now that we've fixed the immediate issue, let's do a thorough root cause analysis. What systemic issues led to this problem?"
+```
+
+**Feature Development vs Technical Debt**:
+```bash
+# Feature implementation session
+/sessions new "New Feature Development"
+"Let's implement the new user notification system..."
+
+# Technical debt assessment session
+/sessions new "Technical Debt Review"
+/context add-session session-feature-dev
+"Given this new feature implementation, what technical debt are we creating? How should we refactor existing code?"
+```
+
+#### Benefits of Multi-Persona Workflows
+
+**1. Mental Context Switching**:
+- Clear separation between different types of thinking
+- Prevents implementation bias from affecting critical review
+- Allows focused expertise application
+
+**2. Comprehensive Coverage**:
+- Development session: "How do I build this?"
+- Review session: "What could go wrong?"
+- Architecture session: "Is this the right approach?"
+- Operations session: "How do we run this in production?"
+
+**3. Learning and Validation**:
+- Build understanding through implementation
+- Validate through critical analysis
+- Cross-reference different perspectives
+- Identify blind spots and assumptions
+
+**4. Team Knowledge Sharing**:
+- Export expertise-focused sessions for team learning
+- Import different perspectives on same problems
+- Collaborative problem-solving across different skill areas
+
+**5. Quality Improvement**:
+- Self-review through different personas
+- Systematic consideration of multiple concerns
+- Reduced single-perspective bias
+- More thorough problem analysis
+
+#### Example Multi-Session Workflow
+
+```bash
+# 1. Initial exploration
+/sessions new "Problem Understanding"
+"We need to improve our API response times. Help me understand the current bottlenecks..."
+
+# 2. Solution design
+/sessions new "Performance Optimization Design"
+/context add-session session-problem-understanding
+"Based on our analysis, let's design a caching strategy..."
+
+# 3. Implementation
+/sessions new "Cache Implementation"
+/context add-session session-optimization-design
+"Help me implement Redis caching for our API endpoints..."
+
+# 4. Critical review
+/sessions new "Implementation Review"
+/context add-session session-cache-implementation
+"Let's critically review this caching implementation. What edge cases, security issues, or operational concerns should we address?"
+
+# 5. Deployment planning
+/sessions new "Deployment Strategy"
+/context add-session session-implementation-review
+"How should we safely deploy this caching solution to production?"
+```
+
+This multi-persona approach, combined with the command structure and cross-session context capabilities, transforms the workspace-based chat system from a simple conversation tool into a comprehensive thinking and validation framework, enabling more thorough and well-considered development decisions.
+
+## Architecture
+
+### Workspace Identity System
+- **Deterministic IDs**: SHA256 hash of canonical workspace path
+- **Directory naming**: `workspace-hash-abc123` format for storage directories
+- **Metadata tracking**: Project type, creation time, last access stored in `workspace.json`
+- **Path resolution**: Handles symlinks, relative paths, and subdirectories consistently
+- **Git-safe storage**: All data stored in `~/.amazon-q/workspaces/`, never in workspace directory
+
+### Session Lifecycle
+- **Auto-creation**: New sessions created automatically when needed
+- **Auto-resume**: Last active session resumed by default
+- **Cleanup policies**: Configurable retention and archival rules
+- **Migration support**: Handle workspace moves and renames
+
+### Storage Strategy
+- **Home directory storage**: All data stored in `~/.amazon-q/workspaces/` to avoid git commits
+- **Workspace hashing**: Each workspace gets a unique directory based on SHA256 hash of canonical path
+- **Single database per workspace**: One SQLite database contains all sessions and messages for a workspace
+- **Export capabilities**: JSON/Markdown export for sharing and backup
+- **Privacy-first**: All data stored locally, never transmitted
+
+### Integration Points
+- **Existing conversation state**: Extends current `ConversationState` system
+- **Database infrastructure**: Builds on existing SQLite foundation
+- **Command system**: Integrates with current `/` command pattern
+- **Tool system**: Preserves tool execution history and context
+
+## Detailed Design
+
+### Workspace Detection Logic
+
+The system implements a hierarchical workspace detection strategy:
+
+```rust
+pub enum WorkspaceType {
+    GitRepository { 
+        remote_url: Option<String>,
+        branch: Option<String> 
+    },
+    Directory,  // Non-git directory
+}
+
+pub struct Workspace {
+    pub id: String,           // SHA256 hash of canonical path
+    pub path: PathBuf,        // Canonical workspace path
+    pub name: String,         // Display name (directory name or repo name)
+    pub workspace_type: WorkspaceType,
+    pub created_at: DateTime<Utc>,
+    pub last_accessed: DateTime<Utc>,
+}
+```
+
+**Detection Algorithm**:
+1. Start from current directory
+2. Walk up directory tree looking for `.git` directory
+3. If `.git` found, use that directory as workspace root
+4. If no `.git` found, use current directory as workspace
+5. Generate stable workspace ID from canonical path
+
+### Session Management
+
+```rust
+pub struct ChatSession {
+    pub id: String,                    // UUID
+    pub workspace_id: String,          // Foreign key to workspace
+    pub name: Option<String>,          // User-provided name
+    pub first_prompt: Option<String>,  // First user message for display
+    pub first_prompt_preview: Option<String>, // Truncated version for lists
+    pub created_at: DateTime<Utc>,
+    pub last_active: DateTime<Utc>,
+    pub message_count: usize,
+    pub is_active: bool,               // Only one active session per workspace
+    pub context_files: Vec<PathBuf>,   // Files added to session context
+}
+```
+
+### Message Storage
+
+```rust
+pub struct PersistedMessage {
+    pub id: String,
+    pub session_id: String,
+    pub message_type: MessageType,     // User, Assistant, System, Tool
+    pub content: String,
+    pub timestamp: DateTime<Utc>,
+    pub tool_calls: Option<Vec<ToolCall>>,
+    pub tool_results: Option<Vec<ToolResult>>,
+    pub context_snapshot: Option<String>, // Context state at message time
+}
+```
+
+### Database Schema
+
+**Single SQLite database per workspace** (`workspace.db`) containing all related data:
+
+```sql
+-- Workspaces table (metadata about the workspace)
+CREATE TABLE workspace_info (
+    id TEXT PRIMARY KEY,                -- SHA256 hash of canonical path
+    path TEXT NOT NULL UNIQUE,          -- Canonical workspace path
+    name TEXT NOT NULL,                 -- Display name (directory or repo name)
+    workspace_type TEXT NOT NULL,       -- 'GitRepository' or 'Directory'
+    metadata TEXT,                      -- JSON for type-specific data (git remote, branch, etc.)
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    last_accessed DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Chat sessions table
+CREATE TABLE chat_sessions (
+    id TEXT PRIMARY KEY,                -- UUID
+    workspace_id TEXT NOT NULL,         -- Foreign key to workspace_info
+    name TEXT,                          -- User-provided name
+    first_prompt TEXT,                  -- Full first user message
+    first_prompt_preview TEXT,          -- Truncated version for display
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    last_active DATETIME DEFAULT CURRENT_TIMESTAMP,
+    message_count INTEGER DEFAULT 0,
+    is_active BOOLEAN DEFAULT FALSE,    -- Only one active session per workspace
+    context_files TEXT,                 -- JSON array of file paths
+    FOREIGN KEY (workspace_id) REFERENCES workspace_info(id)
+);
+
+-- Messages table
+CREATE TABLE chat_messages (
+    id TEXT PRIMARY KEY,                -- UUID
+    session_id TEXT NOT NULL,           -- Foreign key to chat_sessions
+    message_type TEXT NOT NULL,         -- 'user', 'assistant', 'system', 'tool'
+    content TEXT NOT NULL,              -- Message content
+    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+    tool_calls TEXT,                    -- JSON array of tool calls
+    tool_results TEXT,                  -- JSON array of tool results
+    context_snapshot TEXT,              -- JSON snapshot of context at message time
+    FOREIGN KEY (session_id) REFERENCES chat_sessions(id)
+);
+
+-- Indexes for performance
+CREATE INDEX idx_sessions_workspace ON chat_sessions(workspace_id);
+CREATE INDEX idx_sessions_active ON chat_sessions(workspace_id, is_active);
+CREATE INDEX idx_sessions_last_active ON chat_sessions(last_active DESC);
+CREATE INDEX idx_messages_session ON chat_messages(session_id);
+CREATE INDEX idx_messages_timestamp ON chat_messages(timestamp DESC);
+CREATE INDEX idx_messages_content_fts ON chat_messages USING fts(content);
+```
+
+### New Commands
+
+#### History Commands
+```rust
+pub enum HistoryCommand {
+    Show {
+        session_id: Option<String>,
+        limit: Option<usize>,
+        since: Option<String>,
+    },
+    Search {
+        query: String,
+        session_id: Option<String>,
+        global: bool,
+    },
+}
+```
+
+#### Session Commands
+```rust
+pub enum SessionCommand {
+    New { name: Option<String> },
+    List { 
+        global: bool,
+        workspace: Option<PathBuf>,
+        page: Option<usize>,
+        limit: Option<usize>,
+    },
+    Search {
+        query: String,
+        global: bool,
+    },
+    Resume { 
+        target: ResumeTarget,
+        global: bool,
+    },
+    Delete { session_id: String },
+    Rename { session_id: String, name: String },
+    Archive { session_id: String },
+    Info,  // Show workspace session statistics
+    Cleanup {
+        dry_run: bool,
+        older_than: Option<String>,
+    },
+    Export {
+        session_id: String,
+        format: ExportFormat,
+        path: PathBuf,
+    },
+    Import {
+        path: PathBuf,
+    },
+}
+
+pub enum ResumeTarget {
+    Number(usize),        // Resume by list number
+    SessionId(String),    // Resume by session ID
+    Latest,               // Resume most recent session
+}
+
+pub enum ExportFormat {
+    Json,      // Complete data for import/backup
+    Markdown,  // Human-readable for documentation
+}
+```
+
+## Configuration
+
+The workspace-based chat history system can be configured through the following settings:
+
+```toml
+[chat.history]
+enabled = true                         # Enable/disable persistent chat history
+max_sessions_per_workspace = 50        # Maximum sessions tracked per workspace
+auto_cleanup_days = 90                 # Auto-archive sessions older than 90 days
+max_messages_per_session = 2000        # Maximum messages per session
+search_index_enabled = true            # Enable full-text search indexing
+default_list_limit = 10                # Default number of sessions shown in /sessions list
+max_list_limit = 100                   # Maximum sessions that can be shown at once
+
+[chat.workspace]
+auto_detect = true                     # Enable automatic workspace detection
+detection_depth = 10                   # Max directories to walk up when detecting workspace
+cache_workspace_info = true            # Cache workspace detection results for performance
+
+[chat.privacy]
+# Note: Sensitive data handling is not implemented in initial version
+# Users should be aware that all conversation content is stored locally
+```
+
+### Configuration Details
+
+**Session Management**:
+- `max_sessions_per_workspace`: Controls storage limits and prevents unbounded growth
+- `auto_cleanup_days`: Automatic archival of old sessions to manage storage
+- `max_messages_per_session`: Prevents individual sessions from becoming too large
+
+**Performance**:
+- `default_list_limit` and `max_list_limit`: Control pagination and query performance
+- `search_index_enabled`: Full-text search can be disabled to save storage space
+- `cache_workspace_info`: Improves startup performance by caching workspace detection
+
+**Workspace Detection**:
+- `auto_detect`: Can be disabled to use current directory only
+- `detection_depth`: Prevents excessive directory traversal on deep file systems
+
+### Privacy and Security
+
+#### Data Retention
+- **Configurable retention**: User-defined cleanup policies
+- **Selective deletion**: Delete specific messages or entire sessions
+- **Export before cleanup**: Automatic export of sessions before deletion
+
+### Storage Location and Git Safety
+
+#### Why Home Directory Storage
+
+Chat history is stored in the user's home directory (`~/.amazon-q/workspaces/`) rather than within workspace directories for several critical reasons:
+
+**Git Safety**: 
+- Prevents accidental commits of sensitive conversation data
+- No risk of chat history being pushed to version control
+- Keeps workspace directories clean and unmodified
+
+**Cross-Directory Access**:
+- Works from any subdirectory within the workspace
+- Consistent workspace detection regardless of current working directory
+- Same conversation continues whether you're in `/project/src/` or `/project/docs/`
+
+**Workspace Portability**:
+- Workspace can be moved or renamed without losing chat history
+- History persists even if workspace is temporarily unavailable
+- No dependency on workspace directory structure
+
+#### Workspace Detection vs Storage
+
+**Detection Process**:
+1. Start from current working directory
+2. Walk up directory tree looking for `.git` directory
+3. If `.git` found, use that directory as workspace root (GitRepository type)
+4. If no `.git` found after reaching filesystem root, use current directory (Directory type)
+5. Generate SHA256 hash of canonical workspace path
+6. Use hash as storage directory name
+
+**Storage Process**:
+1. All data stored in `~/.amazon-q/workspaces/workspace-hash-abc123/`
+2. Single SQLite database per workspace contains all sessions and messages
+3. Workspace metadata stored in `workspace.json`
+
+**Example Flow**:
+```bash
+# User in project subdirectory
+cd /home/user/my-project/src/components
+q chat
+
+# System detects workspace root: /home/user/my-project (found .git)
+# Generates hash: abc123... (SHA256 of "/home/user/my-project")
+# Stores data in: ~/.amazon-q/workspaces/workspace-hash-abc123/workspace.db
+
+# Later, from different subdirectory
+cd /home/user/my-project/docs
+q chat
+
+# Same workspace detected: /home/user/my-project
+# Same hash generated: abc123...
+# Loads same database: ~/.amazon-q/workspaces/workspace-hash-abc123/workspace.db
+# Continues previous conversation seamlessly
+```
+
+#### Benefits of Single Database Per Workspace
+
+**Efficient Queries**:
+```sql
+-- Cross-session search within workspace
+SELECT m.content, s.first_prompt_preview, m.timestamp
+FROM chat_messages m
+JOIN chat_sessions s ON m.session_id = s.id
+WHERE m.content LIKE '%deployment error%'
+ORDER BY m.timestamp DESC;
+```
+
+**Simplified Management**:
+- One database file per workspace to backup/restore
+- Atomic operations across sessions and messages
+- Better performance with proper indexing
+- Easier cleanup and maintenance
+
+**Data Integrity**:
+- Foreign key constraints ensure data consistency
+- Transactions can span sessions and messages
+- Single point of truth for workspace conversation history
+
+### Session Limits and Cleanup Policies
+
+To prevent unbounded storage growth and maintain performance, the system enforces limits on session tracking:
+
+**Per-Workspace Limits**:
+- **Maximum sessions**: 50 sessions per workspace (configurable)
+- **Automatic cleanup**: Sessions older than 90 days are automatically archived
+- **Storage cap**: Approximately 100-500MB per workspace depending on conversation length
+
+**When Limits Are Reached**:
+1. **Oldest sessions archived**: When the 50-session limit is reached, the oldest sessions are automatically moved to archive
+2. **User notification**: Users are warned when approaching limits
+3. **Manual cleanup options**: Users can delete or archive sessions manually
+
+#### Cleanup Behavior
+
+```bash
+# When creating session #51 in a workspace:
+Creating new session... (51/50 sessions)
+⚠️  Workspace has reached session limit. Archiving oldest session:
+    session-20250520-090000 → "How do I set up Docker containers..."
+    
+New session created: session-20250621-143022
+```
+
+**Archive vs Delete**:
+- **Archive**: Sessions moved to `.amazon-q/workspaces/{id}/archive/`
+- **Delete**: Permanently removed (user choice)
+- **Export before archive**: Optional automatic export to JSON/Markdown
+
+#### Manual Session Management
+
+```bash
+# Check workspace storage usage
+/sessions info
+# Output:
+# Current workspace: /home/user/my-project
+# Sessions: 45/50 (90% of limit)
+# Storage used: ~150MB
+# Oldest session: 85 days ago
+# Cleanup suggestion: 5 sessions eligible for archiving
+
+# Manual cleanup commands
+/sessions cleanup --dry-run        # Show what would be cleaned up
+/sessions cleanup --older-than 60d # Archive sessions older than 60 days
+/sessions archive <session-id>     # Archive specific session
+/sessions delete <session-id>      # Permanently delete session
+```
+
+### Performance Considerations
+
+#### Startup Performance
+- **Lazy loading**: Load conversation history on demand
+- **Workspace caching**: Cache workspace detection results
+- **Index optimization**: Efficient database indexes for common queries
+
+#### Session List Performance
+- **Pagination**: Session lists are indexed by `last_active` timestamp
+- **Fast first page**: Initial 10 sessions load instantly (< 50ms)
+- **Page caching**: Subsequent pages cached for 5 minutes
+- **Global optimization**: Global session listing uses workspace-level aggregation
+
+#### Memory Management
+- **Streaming history**: Load large conversations incrementally
+- **Context window management**: Maintain reasonable context sizes
+- **Background cleanup**: Periodic cleanup of old data
+
+#### Storage Optimization
+- **Message compression**: Content compressed in database
+- **Separate tool storage**: Tool outputs larger than 10KB stored separately
+- **Orphan cleanup**: Automatic cleanup of orphaned tool result files
+- **Database maintenance**: VACUUM operations during low usage periods
+
+### Migration Strategy
+
+#### Existing Users
+- **Opt-in activation**: Feature disabled by default initially
+- **Migration assistant**: Help users migrate existing workflows
+- **Backward compatibility**: All existing commands continue to work
+
+#### Data Migration
+- **Current session preservation**: Convert active sessions to new format
+- **Context migration**: Preserve existing context files and settings
+- **Gradual rollout**: Phased activation across user base
+
+## Drawbacks
+
+- **Storage overhead**: Additional disk space for conversation history (estimated 10-50MB per active workspace)
+- **Complexity increase**: New concepts and commands for users to learn
+- **Performance impact**: Potential startup delay for workspaces with large histories
+- **Privacy concerns**: Sensitive information persisted in chat history
+- **Maintenance burden**: Additional code paths, edge cases, and testing requirements
+- **Cross-platform considerations**: Different file system behaviors across platforms
+
+## Rationale and alternatives
+
+### Why this design?
+
+**Workspace-centric approach**: Aligns with how developers actually work - in project contexts rather than global conversations. This matches the mental model of tools like VS Code, Git, and other development tools.
+
+**Automatic behavior**: Minimizes cognitive overhead by making persistence invisible until needed. Users get the benefits without having to learn new workflows initially.
+
+**Incremental adoption**: Users can ignore advanced features and still benefit from basic persistence. Power users can leverage advanced session management.
+
+**Local-first**: Maintains privacy and works offline, consistent with CLI tool expectations and security requirements.
+
+**Extensible foundation**: Architecture supports future enhancements like team sharing, analytics, and integration with other tools.
+
+### Alternatives considered
+
+**Alternative 1: Global conversation history**
+- Single conversation thread across all work
+- Simpler implementation but less contextual
+- Rejected: Doesn't match developer mental models of project-based work
+
+**Alternative 2: Manual session management only**
+- Require explicit session creation/switching for all persistence
+- More control but higher cognitive overhead
+- Rejected: Violates principle of "it just works" for basic use cases
+
+**Alternative 3: File-based storage**
+- Store conversations as JSON/Markdown files in project directories
+- Simpler implementation but harder to query and manage
+- Rejected: Poor performance for search, complex queries, and cross-session operations
+
+**Alternative 4: Cloud-based storage**
+- Store conversation history in AWS/cloud services
+- Better for team collaboration but privacy concerns
+- Rejected: Conflicts with local-first philosophy and adds complexity
+
+**Alternative 5: Integration with existing tools**
+- Store history in Git, VS Code settings, or other existing tools
+- Leverages existing infrastructure but limited functionality
+- Rejected: Too restrictive and doesn't provide needed query capabilities
+
+## Impact of not doing this
+
+Without workspace-based chat history:
+- **Continued user frustration**: Users lose valuable conversation context regularly
+- **Reduced adoption**: Lower usage of Q CLI for complex, multi-session workflows
+- **Competitive disadvantage**: Other AI tools (Cursor, Cline) provide this functionality
+- **Missed learning opportunities**: No ability to analyze and improve based on conversation patterns
+- **Limited collaboration**: No foundation for future team-based features
+- **Workflow inefficiency**: Users waste time re-establishing context repeatedly
+
+## Unresolved questions
+
+- **Session cleanup policies**: What are appropriate defaults for session retention, archival, and automatic cleanup?
+- **Performance optimization**: How to handle very large conversation histories (1000+ messages) efficiently without impacting startup time?
+- **Sensitive data handling**: Should the system implement automatic detection and filtering of credentials, API keys, and other sensitive information in chat history? This adds significant complexity and may have false positives/negatives.
+- **Network drives and remote filesystems**: How should workspace detection work with network-mounted directories?
+- **Workspace migration**: How to handle cases where projects are moved, renamed, or restructured?
+
+## Future possibilities
+
+### Near-term enhancements
+- **Workspace templates**: Pre-configured conversation starters and context for different project types
+- **Enhanced search**: Full-text search across all workspace conversations with relevance ranking
+- **Export integrations**: Direct export to documentation systems, issue trackers, or team wikis
+- **Session analytics**: Insights into conversation patterns, common issues, and productivity metrics
+
+### Medium-term possibilities
+- **Cross-workspace insights**: AI analysis of patterns across multiple projects to suggest solutions
+- **Team workspace sharing**: Controlled sharing of conversation history within development teams
+- **Integration with version control**: Tie conversation history to git branches, commits, or pull requests
+- **Conversation summarization**: Automatic generation of summaries for long conversations
+- **Context recommendations**: AI-powered suggestions for relevant context files and previous conversations
+
+### Long-term vision
+- **Collaborative AI assistance**: Multiple team members contributing to shared workspace conversations
+- **Organizational knowledge base**: Aggregate insights across team workspaces for organizational learning
+- **Workflow automation**: Trigger actions based on conversation patterns and outcomes
+- **Integration ecosystem**: APIs for third-party tools to integrate with workspace conversation history
+- **Advanced analytics**: Detailed insights into development patterns, bottlenecks, and AI assistance effectiveness


### PR DESCRIPTION
## Summary
This RFC proposes adding persistent chat history tied to workspaces/projects, enabling conversation continuity across terminal sessions.

## Related Issue
Closes #[2089]
https://github.com/aws/amazon-q-developer-cli/issues/2089

## RFC Overview
- **Problem**: Ephemeral chat sessions cause friction for developers
- **Solution**: Workspace-based persistent sessions with automatic detection
- **Impact**: Significantly improved UX for complex, multi-session workflows

## Key Features
- Automatic workspace detection (Git repos + directory fallback)
- Session management commands (`/sessions list`, `/sessions resume`)
- Cross-session context integration (`/context add-session`)
- Export/import for collaboration
- Local-first storage (privacy-focused)

## Implementation Approach
- Builds on existing ConversationState system
- Extends current SQLite database infrastructure
- Integrates with existing command patterns
- Backward compatible

## Review Focus Areas
- [ ] Technical architecture and database design
- [ ] User experience and command interface
- [ ] Integration with existing codebase
- [ ] Performance and storage considerations
- [ ] Security and privacy implications

---
**Note**: This is a substantial feature addition. I'm happy to implement it incrementally based on feedback and break it into smaller PRs if preferred.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
