### PR TITLE
feat: support a --script option

### DIFF
--- a/crates/cli/src/cli/chat/cli.rs
+++ b/crates/cli/src/cli/chat/cli.rs
@@ -17,6 +17,9 @@ pub struct Chat {
     /// prompt requests permissions to use a tool, unless --trust-all-tools is also used.
     #[arg(long)]
     pub no_interactive: bool,
+    /// Runs the given path as a Q script
+    #[arg(long, conflicts_with = "input")]
+    pub script: Option<String>,
     /// Resumes the previous conversation from this directory.
     #[arg(short, long)]
     pub resume: bool,

--- a/crates/cli/src/cli/chat/mod.rs
+++ b/crates/cli/src/cli/chat/mod.rs
@@ -153,6 +153,7 @@ use crate::api_client::model::{
     Tool as FigTool,
     ToolResultStatus,
 };
+use crate::cli::script::read_q_script;
 use crate::database::Database;
 use crate::database::settings::Setting;
 use crate::mcp_client::{
@@ -300,10 +301,22 @@ pub async fn launch_chat(database: &mut Database, telemetry: &TelemetryThread, a
         tools
     });
 
+    // input and script are mutually exclusive options, so we can just read the script and
+    // pass it as the input here
+    let mut input = args.input.clone();
+    if let Some(script) = args.script {
+        match read_q_script(&script).await {
+            Ok(v) => input = Some(v),
+            Err(e) => {
+                bail!("Unable to read script {}, {}", script, e);
+            },
+        }
+    }
+
     chat(
         database,
         telemetry,
-        args.input,
+        input,
         args.no_interactive,
         args.resume,
         args.accept_all,

--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -3,6 +3,7 @@ mod debug;
 mod diagnostics;
 mod feed;
 mod issue;
+mod script;
 mod settings;
 mod user;
 
@@ -369,6 +370,7 @@ mod test {
             subcommand: Some(CliRootCommands::Chat(Chat {
                 accept_all: false,
                 no_interactive: false,
+                script: None,
                 resume: false,
                 input: None,
                 profile: None,
@@ -408,6 +410,7 @@ mod test {
             CliRootCommands::Chat(Chat {
                 accept_all: false,
                 no_interactive: false,
+                script: None,
                 resume: false,
                 input: None,
                 profile: Some("my-profile".to_string()),
@@ -424,6 +427,7 @@ mod test {
             CliRootCommands::Chat(Chat {
                 accept_all: false,
                 no_interactive: false,
+                script: None,
                 resume: false,
                 input: Some("Hello".to_string()),
                 profile: Some("my-profile".to_string()),
@@ -440,6 +444,7 @@ mod test {
             CliRootCommands::Chat(Chat {
                 accept_all: true,
                 no_interactive: false,
+                script: None,
                 resume: false,
                 input: None,
                 profile: Some("my-profile".to_string()),
@@ -456,6 +461,7 @@ mod test {
             CliRootCommands::Chat(Chat {
                 accept_all: false,
                 no_interactive: true,
+                script: None,
                 resume: true,
                 input: None,
                 profile: None,
@@ -468,6 +474,7 @@ mod test {
             CliRootCommands::Chat(Chat {
                 accept_all: false,
                 no_interactive: true,
+                script: None,
                 resume: true,
                 input: None,
                 profile: None,
@@ -484,6 +491,7 @@ mod test {
             CliRootCommands::Chat(Chat {
                 accept_all: false,
                 no_interactive: false,
+                script: None,
                 resume: false,
                 input: None,
                 profile: None,
@@ -500,6 +508,7 @@ mod test {
             CliRootCommands::Chat(Chat {
                 accept_all: false,
                 no_interactive: false,
+                script: None,
                 resume: false,
                 input: None,
                 profile: None,
@@ -516,6 +525,7 @@ mod test {
             CliRootCommands::Chat(Chat {
                 accept_all: false,
                 no_interactive: false,
+                script: None,
                 resume: false,
                 input: None,
                 profile: None,

--- a/crates/cli/src/cli/script.rs
+++ b/crates/cli/src/cli/script.rs
@@ -1,0 +1,145 @@
+use std::io;
+
+use eyre::Result;
+use tokio::fs;
+
+/// read_q_script reads the file passed in and returns its contents. If it's first line begins with
+/// a shebang (#!), that line and consecutive lines beginning with a '#' character are skipped.
+pub async fn read_q_script(script: &str) -> Result<String, io::Error> {
+    match fs::read_to_string(&script).await {
+        Ok(content) => {
+            let mut lines = content.lines().peekable();
+            let mut result_lines = Vec::new();
+
+            // Only skip the first line if it starts with '#!'
+            if lines.peek().is_some_and(|line| line.starts_with("#!")) {
+                lines.next();
+                // Skip consecutive comment lines after shebang
+                while lines.peek().is_some_and(|line| line.starts_with('#')) {
+                    lines.next();
+                }
+            }
+
+            result_lines.extend(lines);
+            Ok(result_lines.join("\n"))
+        },
+        Err(e) => Err(e),
+    }
+}
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use tempfile::NamedTempFile;
+
+    use super::*;
+
+    fn create_temp_script(content: &str) -> NamedTempFile {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+        file
+    }
+
+    #[tokio::test]
+    async fn test_script_with_shebang_and_consecutive_comments() {
+        let content =
+            "#!/usr/bin/env q\n# This is a comment\n# Another comment\nactual content\n# Later comment\nmore content";
+        let file = create_temp_script(content);
+
+        let result = read_q_script(file.path().to_string_lossy().as_ref()).await;
+        assert_eq!(result.unwrap(), "actual content\n# Later comment\nmore content");
+    }
+
+    #[tokio::test]
+    async fn test_script_with_shebang_no_comments() {
+        let content = "#!/usr/bin/env q\nactual content\nmore content";
+        let file = create_temp_script(content);
+
+        let result = read_q_script(file.path().to_string_lossy().as_ref()).await;
+        assert_eq!(result.unwrap(), "actual content\nmore content");
+    }
+
+    #[tokio::test]
+    async fn test_script_without_shebang_with_comments() {
+        let content = "# This is a comment\nactual content\n# Later comment\nmore content";
+        let file = create_temp_script(content);
+
+        let result = read_q_script(file.path().to_string_lossy().as_ref()).await;
+        assert_eq!(
+            result.unwrap(),
+            "# This is a comment\nactual content\n# Later comment\nmore content"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_script_without_shebang_no_comments() {
+        let content = "actual content\nmore content";
+        let file = create_temp_script(content);
+
+        let result = read_q_script(file.path().to_string_lossy().as_ref()).await;
+        assert_eq!(result.unwrap(), "actual content\nmore content");
+    }
+
+    #[tokio::test]
+    async fn test_script_with_only_shebang() {
+        let content = "#!/usr/bin/env q";
+        let file = create_temp_script(content);
+
+        let result = read_q_script(file.path().to_string_lossy().as_ref()).await;
+        assert_eq!(result.unwrap(), "");
+    }
+
+    #[tokio::test]
+    async fn test_script_with_shebang_and_only_comments() {
+        let content = "#!/usr/bin/env q\n# Comment 1\n# Comment 2";
+        let file = create_temp_script(content);
+
+        let result = read_q_script(file.path().to_string_lossy().as_ref()).await;
+        assert_eq!(result.unwrap(), "");
+    }
+
+    #[tokio::test]
+    async fn test_script_with_non_shebang_hash_first_line() {
+        let content = "#not a shebang\nactual content\nmore content";
+        let file = create_temp_script(content);
+
+        let result = read_q_script(file.path().to_string_lossy().as_ref()).await;
+        assert_eq!(result.unwrap(), "#not a shebang\nactual content\nmore content");
+    }
+
+    #[tokio::test]
+    async fn test_empty_script() {
+        let content = "";
+        let file = create_temp_script(content);
+
+        let result = read_q_script(file.path().to_string_lossy().as_ref()).await;
+        assert_eq!(result.unwrap(), "");
+    }
+
+    #[tokio::test]
+    async fn test_script_with_mixed_content() {
+        let content = "#!/usr/bin/env q\n# Header comment\n# Another header comment\n\nactual content\n# Inline comment\nmore content\n\n# Final comment";
+        let file = create_temp_script(content);
+
+        let result = read_q_script(file.path().to_string_lossy().as_ref()).await;
+        assert_eq!(
+            result.unwrap(),
+            "\nactual content\n# Inline comment\nmore content\n\n# Final comment"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_nonexistent_file() {
+        let result = read_q_script("/nonexistent/file.q").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_script_with_shebang_and_empty_lines() {
+        let content = "#!/usr/bin/env q\n# Comment\n\n\nactual content";
+        let file = create_temp_script(content);
+
+        let result = read_q_script(file.path().to_string_lossy().as_ref()).await;
+        assert_eq!(result.unwrap(), "\n\nactual content");
+    }
+}


### PR DESCRIPTION
*Description of changes:*

This allows using the Q cli as an intepreter for a script.

E.g.
```
#!/usr/bin/env q chat --no-interactive --trust-tools=a,b --script
```

`--no-interactive` is optional, if not passed the script is passed as the initial input and then Q cli enters standard interactive mode.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
