### PR TITLE
 Adding command to export conversation to markdown 

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/export.rs
+++ b/crates/chat-cli/src/cli/chat/cli/export.rs
@@ -1,9 +1,18 @@
-use clap::Parser;
-use crossterm::execute;
-use crossterm::style::{self, Color, Attribute};
 use std::path::PathBuf;
 
-use crate::cli::chat::{ChatError, ChatSession, ChatState};
+use clap::Parser;
+use crossterm::execute;
+use crossterm::style::{
+    self,
+    Attribute,
+    Color,
+};
+
+use crate::cli::chat::{
+    ChatError,
+    ChatSession,
+    ChatState,
+};
 use crate::os::Os;
 
 /// Export the conversation transcript to a markdown file
@@ -18,7 +27,7 @@ pub struct ExportArgs {
 impl ExportArgs {
     pub async fn execute(&self, os: &mut Os, session: &mut ChatSession) -> Result<ChatState, ChatError> {
         let transcript = self.get_markdown_transcript(session);
-        
+
         if os.fs.exists(&self.path) && !self.force {
             execute!(
                 session.stderr,
@@ -29,12 +38,12 @@ impl ExportArgs {
                 )),
                 style::SetAttribute(Attribute::Reset)
             )?;
-            
+
             return Ok(ChatState::PromptUser {
                 skip_printing_tools: false,
             });
         }
-        
+
         match os.fs.write(&self.path, transcript).await {
             Ok(_) => {
                 execute!(
@@ -43,12 +52,12 @@ impl ExportArgs {
                     style::Print(format!("\n✔ Conversation exported to {}\n\n", self.path.display())),
                     style::SetAttribute(Attribute::Reset)
                 )?;
-            }
+            },
             Err(err) => {
                 return Err(ChatError::Custom(
                     format!("Failed to export conversation: {}", err).into(),
                 ));
-            }
+            },
         }
 
         Ok(ChatState::PromptUser {
@@ -58,7 +67,7 @@ impl ExportArgs {
 
     fn get_markdown_transcript(&self, session: &ChatSession) -> String {
         let mut markdown = String::from("# Amazon Q Conversation\n\n");
-        
+
         for message in &session.conversation.transcript {
             if message.starts_with("> ") {
                 markdown.push_str(&format!("## User\n\n{}\n\n", message));
@@ -66,7 +75,7 @@ impl ExportArgs {
                 markdown.push_str(&format!("## Assistant\n\n{}\n\n", message));
             }
         }
-        
+
         markdown
     }
 }

--- a/crates/chat-cli/src/cli/chat/cli/export.rs
+++ b/crates/chat-cli/src/cli/chat/cli/export.rs
@@ -1,0 +1,72 @@
+use clap::Parser;
+use crossterm::execute;
+use crossterm::style::{self, Color, Attribute};
+use std::path::PathBuf;
+
+use crate::cli::chat::{ChatError, ChatSession, ChatState};
+use crate::os::Os;
+
+/// Export the conversation transcript to a markdown file
+#[derive(Debug, PartialEq, Parser)]
+pub struct ExportArgs {
+    #[arg(required = true)]
+    pub path: PathBuf,
+    #[arg(short, long)]
+    pub force: bool,
+}
+
+impl ExportArgs {
+    pub async fn execute(&self, os: &mut Os, session: &mut ChatSession) -> Result<ChatState, ChatError> {
+        let transcript = self.get_markdown_transcript(session);
+        
+        if os.fs.exists(&self.path) && !self.force {
+            execute!(
+                session.stderr,
+                style::SetForegroundColor(Color::Red),
+                style::Print(format!(
+                    "\nFile at {} already exists. To overwrite, use -f or --force\n\n",
+                    &self.path.display()
+                )),
+                style::SetAttribute(Attribute::Reset)
+            )?;
+            
+            return Ok(ChatState::PromptUser {
+                skip_printing_tools: false,
+            });
+        }
+        
+        match os.fs.write(&self.path, transcript).await {
+            Ok(_) => {
+                execute!(
+                    session.stderr,
+                    style::SetForegroundColor(Color::Green),
+                    style::Print(format!("\n✔ Conversation exported to {}\n\n", self.path.display())),
+                    style::SetAttribute(Attribute::Reset)
+                )?;
+            }
+            Err(err) => {
+                return Err(ChatError::Custom(
+                    format!("Failed to export conversation: {}", err).into(),
+                ));
+            }
+        }
+
+        Ok(ChatState::PromptUser {
+            skip_printing_tools: false,
+        })
+    }
+
+    fn get_markdown_transcript(&self, session: &ChatSession) -> String {
+        let mut markdown = String::from("# Amazon Q Conversation\n\n");
+        
+        for message in &session.conversation.transcript {
+            if message.starts_with("> ") {
+                markdown.push_str(&format!("## User\n\n{}\n\n", message));
+            } else {
+                markdown.push_str(&format!("## Assistant\n\n{}\n\n", message));
+            }
+        }
+        
+        markdown
+    }
+}

--- a/crates/chat-cli/src/cli/chat/cli/mod.rs
+++ b/crates/chat-cli/src/cli/chat/cli/mod.rs
@@ -2,6 +2,7 @@ pub mod clear;
 pub mod compact;
 pub mod context;
 pub mod editor;
+pub mod export;
 pub mod hooks;
 pub mod knowledge;
 pub mod mcp;
@@ -18,6 +19,7 @@ use clear::ClearArgs;
 use compact::CompactArgs;
 use context::ContextSubcommand;
 use editor::EditorArgs;
+use export::ExportArgs;
 use hooks::HooksArgs;
 use knowledge::KnowledgeSubcommand;
 use mcp::McpArgs;
@@ -76,6 +78,8 @@ pub enum SlashCommand {
     Mcp(McpArgs),
     /// Select a model for the current conversation session
     Model(ModelArgs),
+    /// Export the conversation transcript to a markdown file
+    Export(ExportArgs),
     /// Upgrade to a Q Developer Pro subscription for increased query limits
     Subscribe(SubscribeArgs),
     #[command(flatten)]
@@ -109,6 +113,7 @@ impl SlashCommand {
             Self::Usage(args) => args.execute(os, session).await,
             Self::Mcp(args) => args.execute(session).await,
             Self::Model(args) => args.execute(session).await,
+            Self::Export(args) => args.execute(os, session).await,
             Self::Subscribe(args) => args.execute(os, session).await,
             Self::Persist(subcommand) => subcommand.execute(os, session).await,
             // Self::Root(subcommand) => {

--- a/crates/chat-cli/src/cli/chat/prompt.rs
+++ b/crates/chat-cli/src/cli/chat/prompt.rs
@@ -80,6 +80,7 @@ pub const COMMANDS: &[&str] = &[
     "/compact",
     "/compact help",
     "/usage",
+    "/export",
     "/save",
     "/load",
     "/subscribe",


### PR DESCRIPTION
Adding command to export conversation to markdown

Usage:
`/export path/to/file.md`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.