### PR TITLE
fix(agent): agent fallback behavior

### DIFF
--- a/crates/chat-cli/src/cli/agent/mod.rs
+++ b/crates/chat-cli/src/cli/agent/mod.rs
@@ -439,7 +439,7 @@ impl Agents {
         // Assume agent in the following order of priority:
         // 1. The agent name specified by the start command via --agent (this is the agent_name that's
         //    passed in)
-        // 2. If the above is missing or invalid, assume one that is specified by chat.defautlAgent
+        // 2. If the above is missing or invalid, assume one that is specified by chat.defaultAgent
         // 3. If the above is missing or invalid, assume the in-memory default
         let active_idx = 'active_idx: {
             if let Some(name) = agent_name {

--- a/crates/chat-cli/src/cli/agent/mod.rs
+++ b/crates/chat-cli/src/cli/agent/mod.rs
@@ -15,7 +15,10 @@ use std::path::{
 };
 
 use context_migrate::ContextMigrate;
-use crossterm::style::Stylize as _;
+use crossterm::style::{
+    Color,
+    Stylize as _,
+};
 use crossterm::{
     queue,
     style,
@@ -47,6 +50,7 @@ use super::chat::tools::{
     NATIVE_TOOLS,
     ToolOrigin,
 };
+use crate::database::settings::Setting;
 use crate::os::Os;
 use crate::util::{
     MCP_SERVER_TOOL_DELIMITER,
@@ -432,11 +436,51 @@ impl Agents {
 
         local_agents.append(&mut global_agents);
 
-        // If we are told which agent to set as active, we will fall back to a default whose
-        // lifetime matches that of the session
-        if agent_name.is_none() {
+        // Assume agent in the following order of priority:
+        // 1. The agent name specified by the start command via --agent (this is the agent_name that's
+        //    passed in)
+        // 2. If the above is missing or invalid, assume one that is specified by chat.defautlAgent
+        // 3. If the above is missing or invalid, assume the in-memory default
+        let active_idx = 'active_idx: {
+            if let Some(name) = agent_name {
+                if local_agents.iter().any(|a| a.name.as_str() == name) {
+                    break 'active_idx name.to_string();
+                }
+                let _ = queue!(
+                    output,
+                    style::SetForegroundColor(Color::Red),
+                    style::Print("Error"),
+                    style::SetForegroundColor(Color::Yellow),
+                    style::Print(format!(
+                        ": no agent with name {} found. Falling back to user specified default",
+                        name
+                    )),
+                    style::Print("\n"),
+                    style::SetForegroundColor(Color::Reset)
+                );
+            }
+
+            if let Some(user_set_default) = os.database.settings.get_string(Setting::ChatDefaultAgent) {
+                if local_agents.iter().any(|a| a.name == user_set_default) {
+                    break 'active_idx user_set_default;
+                }
+                let _ = queue!(
+                    output,
+                    style::SetForegroundColor(Color::Red),
+                    style::Print("Error"),
+                    style::SetForegroundColor(Color::Yellow),
+                    style::Print(format!(
+                        ": user defined default {} not found. Falling back to in-memory default",
+                        user_set_default
+                    )),
+                    style::Print("\n"),
+                    style::SetForegroundColor(Color::Reset)
+                );
+            }
+
             local_agents.push(Agent::default());
-        }
+            "default".to_string()
+        };
 
         let _ = output.flush();
 
@@ -445,7 +489,7 @@ impl Agents {
                 .into_iter()
                 .map(|a| (a.name.clone(), a))
                 .collect::<HashMap<_, _>>(),
-            active_idx: agent_name.unwrap_or("default").to_string(),
+            active_idx,
             ..Default::default()
         }
     }

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -223,7 +223,10 @@ impl ChatArgs {
             let mut agents = Agents::load(os, self.agent.as_deref(), skip_migration, &mut stderr).await;
             agents.trust_all_tools = self.trust_all_tools;
 
-            if agents.get_active().is_none_or(|a| a.mcp_servers.mcp_servers.is_empty()) {
+            if agents
+                .get_active()
+                .is_some_and(|a| !a.mcp_servers.mcp_servers.is_empty())
+            {
                 if !self.no_interactive && !os.database.settings.get_bool(Setting::McpLoadedBefore).unwrap_or(false) {
                     execute!(
                         stderr,

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -219,39 +219,20 @@ impl ChatArgs {
         let mut stderr = std::io::stderr();
 
         let agents = {
-            let mut default_agent_name = None::<String>;
-            let agent_name = if let Some(agent) = self.agent.as_deref() {
-                Some(agent)
-            } else if let Some(agent) = os.database.settings.get_string(Setting::ChatDefaultAgent) {
-                default_agent_name.replace(agent);
-                default_agent_name.as_deref()
-            } else {
-                None
-            };
             let skip_migration = self.no_interactive || !self.migrate;
-            let mut agents = Agents::load(os, agent_name, skip_migration, &mut stderr).await;
+            let mut agents = Agents::load(os, self.agent.as_deref(), skip_migration, &mut stderr).await;
             agents.trust_all_tools = self.trust_all_tools;
 
-            if let Some(name) = self.agent.as_ref() {
-                match agents.switch(name) {
-                    Ok(agent) if !agent.mcp_servers.mcp_servers.is_empty() => {
-                        if !self.no_interactive
-                            && !os.database.settings.get_bool(Setting::McpLoadedBefore).unwrap_or(false)
-                        {
-                            execute!(
-                                stderr,
-                                style::Print(
-                                    "To learn more about MCP safety, see https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-mcp-security.html\n\n"
-                                )
-                            )?;
-                        }
-                        os.database.settings.set(Setting::McpLoadedBefore, true).await?;
-                    },
-                    Err(e) => {
-                        let _ = execute!(stderr, style::Print(format!("Error switching profile: {}", e)));
-                    },
-                    _ => {},
+            if agents.get_active().is_none_or(|a| a.mcp_servers.mcp_servers.is_empty()) {
+                if !self.no_interactive && !os.database.settings.get_bool(Setting::McpLoadedBefore).unwrap_or(false) {
+                    execute!(
+                        stderr,
+                        style::Print(
+                            "To learn more about MCP safety, see https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-mcp-security.html\n\n"
+                        )
+                    )?;
                 }
+                os.database.settings.set(Setting::McpLoadedBefore, true).await?;
             }
 
             if let Some(trust_tools) = self.trust_tools.take() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes scenario where invalid agents are chosen, fallback does not correctly show active agent. 
Agents are assumed in the following order: 
        1. The agent name specified by the start command via --agent (this is the agent_name that's
           passed in)
        2. If the above is missing or invalid, assume one that is specified by chat.defaultAgent
        3. If the above is missing or invalid, assume the in-memory default


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
