### PR TITLE
Add bell support for eat terminal

### DIFF
--- a/crates/chat-cli/src/cli/chat/util/mod.rs
+++ b/crates/chat-cli/src/cli/chat/util/mod.rs
@@ -76,6 +76,9 @@ fn should_play_bell() -> bool {
             "gnome-256color",
             "alacritty",
             "iterm2",
+            "eat-truecolor",
+            "eat-256color",
+            "eat-color",
         ];
 
         // Check if the current terminal is in the compatible list


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The emacs eat terminal handles beeps fine, and the beep feature only works for allowlisted terminals.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
