### PR TITLE
fix: Improve quota breach error message for better user experience

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -737,7 +737,10 @@ impl ChatSession {
 
                     return Ok(());
                 },
-                ApiClientError::QuotaBreach { message, .. } => {
+                ApiClientError::QuotaBreach {
+                    message: _,
+                    status_code: _,
+                } => {
                     let err = "Request quota exceeded. Please wait a moment and try again.".to_string();
                     self.conversation.append_transcript(err.clone());
                     execute!(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR improves the user experience when the quota is exceeded (HTTP 429). Previously, users saw a raw error message with redundant backtrace info like:
![Screenshot 2025-07-08 at 5 28 40 PM](https://github.com/user-attachments/assets/0f1eef0f-3bc9-402f-a235-2a52006ec43e)

This has now been simplified to a cleaner message:
![Screenshot 2025-07-08 at 5 30 36 PM](https://github.com/user-attachments/assets/bba3f746-c272-41f9-9257-acff0d8cd5cc)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
