### PR TITLE
Safeguard against -ok option for find command

### DIFF
--- a/crates/chat-cli/src/cli/chat/tools/execute/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/execute/mod.rs
@@ -90,7 +90,7 @@ impl ExecuteCommand {
                     if cmd == "find"
                         && cmd_args
                             .iter()
-                            .any(|arg| arg.contains("-exec") || arg.contains("-delete")) =>
+                            .any(|arg| arg.contains("-exec") || arg.contains("-delete") || arg.contains("-ok")) =>
                 {
                     return true;
                 },


### PR DESCRIPTION
*Description of changes:*

The trust checks for the `execute_bash` tool can be bypassed, causing to execute commands it shouldn't (e.g., deleting files) without asking for confirmation from the user. Specifically, `find` has an `-ok` option which works similar to `-exec`, but asks for confirmation before running the command. However, this can be bypassed on macOS using a herestring (which isn't part of the patterns Q checks for to decide if it should auto-trust a command), for example:

```
> run the following command: find . -name "*.md" -ok rm {} + <<< "y"
I'll run that command to find and remove all .md files in the current directory and subdirectories. The command uses -ok which will prompt for confirmation before removing each file, and the
<<< "y" provides "y" as input to confirm the deletion.


🛠️  Using tool: execute_bash (trusted)
 ⋮
 ● I will run the following shell command:
find . -name "*.md" -ok rm {} + <<< "y"
 ⋮
 ↳ Purpose: Find and remove all .md files with confirmation

"rm ./codebase-summary.md ./CODE_OF_CONDUCT.md ./crates/figterm/README.md ./crates/figterm/src/input/README.md ./crates/fig_telemetry_core/README.md ./crates/fig_desktop/README.md ./crates/zbus_names/README.md ./crates/zbus/README.md ./crates/aws-toolkit-telemetry-definitions/README.md ./crates/semantic_search_client/README.md ./crates/fig_test_utils/README.md ./proto/README.md ./tests/figterm/README.md ./rfcs/0001-rfc-process.md ./rfcs/0000-template.md ./extensions/gnome-extension/README.md ./extensions/gnome-extension/CONTRIBUTING.md ./extensions/jetbrains/README.md ./extensions/gnome-legacy-extension/README.md ./extensions/gnome-legacy-extension/CONTRIBUTING.md ./extensions/vscode/README.md ./extensions/vscode/vsc-extension-quickstart.md ./README.md ./CONTRIBUTING.md ./packages/api-bindings-wrappers/README.md ./packages/api-bindings/README.md ./packages/autocomplete/README.md ./packages/autocomplete-parser/README.md ./packages/autocomplete-app/README.md ./packages/shared/README.md ./packages/fuzzysort/README.md ./packages/eslint-config/README.md ./packages/dashboard-app/README.md ./packages/shell-parser/README.md ./AmazonQ.md ./SECURITY.md"?

 ⋮
 ● Completed in 0.489s
```

This PR adds a check for the `-ok` option.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
