### PR TITLE
feat(cli): Support specifying specific mcp configurations per profile (#1490)

### DIFF
--- a/crates/cli/src/cli/chat/cli.rs
+++ b/crates/cli/src/cli/chat/cli.rs
@@ -46,10 +46,9 @@ pub enum Mcp {
     /// Import a server configuration from another file
     Import(McpImport),
     /// Get the status of a configured server
-    Status {
-        #[arg(long)]
-        name: String,
-    },
+    Status(McpStatus),
+    /// Set whether a profile should exclusively use its own MCP servers
+    UseProfileServersOnly(McpUseProfileServersOnly),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Args)]
@@ -63,6 +62,9 @@ pub struct McpAdd {
     /// Where to add the server to.
     #[arg(long, value_enum)]
     pub scope: Option<Scope>,
+    /// Profile to add the MCP server to
+    #[arg(long)]
+    pub profile: Option<String>,
     /// Environment variables to use when launching the server
     #[arg(long, value_parser = parse_env_vars)]
     pub env: Vec<HashMap<String, String>>,
@@ -80,13 +82,17 @@ pub struct McpRemove {
     pub name: String,
     #[arg(long, value_enum)]
     pub scope: Option<Scope>,
+    /// Profile to remove the MCP server from
+    #[arg(long)]
+    pub profile: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Args)]
 pub struct McpList {
     #[arg(value_enum)]
     pub scope: Option<Scope>,
-    #[arg(long, hide = true)]
+    /// Profile to list MCP servers for
+    #[arg(long)]
     pub profile: Option<String>,
 }
 
@@ -96,15 +102,35 @@ pub struct McpImport {
     pub file: String,
     #[arg(value_enum)]
     pub scope: Option<Scope>,
+    /// Profile to import MCP servers to
+    #[arg(long)]
+    pub profile: Option<String>,
     /// Overwrite an existing server with the same name
     #[arg(long, default_value_t = false)]
     pub force: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Args)]
+pub struct McpStatus {
+    #[arg(long)]
+    pub name: String,
+    #[arg(long)]
+    pub profile: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Args)]
+pub struct McpUseProfileServersOnly {
+    #[arg(long, help = "Profile name")]
+    pub profile: String,
+    #[arg(long, default_value_t = false)]
+    pub value: bool,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, ValueEnum)]
 pub enum Scope {
     Workspace,
     Global,
+    Profile,
 }
 
 impl std::fmt::Display for Scope {
@@ -112,6 +138,7 @@ impl std::fmt::Display for Scope {
         match self {
             Scope::Workspace => write!(f, "workspace"),
             Scope::Global => write!(f, "global"),
+            Scope::Profile => write!(f, "profile"),
         }
     }
 }

--- a/crates/cli/src/cli/chat/cli.rs
+++ b/crates/cli/src/cli/chat/cli.rs
@@ -120,9 +120,9 @@ pub struct McpStatus {
 
 #[derive(Debug, Clone, PartialEq, Eq, Args)]
 pub struct McpUseProfileServersOnly {
-    #[arg(long, help = "Profile name")]
+    #[arg(long)]
     pub profile: String,
-    #[arg(long, default_value_t = false)]
+    #[arg(long, value_name = "BOOLEAN", default_value = "true", action = clap::ArgAction::Set)]
     pub value: bool,
 }
 

--- a/crates/cli/src/cli/chat/mcp.rs
+++ b/crates/cli/src/cli/chat/mcp.rs
@@ -19,11 +19,15 @@ use crate::cli::chat::cli::{
     McpImport,
     McpList,
     McpRemove,
+    McpStatus,
+    McpUseProfileServersOnly,
     Scope,
 };
 use crate::cli::chat::tool_manager::{
     McpServerConfig,
     global_mcp_config_path,
+    profile_mcp_path,
+    queue_profile_exclusive_warning,
     workspace_mcp_config_path,
 };
 use crate::cli::chat::tools::custom_tool::{
@@ -42,7 +46,8 @@ pub async fn execute_mcp(args: Mcp) -> Result<ExitCode> {
         Mcp::Remove(args) => remove_mcp_server(&ctx, &mut output, args).await?,
         Mcp::List(args) => list_mcp_server(&ctx, &mut output, args).await?,
         Mcp::Import(args) => import_mcp_server(&ctx, &mut output, args).await?,
-        Mcp::Status { name } => get_mcp_server_status(&ctx, &mut output, name).await?,
+        Mcp::Status(args) => get_mcp_server_status(&ctx, &mut output, args).await?,
+        Mcp::UseProfileServersOnly(args) => set_profile_servers_only(&ctx, &mut output, args).await?,
     }
 
     output.flush()?;
@@ -51,7 +56,7 @@ pub async fn execute_mcp(args: Mcp) -> Result<ExitCode> {
 
 pub async fn add_mcp_server(ctx: &Context, output: &mut SharedWriter, args: McpAdd) -> Result<()> {
     let scope = args.scope.unwrap_or(Scope::Workspace);
-    let config_path = resolve_scope_profile(ctx, args.scope)?;
+    let config_path = resolve_scope_profile(ctx, args.scope, args.profile)?;
 
     let mut config: McpServerConfig = ensure_config_file(ctx, &config_path, output).await?;
 
@@ -89,7 +94,7 @@ pub async fn add_mcp_server(ctx: &Context, output: &mut SharedWriter, args: McpA
 
 pub async fn remove_mcp_server(ctx: &Context, output: &mut SharedWriter, args: McpRemove) -> Result<()> {
     let scope = args.scope.unwrap_or(Scope::Workspace);
-    let config_path = resolve_scope_profile(ctx, args.scope)?;
+    let config_path = resolve_scope_profile(ctx, args.scope, args.profile)?;
 
     if !ctx.fs().exists(&config_path) {
         writeln!(output, "\nNo MCP server configurations found.\n")?;
@@ -120,7 +125,7 @@ pub async fn remove_mcp_server(ctx: &Context, output: &mut SharedWriter, args: M
 }
 
 pub async fn list_mcp_server(ctx: &Context, output: &mut SharedWriter, args: McpList) -> Result<()> {
-    let configs = get_mcp_server_configs(ctx, args.scope).await?;
+    let configs = get_mcp_server_configs(ctx, output, args.scope, args.profile).await?;
     if configs.is_empty() {
         writeln!(output, "No MCP server configurations found.\n")?;
         return Ok(());
@@ -146,7 +151,7 @@ pub async fn list_mcp_server(ctx: &Context, output: &mut SharedWriter, args: Mcp
 
 pub async fn import_mcp_server(ctx: &Context, output: &mut SharedWriter, args: McpImport) -> Result<()> {
     let scope: Scope = args.scope.unwrap_or(Scope::Workspace);
-    let config_path = resolve_scope_profile(ctx, args.scope)?;
+    let config_path = resolve_scope_profile(ctx, args.scope, args.profile)?;
     let mut dst_cfg = ensure_config_file(ctx, &config_path, output).await?;
 
     let src_path = expand_path(ctx, &args.file)?;
@@ -180,12 +185,12 @@ pub async fn import_mcp_server(ctx: &Context, output: &mut SharedWriter, args: M
     Ok(())
 }
 
-pub async fn get_mcp_server_status(ctx: &Context, output: &mut SharedWriter, name: String) -> Result<()> {
-    let configs = get_mcp_server_configs(ctx, None).await?;
+pub async fn get_mcp_server_status(ctx: &Context, output: &mut SharedWriter, args: McpStatus) -> Result<()> {
+    let configs = get_mcp_server_configs(ctx, output, None, args.profile).await?;
     let mut found = false;
 
     for (sc, path, cfg_opt) in configs {
-        if let Some(cfg) = cfg_opt.and_then(|c| c.mcp_servers.get(&name).cloned()) {
+        if let Some(cfg) = cfg_opt.and_then(|c| c.mcp_servers.get(&args.name).cloned()) {
             found = true;
             execute!(
                 output,
@@ -206,24 +211,36 @@ pub async fn get_mcp_server_status(ctx: &Context, output: &mut SharedWriter, nam
     writeln!(output, "\n")?;
 
     if !found {
-        bail!("No MCP server named '{name}' found in any scope/profile\n");
+        bail!("No MCP server named '{0}' found in any scope/profile\n", args.name);
     }
     Ok(())
 }
 
-async fn get_mcp_server_configs(
+pub async fn get_mcp_server_configs(
     ctx: &Context,
+    output: &mut SharedWriter,
     scope: Option<Scope>,
+    profile: Option<String>,
 ) -> Result<Vec<(Scope, PathBuf, Option<McpServerConfig>)>> {
-    let mut targets = Vec::new();
-    match scope {
-        Some(scope) => targets.push(scope),
-        None => targets.extend([Scope::Workspace, Scope::Global]),
-    }
-
     let mut results = Vec::new();
-    for sc in targets {
-        let path = resolve_scope_profile(ctx, Some(sc))?;
+
+    // Determine which scopes to include based on the scope parameter
+    let scopes_to_include = match scope {
+        Some(specific_scope) => vec![specific_scope],
+        None => vec![Scope::Profile, Scope::Workspace, Scope::Global],
+    };
+
+    // Process each scope
+    for sc in scopes_to_include {
+        // Skip Profile scope if no profile name is provided
+        if sc == Scope::Profile && profile.is_none() {
+            continue;
+        }
+
+        // Resolve the path for this scope using resolve_scope_profile consistently
+        let path = resolve_scope_profile(ctx, Some(sc), profile.clone())?;
+
+        // Load the configuration if it exists
         let cfg_opt = if ctx.fs().exists(&path) {
             match McpServerConfig::load_from_file(ctx, &path).await {
                 Ok(cfg) => Some(cfg),
@@ -235,8 +252,20 @@ async fn get_mcp_server_configs(
         } else {
             None
         };
+
+        // Check if this is a profile with use_profile_servers_only set to true
+        if sc == Scope::Profile {
+            if let Some(cfg) = &cfg_opt {
+                if cfg.use_profile_servers_only {
+                    queue_profile_exclusive_warning(output)?;
+                    return Ok(vec![(sc, path, cfg_opt)]);
+                }
+            }
+        }
+
         results.push((sc, path, cfg_opt));
     }
+
     Ok(results)
 }
 
@@ -244,14 +273,19 @@ fn scope_display(scope: &Scope) -> String {
     match scope {
         Scope::Workspace => "📄 workspace".into(),
         Scope::Global => "🌍 global".into(),
+        Scope::Profile => "👤 profile".into(),
     }
 }
 
-fn resolve_scope_profile(ctx: &Context, scope: Option<Scope>) -> Result<PathBuf> {
-    Ok(match scope {
-        Some(Scope::Global) => global_mcp_config_path(ctx)?,
-        _ => workspace_mcp_config_path(ctx)?,
-    })
+fn resolve_scope_profile(ctx: &Context, scope: Option<Scope>, profile: Option<String>) -> Result<PathBuf> {
+    match scope {
+        Some(Scope::Profile) => {
+            let profile_name = profile.ok_or_else(|| eyre::eyre!("Profile name is required when scope is Profile"))?;
+            profile_mcp_path(ctx, &profile_name)
+        },
+        Some(Scope::Global) => global_mcp_config_path(ctx),
+        _ => workspace_mcp_config_path(ctx), // None or Workspace both default to workspace
+    }
 }
 
 fn expand_path(ctx: &Context, p: &str) -> Result<PathBuf> {
@@ -286,11 +320,17 @@ async fn load_cfg(ctx: &Context, p: &PathBuf) -> Result<McpServerConfig> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli::chat::cli::{
+        McpAdd,
+        McpRemove,
+        McpUseProfileServersOnly,
+    };
+    use crate::util::directories;
 
-    #[test]
-    fn test_scope_and_profile_defaults_to_workspace() {
-        let ctx = Context::new();
-        let path = resolve_scope_profile(&ctx, None).unwrap();
+    #[tokio::test]
+    async fn test_scope_and_profile_defaults_to_workspace() {
+        let ctx = Context::builder().with_test_home().await.unwrap().build_fake();
+        let path = resolve_scope_profile(&ctx, None, None).unwrap();
         assert_eq!(
             path.to_str(),
             workspace_mcp_config_path(&ctx).unwrap().to_str(),
@@ -298,27 +338,45 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_resolve_paths() {
-        let ctx = Context::new();
-        // workspace
-        let p = resolve_scope_profile(&ctx, Some(Scope::Workspace)).unwrap();
-        assert_eq!(p, workspace_mcp_config_path(&ctx).unwrap());
+    #[tokio::test]
+    async fn test_resolve_scope_profile_all_cases() {
+        let ctx = Context::builder().with_test_home().await.unwrap().build_fake();
 
-        // global
-        let p = resolve_scope_profile(&ctx, Some(Scope::Global)).unwrap();
-        assert_eq!(p, global_mcp_config_path(&ctx).unwrap());
+        // Test default (None scope, None profile) -> workspace
+        let path = resolve_scope_profile(&ctx, None, None).unwrap();
+        assert_eq!(path, workspace_mcp_config_path(&ctx).unwrap());
+
+        // Test explicit workspace scope
+        let path = resolve_scope_profile(&ctx, Some(Scope::Workspace), None).unwrap();
+        assert_eq!(path, workspace_mcp_config_path(&ctx).unwrap());
+
+        // Test global scope
+        let path = resolve_scope_profile(&ctx, Some(Scope::Global), None).unwrap();
+        assert_eq!(path, global_mcp_config_path(&ctx).unwrap());
+
+        // Test profile scope with profile name
+        let path = resolve_scope_profile(&ctx, Some(Scope::Profile), Some("test_profile".to_string())).unwrap();
+        assert_eq!(path, profile_mcp_path(&ctx, "test_profile").unwrap());
     }
 
-    #[ignore = "TODO: fix in CI"]
+    #[tokio::test]
+    async fn test_resolve_scope_profile_errors() {
+        let ctx = Context::builder().with_test_home().await.unwrap().build_fake();
+
+        // Test Profile scope without profile name should error
+        let result = resolve_scope_profile(&ctx, Some(Scope::Profile), None);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Profile name is required"));
+    }
+
     #[tokio::test]
     async fn ensure_file_created_and_loaded() {
-        let ctx = Context::new();
+        let ctx = Context::builder().with_test_home().await.unwrap().build_fake();
         let mut out = SharedWriter::null();
         let path = workspace_mcp_config_path(&ctx).unwrap();
 
         let cfg = super::ensure_config_file(&ctx, &path, &mut out).await.unwrap();
-        assert!(path.exists(), "config file should be created");
+        assert!(ctx.fs().exists(&path), "config file should be created");
         assert!(cfg.mcp_servers.is_empty());
     }
 
@@ -329,7 +387,7 @@ mod tests {
             McpRemove,
         };
 
-        let ctx = Context::new();
+        let ctx = Context::builder().with_test_home().await.unwrap().build_fake();
         let mut out = SharedWriter::null();
 
         // 1. add
@@ -339,6 +397,7 @@ mod tests {
             env: vec![],
             timeout: None,
             scope: None,
+            profile: None,
             force: false,
         };
         add_mcp_server(&ctx, &mut out, add_args).await.unwrap();
@@ -351,10 +410,202 @@ mod tests {
         let rm_args = McpRemove {
             name: "local".into(),
             scope: None,
+            profile: None,
         };
         remove_mcp_server(&ctx, &mut out, rm_args).await.unwrap();
 
         let cfg: McpServerConfig = serde_json::from_str(&ctx.fs().read_to_string(cfg_path).await.unwrap()).unwrap();
         assert!(cfg.mcp_servers.is_empty());
     }
+
+    #[tokio::test]
+    async fn test_mcp_commands_with_profile() {
+        let ctx = Context::builder().with_test_home().await.unwrap().build_fake();
+        let mut output = SharedWriter::null();
+
+        // Create a test profile directory
+        let profile_dir = directories::chat_profiles_dir(&ctx).unwrap().join("test_profile");
+        ctx.fs().create_dir_all(&profile_dir).await.unwrap();
+
+        // Test add command
+        let add_args = McpAdd {
+            name: "test_server".to_string(),
+            command: "test_command".to_string(),
+            scope: None,
+            profile: Some("test_profile".to_string()),
+            env: vec![],
+            timeout: None,
+            force: false,
+        };
+        add_mcp_server(&ctx, &mut output, add_args).await.unwrap();
+
+        // Test list command
+        let list_args = McpList {
+            scope: None,
+            profile: Some("test_profile".to_string()),
+        };
+        list_mcp_server(&ctx, &mut output, list_args).await.unwrap();
+
+        // Test remove command
+        let remove_args = McpRemove {
+            name: "test_server".to_string(),
+            scope: None,
+            profile: Some("test_profile".to_string()),
+        };
+        remove_mcp_server(&ctx, &mut output, remove_args).await.unwrap();
+
+        // Test use-profile-servers-only command
+        set_profile_servers_only(&ctx, &mut output, McpUseProfileServersOnly {
+            profile: "test_profile".to_string(),
+            value: true,
+        })
+        .await
+        .unwrap();
+
+        // Verify the flag was set
+        let profile_path = profile_mcp_path(&ctx, "test_profile").unwrap();
+        let config = McpServerConfig::load_from_file(&ctx, &profile_path).await.unwrap();
+        assert!(config.use_profile_servers_only);
+
+        // Clean up
+        ctx.fs().remove_file(&profile_path).await.unwrap();
+        ctx.fs().remove_dir_all(&profile_dir).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_profile_servers_only_flag() {
+        let ctx = Context::builder().with_test_home().await.unwrap().build_fake();
+        let mut output = SharedWriter::null();
+
+        // Add servers to different scopes
+        add_mcp_server(&ctx, &mut output, McpAdd {
+            name: "profile_server".to_string(),
+            command: "profile_command".to_string(),
+            scope: Some(Scope::Profile),
+            profile: Some("test_profile".to_string()),
+            env: vec![],
+            timeout: None,
+            force: false,
+        })
+        .await
+        .unwrap();
+
+        add_mcp_server(&ctx, &mut output, McpAdd {
+            name: "workspace_server".to_string(),
+            command: "workspace_command".to_string(),
+            scope: Some(Scope::Workspace),
+            profile: None,
+            env: vec![],
+            timeout: None,
+            force: false,
+        })
+        .await
+        .unwrap();
+
+        add_mcp_server(&ctx, &mut output, McpAdd {
+            name: "global_server".to_string(),
+            command: "global_command".to_string(),
+            scope: Some(Scope::Global),
+            profile: None,
+            env: vec![],
+            timeout: None,
+            force: false,
+        })
+        .await
+        .unwrap();
+
+        // Test with use_profile_servers_only = false (default)
+        let configs = get_mcp_server_configs(&ctx, &mut output, None, Some("test_profile".to_string()))
+            .await
+            .unwrap();
+        assert_eq!(
+            configs.len(),
+            3,
+            "Should return configs from all scopes when use_profile_servers_only is false"
+        );
+
+        // Verify all scopes are included
+        let scopes: Vec<Scope> = configs.iter().map(|(scope, _, _)| *scope).collect();
+        assert!(scopes.contains(&Scope::Profile), "Should include Profile scope");
+        assert!(scopes.contains(&Scope::Workspace), "Should include Workspace scope");
+        assert!(scopes.contains(&Scope::Global), "Should include Global scope");
+
+        // Set use_profile_servers_only = true
+        set_profile_servers_only(&ctx, &mut output, McpUseProfileServersOnly {
+            profile: "test_profile".to_string(),
+            value: true,
+        })
+        .await
+        .unwrap();
+
+        // Test with use_profile_servers_only = true
+        let configs = get_mcp_server_configs(&ctx, &mut output, None, Some("test_profile".to_string()))
+            .await
+            .unwrap();
+        assert_eq!(
+            configs.len(),
+            1,
+            "Should return only profile config when use_profile_servers_only is true"
+        );
+        assert_eq!(configs[0].0, Scope::Profile, "Should return profile scope only");
+
+        // Verify the profile config contains the expected server
+        if let Some(ref config) = configs[0].2 {
+            assert!(
+                config.mcp_servers.contains_key("profile_server"),
+                "Profile server should be present"
+            );
+            assert!(config.use_profile_servers_only, "Flag should be set to true");
+        } else {
+            panic!("Profile config should exist");
+        }
+    }
+}
+
+pub async fn set_profile_servers_only(
+    ctx: &Context,
+    output: &mut SharedWriter,
+    args: McpUseProfileServersOnly,
+) -> Result<()> {
+    // Get the profile MCP path
+    let profile_mcp_path = profile_mcp_path(ctx, &args.profile)?;
+
+    // Check if the profile exists
+    let profile_dir = profile_mcp_path
+        .parent()
+        .ok_or_else(|| eyre::eyre!("Invalid profile path"))?;
+    if !ctx.fs().exists(profile_dir) {
+        bail!("Profile '{}' does not exist", args.profile);
+    }
+
+    // Load or create the profile MCP configuration
+    let mut config = if ctx.fs().exists(&profile_mcp_path) {
+        match McpServerConfig::load_from_file(ctx, &profile_mcp_path).await {
+            Ok(config) => config,
+            Err(e) => {
+                warn!("Failed to load profile MCP config: {}", e);
+                McpServerConfig::default()
+            },
+        }
+    } else {
+        McpServerConfig::default()
+    };
+
+    // Set the exclusivity flag
+    config.use_profile_servers_only = args.value;
+
+    // Save the configuration
+    if let Some(parent) = profile_mcp_path.parent() {
+        ctx.fs().create_dir_all(parent).await?;
+    }
+    config.save_to_file(ctx, &profile_mcp_path).await?;
+
+    writeln!(
+        output,
+        "\n✓ Set profile '{}' to {} use profile-specific MCP servers exclusively\n",
+        args.profile,
+        if args.value { "now" } else { "no longer" }
+    )?;
+
+    Ok(())
 }

--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -321,6 +321,7 @@ mod test {
         McpImport,
         McpList,
         McpRemove,
+        McpStatus,
         Scope,
     };
 
@@ -551,6 +552,7 @@ mod test {
                 ],
                 timeout: None,
                 force: false,
+                profile: None,
             }))
         );
     }
@@ -562,6 +564,7 @@ mod test {
             CliRootCommands::Mcp(Mcp::Remove(McpRemove {
                 name: "old".into(),
                 scope: None,
+                profile: None,
             }))
         );
     }
@@ -573,6 +576,7 @@ mod test {
                 file: "servers.json".into(),
                 scope: None,
                 force: true,
+                profile: None,
             }))
         );
     }
@@ -581,7 +585,10 @@ mod test {
     fn test_mcp_subcommand_status_simple() {
         assert_parse!(
             ["mcp", "status", "--name", "aws"],
-            CliRootCommands::Mcp(Mcp::Status { name: "aws".into() })
+            CliRootCommands::Mcp(Mcp::Status(McpStatus {
+                name: "aws".into(),
+                profile: None
+            }))
         );
     }
 


### PR DESCRIPTION
*Issue #, if available:*
#1490 

*Description of changes:*

This PR adds the ability for users to specify which MCP servers they would like to use for any given profile. I believe this would be a very powerful feature for users, as it allows them to pick specific sets of tools for certain tasks, resulting in better context window utilisation and mitigating other issues caused by having too many mcp servers enabled.  

The way this is currently implemented in this PR is like this:
- If a user places a `mcp.json` file into the `/.aws/amazonq/profiles/<profilename>/mcp.json` (or creates one using the `q mcp add` command) , and that profile is active, the mcp servers defined here will be included along with the global and workspace based servers (by default)
- A new field within this `mcp.json` file may exist called `useProfileServersOnly`. When this field exists and is set to `true`, the mcp servers configured at the profile level are used exclusively, and global/workspace servers are not loaded.
- When profile based mcp servers are included alongside the global/workspace ones (default behaviour), the order of precedence goes Profile > Workspace > Global in the event of a conflict.
- When a user switches profile using the `/profile set <profilename>` command, all mcp servers are reloaded to take the profile level preferences into account.
- The q mcp commands allow for showing/manipulating profile level mcp servers, in addition to global and workspace as it is currently. e.g `q mcp list --profile <profilename>`
- There is a new `q mcp` command for setting the `useProfileServersOnly` field in the json. Example: `q mcp use-profile-servers-only --profile gateway`

Apologies for the size of this PR, I tried to keep it brief but it interacts with a fair amount of logic so some refactors were necessary.

Next Steps:
- All feedback would be very welcome on either the design (UX) or implementation for this PR. 
- Nitpicks on the code are also helpful, I'm not too familiar with Rust so if I've missed some best practices please point them out.
- I think unit testing and documentation for this change can be improved further, so I will do that as well as incorporate any feedback.


--- 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
