### PR TITLE
fix(logs): sanitize strings and print the log message sent by mcp server

### DIFF
--- a/crates/chat-cli/src/mcp_client/client.rs
+++ b/crates/chat-cli/src/mcp_client/client.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::io::stdout;
 use std::process::Stdio;
 use std::sync::atomic::{
     AtomicBool,
@@ -12,10 +11,6 @@ use std::sync::{
 };
 use std::time::Duration;
 
-use crossterm::{
-    queue,
-    style,
-};
 use serde::{
     Deserialize,
     Serialize,
@@ -391,18 +386,6 @@ where
                                             _ => serde_json::to_string_pretty(v).unwrap_or_default(),
                                         });
                                         if let (Some(level), Some(data)) = (level, data) {
-                                            let _ = queue!(
-                                                stdout(),
-                                                style::Print("["),
-                                                style::Print(level.to_uppercase().as_str()),
-                                                style::Print("] "),
-                                                style::SetForegroundColor(style::Color::Magenta),
-                                                style::Print(&server_name),
-                                                style::ResetColor,
-                                                style::Print(": "),
-                                                style::Print(&data),
-                                                style::Print("\n"),
-                                            );
                                             match level.to_lowercase().as_str() {
                                                 "error" => {
                                                     tracing::error!(target: "mcp", "{}: {}", server_name, data);


### PR DESCRIPTION
*Issue #1970*

## Overview
Q CLI supports receiving logs from MCP servers, but the current implementation keeps double quotes (example: `\"info\"` from the json strings, so the level doesn't match either of `debug` | `info` | `warning` | `error`.

Therefore, the issue is that while the message is received, it's never logged.

## Key Changes
- Read '**level**' as `string` instead of `json.to_string()`.
- Read '**data**' as either `string` or `json` as both are supported by MCP SDK
- ~Print the log to stdout so any tool with long runtime can show progress or status to the user for a better user experience.~

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*