### PR TITLE
fixes migration workflow not differentiating between home dir and cwd

### DIFF
--- a/crates/chat-cli/src/cli/agent.rs
+++ b/crates/chat-cli/src/cli/agent.rs
@@ -329,6 +329,16 @@ impl Agents {
         }
 
         let mut local_agents = 'local: {
+            // We could be launching from the home dir, in which case the global and local agents
+            // are the same set of agents. If that is the case, we simply skip this.
+            match (std::env::current_dir(), directories::home_dir(os)) {
+                (Ok(cwd), Ok(home_dir)) if cwd == home_dir => break 'local Vec::<Agent>::new(),
+                _ => {
+                    // noop, we keep going with the extraction of local agents (even if we have an
+                    // error retrieving cwd or home_dir)
+                },
+            }
+
             let Ok(path) = directories::chat_local_agent_dir() else {
                 break 'local Vec::<Agent>::new();
             };
@@ -361,6 +371,7 @@ impl Agents {
 
         // Here we also want to make sure the example config is written to disk if it's not already
         // there.
+        // Note that this config is not what q chat uses. It merely serves as an example.
         'example_config: {
             let Ok(path) = directories::example_agent_config(os) else {
                 error!("Error obtaining example agent path.");


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When we launch from home directory, the migration workflow is no able to discern agent configs from local and global are the same set of config, thus erroneously warning users about conflicts that does not exist. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
