### PR TITLE
Implement disableMarkdownRendering setting to allow users to disable markdown …

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -1952,7 +1952,10 @@ impl ChatSession {
         let mut buf = String::new();
         let mut offset = 0;
         let mut ended = false;
-        let mut state = ParseState::new(Some(self.terminal_width()));
+        let mut state = ParseState::new(
+            Some(self.terminal_width()),
+            os.database.settings.get_bool(Setting::ChatDisableMarkdownRendering),
+        );
         let mut response_prefix_printed = false;
 
         let mut tool_uses = Vec::new();
@@ -1983,10 +1986,13 @@ impl ChatSession {
                         },
                         parser::ResponseEvent::AssistantText(text) => {
                             // Add Q response prefix before the first assistant text.
-                            // This must be markdown - using a code tick, which is printed
-                            // as green.
                             if !response_prefix_printed && !text.trim().is_empty() {
-                                buf.push_str("`>` ");
+                                queue!(
+                                    self.stdout,
+                                    style::SetForegroundColor(Color::Green),
+                                    style::Print("> "),
+                                    style::SetForegroundColor(Color::Reset)
+                                )?;
                                 response_prefix_printed = true;
                             }
                             buf.push_str(&text);

--- a/crates/chat-cli/src/cli/chat/parse.rs
+++ b/crates/chat-cli/src/cli/chat/parse.rs
@@ -82,6 +82,7 @@ impl<'a> ParserError<Partial<&'a str>> for Error<'a> {
 #[derive(Debug)]
 pub struct ParseState {
     pub terminal_width: Option<usize>,
+    pub markdown_disabled: Option<bool>,
     pub column: usize,
     pub in_codeblock: bool,
     pub bold: bool,
@@ -93,9 +94,10 @@ pub struct ParseState {
 }
 
 impl ParseState {
-    pub fn new(terminal_width: Option<usize>) -> Self {
+    pub fn new(terminal_width: Option<usize>, markdown_disabled: Option<bool>) -> Self {
         Self {
             terminal_width,
+            markdown_disabled,
             column: 0,
             in_codeblock: false,
             bold: false,
@@ -135,8 +137,12 @@ pub fn interpret_markdown<'a, 'b>(
         };
     }
 
-    match state.in_codeblock {
-        false => {
+    match (state.in_codeblock, state.markdown_disabled.unwrap_or(false)) {
+        (_, true) => {
+            // If markdown is disabled, do not include markdown-related parsers
+            stateful_alt!(text, line_ending, fallback);
+        },
+        (false, false) => {
             stateful_alt!(
                 // This pattern acts as a short circuit for alphanumeric plaintext
                 // More importantly, it's needed to support manual wordwrapping
@@ -167,7 +173,7 @@ pub fn interpret_markdown<'a, 'b>(
                 fallback
             );
         },
-        true => {
+        (true, false) => {
             stateful_alt!(
                 codeblock_less_than,
                 codeblock_greater_than,
@@ -646,7 +652,7 @@ mod tests {
     use super::*;
 
     macro_rules! validate {
-        ($test:ident, $input:literal, [$($commands:expr),+ $(,)?]) => {
+        ($test:ident, $input:literal, [$($commands:expr),+ $(,)?], $markdown_enabled:expr) => {
             #[test]
             fn $test() -> eyre::Result<()> {
                 use crossterm::ExecutableCommand;
@@ -655,7 +661,7 @@ mod tests {
                 input.push(' ');
                 input.push(' ');
 
-                let mut state = ParseState::new(Some(80));
+                let mut state = ParseState::new(Some(80), Some($markdown_enabled));
                 let mut presult = vec![];
                 let mut offset = 0;
 
@@ -685,6 +691,10 @@ mod tests {
 
                 Ok(())
             }
+        };
+
+        ($test:ident, $input:literal, [$($commands:expr),+ $(,)?]) => {
+            validate!($test, $input, [$($commands),+], false);
         };
     }
 
@@ -759,4 +769,53 @@ mod tests {
     validate!(square_bracket_url_like_2, "[text](without url part", [style::Print(
         "[text](without url part"
     )]);
+
+    validate!(markdown_disabled_bold, "**hello**", [style::Print("**hello**")], true);
+    validate!(markdown_disabled_italic, "*hello*", [style::Print("*hello*")], true);
+    validate!(markdown_disabled_code, "`print`", [style::Print("`print`")], true);
+    validate!(
+        markdown_disabled_heading,
+        "# Hello World",
+        [style::Print("# Hello World")],
+        true
+    );
+    validate!(markdown_disabled_bullet, "- bullet", [style::Print("- bullet")], true);
+    validate!(markdown_disabled_number, "1. number", [style::Print("1. number")], true);
+    validate!(markdown_disabled_blockquote, "> hello", [style::Print("> hello")], true);
+    validate!(
+        markdown_disabled_url,
+        "[amazon](amazon.com)",
+        [style::Print("[amazon](amazon.com)")],
+        true
+    );
+    validate!(
+        markdown_disabled_codeblock,
+        "```java hello world!```",
+        [style::Print("```java hello world!```")],
+        true
+    );
+    validate!(
+        markdown_disabled_text,
+        "hello world!",
+        [style::Print("hello world!")],
+        true
+    );
+    validate!(
+        markdown_disabled_line_ending,
+        "line one\nline two",
+        [
+            style::Print("line one"),
+            style::ResetColor,
+            style::SetAttribute(style::Attribute::Reset),
+            style::Print("\n"),
+            style::Print("line two")
+        ],
+        true
+    );
+    validate!(
+        markdown_disabled_fallback,
+        "+ % @ . ?",
+        [style::Print("+ % @ . ?")],
+        true
+    );
 }

--- a/crates/chat-cli/src/database/settings.rs
+++ b/crates/chat-cli/src/database/settings.rs
@@ -33,6 +33,7 @@ pub enum Setting {
     McpNoInteractiveTimeout,
     McpLoadedBefore,
     ChatDefaultModel,
+    ChatDisableMarkdownRendering,
     ChatDefaultAgent,
     ChatDisableAutoCompaction,
     ChatEnableHistoryHints,
@@ -57,6 +58,7 @@ impl AsRef<str> for Setting {
             Self::McpNoInteractiveTimeout => "mcp.noInteractiveTimeout",
             Self::McpLoadedBefore => "mcp.loadedBefore",
             Self::ChatDefaultModel => "chat.defaultModel",
+            Self::ChatDisableMarkdownRendering => "chat.disableMarkdownRendering",
             Self::ChatDefaultAgent => "chat.defaultAgent",
             Self::ChatDisableAutoCompaction => "chat.disableAutoCompaction",
             Self::ChatEnableHistoryHints => "chat.enableHistoryHints",
@@ -91,6 +93,7 @@ impl TryFrom<&str> for Setting {
             "mcp.noInteractiveTimeout" => Ok(Self::McpNoInteractiveTimeout),
             "mcp.loadedBefore" => Ok(Self::McpLoadedBefore),
             "chat.defaultModel" => Ok(Self::ChatDefaultModel),
+            "chat.disableMarkdownRendering" => Ok(Self::ChatDisableMarkdownRendering),
             "chat.defaultAgent" => Ok(Self::ChatDefaultAgent),
             "chat.disableAutoCompaction" => Ok(Self::ChatDisableAutoCompaction),
             "chat.enableHistoryHints" => Ok(Self::ChatEnableHistoryHints),
@@ -213,12 +216,17 @@ mod test {
         assert_eq!(settings.get(Setting::ShareCodeWhispererContent), None);
         assert_eq!(settings.get(Setting::McpLoadedBefore), None);
         assert_eq!(settings.get(Setting::ChatDefaultModel), None);
+        assert_eq!(settings.get(Setting::ChatDisableMarkdownRendering), None);
 
         settings.set(Setting::TelemetryEnabled, true).await.unwrap();
         settings.set(Setting::OldClientId, "test").await.unwrap();
         settings.set(Setting::ShareCodeWhispererContent, false).await.unwrap();
         settings.set(Setting::McpLoadedBefore, true).await.unwrap();
         settings.set(Setting::ChatDefaultModel, "model 1").await.unwrap();
+        settings
+            .set(Setting::ChatDisableMarkdownRendering, false)
+            .await
+            .unwrap();
 
         assert_eq!(settings.get(Setting::TelemetryEnabled), Some(&Value::Bool(true)));
         assert_eq!(
@@ -234,15 +242,21 @@ mod test {
             settings.get(Setting::ChatDefaultModel),
             Some(&Value::String("model 1".to_string()))
         );
+        assert_eq!(
+            settings.get(Setting::ChatDisableMarkdownRendering),
+            Some(&Value::Bool(false))
+        );
 
         settings.remove(Setting::TelemetryEnabled).await.unwrap();
         settings.remove(Setting::OldClientId).await.unwrap();
         settings.remove(Setting::ShareCodeWhispererContent).await.unwrap();
         settings.remove(Setting::McpLoadedBefore).await.unwrap();
+        settings.remove(Setting::ChatDisableMarkdownRendering).await.unwrap();
 
         assert_eq!(settings.get(Setting::TelemetryEnabled), None);
         assert_eq!(settings.get(Setting::OldClientId), None);
         assert_eq!(settings.get(Setting::ShareCodeWhispererContent), None);
         assert_eq!(settings.get(Setting::McpLoadedBefore), None);
+        assert_eq!(settings.get(Setting::ChatDisableMarkdownRendering), None);
     }
 }


### PR DESCRIPTION
*Issue #, if available:* 
- None.

*Why make this change:*
- This was personally bothering me as a user - asking Q to generate markdown-formatted text (e.g. CR descriptions) would result in rendered markdown. I would have to re-format the output after pasting it into CRUX.

*Description of changes:*
- Created a new `chat` setting, `disableMarkdownRendering`, that users can use to disable markdown rendering in the responses. The setting defaults to `true`, unless specified `false` by the user.
- When the `disableMarkdownRendering` setting is set to `false`, skip the markdown-related parsers in `parse.rs`.
- Added unit tests to validate behavior.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

EDIT: Updated name of setting from `enableMarkdown` to `disableMarkdownRendering`.