### PR TITLE
docs: remove broken architecture diagram link

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,10 +237,6 @@ Other folder to be aware of
   specification for inter-process communication
 - [`tests/`](tests/) - Contain integration tests for the projects
 
-Below is a high level architecture of how the different components of the app and
-their IPC:
-
-![architecture](docs/assets/architecture.svg)
 
 
 


### PR DESCRIPTION
*Issue # , if available:* 
Resolves #2219

*Description of changes:*
Remove from README.md a broken link to an architecture diagram that got [deleted](https://github.com/aws/amazon-q-developer-cli/commit/8c0aff153eb387e2e9000279b486f0d7a7321070).

*Note: created a new PR since the original used the main branch as source 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
