### PR TITLE
feat(agent): adds mcp json backwards compatibility

### DIFF
--- a/crates/chat-cli/src/cli/agent/context_migrate.rs
+++ b/crates/chat-cli/src/cli/agent/context_migrate.rs
@@ -14,6 +14,7 @@ use super::{
 };
 use crate::cli::agent::{
     CreateHooks,
+    McpServerConfigWrapper,
     PromptHooks,
 };
 use crate::cli::chat::cli::hooks::{
@@ -180,7 +181,7 @@ impl ContextMigrate<'c'> {
                 included_files: context.paths,
                 create_hooks: CreateHooks::Map(create_hooks),
                 prompt_hooks: PromptHooks::Map(prompt_hooks),
-                mcp_servers: mcp_servers.clone().unwrap_or_default(),
+                mcp_servers: McpServerConfigWrapper::Map(mcp_servers.clone().unwrap_or_default()),
                 ..Default::default()
             });
         }
@@ -204,7 +205,7 @@ impl ContextMigrate<'c'> {
                 included_files: context.paths,
                 create_hooks: CreateHooks::Map(create_hooks),
                 prompt_hooks: PromptHooks::Map(prompt_hooks),
-                mcp_servers: mcp_servers.clone().unwrap_or_default(),
+                mcp_servers: McpServerConfigWrapper::Map(mcp_servers.clone().unwrap_or_default()),
                 ..Default::default()
             });
         }

--- a/crates/chat-cli/src/cli/agent/context_migrate.rs
+++ b/crates/chat-cli/src/cli/agent/context_migrate.rs
@@ -181,7 +181,6 @@ impl ContextMigrate<'c'> {
                 included_files: context.paths,
                 create_hooks: CreateHooks::Map(create_hooks),
                 prompt_hooks: PromptHooks::Map(prompt_hooks),
-                mcp_servers: McpServerConfigWrapper::Map(mcp_servers.clone().unwrap_or_default()),
                 ..Default::default()
             });
         }
@@ -205,7 +204,6 @@ impl ContextMigrate<'c'> {
                 included_files: context.paths,
                 create_hooks: CreateHooks::Map(create_hooks),
                 prompt_hooks: PromptHooks::Map(prompt_hooks),
-                mcp_servers: McpServerConfigWrapper::Map(mcp_servers.clone().unwrap_or_default()),
                 ..Default::default()
             });
         }
@@ -214,19 +212,7 @@ impl ContextMigrate<'c'> {
             os.fs.create_dir_all(&global_agent_path).await?;
         }
 
-        let formatted_server_list = mcp_servers
-            .map(|config| {
-                config
-                    .mcp_servers
-                    .keys()
-                    .map(|server_name| format!("@{server_name}"))
-                    .collect::<Vec<_>>()
-            })
-            .unwrap_or_default();
-
         for agent in &mut new_agents {
-            agent.tools.extend(formatted_server_list.clone());
-
             let content = serde_json::to_string_pretty(agent)?;
             if let Some(path) = agent.path.as_ref() {
                 info!("Agent {} peristed in path {}", agent.name, path.to_string_lossy());
@@ -237,6 +223,7 @@ impl ContextMigrate<'c'> {
                     agent.name
                 );
             }
+            agent.mcp_servers = McpServerConfigWrapper::Map(mcp_servers.clone().unwrap_or_default());
         }
 
         let legacy_profile_config_path = directories::chat_profiles_dir(os)?;

--- a/crates/chat-cli/src/cli/agent/mod.rs
+++ b/crates/chat-cli/src/cli/agent/mod.rs
@@ -81,7 +81,7 @@ mod wrapper_types;
 /// Another example is the mcp config. To support backwards compatibility of users existing global
 /// mcp.json, we allow users to supply a list of mcp server names they want the agent to
 /// instantiate. But in order for this config to actually be useful to the CLI, it needs to contain
-/// actual information about the comamnd, not just the list of names. Thus the "warm" state in this
+/// actual information about the command, not just the list of names. Thus the "warm" state in this
 /// field would be a filtered version of [McpServerConfig], while the "cold" state could be either.
 ///
 /// Where agents are instantiated from their config, we would need to convert them from "cold" to

--- a/crates/chat-cli/src/cli/agent/mod.rs
+++ b/crates/chat-cli/src/cli/agent/mod.rs
@@ -140,7 +140,7 @@ impl Default for Agent {
             description: Some("Default agent".to_string()),
             prompt: Default::default(),
             mcp_servers: Default::default(),
-            tools: NATIVE_TOOLS.iter().copied().map(str::to_string).collect::<Vec<_>>(),
+            tools: vec!["*".to_string()],
             alias: Default::default(),
             allowed_tools: {
                 let mut set = HashSet::<String>::new();

--- a/crates/chat-cli/src/cli/agent/wrapper_types.rs
+++ b/crates/chat-cli/src/cli/agent/wrapper_types.rs
@@ -136,7 +136,7 @@ pub enum McpServerConfigWrapper {
 
 impl Default for McpServerConfigWrapper {
     fn default() -> Self {
-        Self::Map(Default::default())
+        Self::List(vec!["*".to_string()])
     }
 }
 

--- a/crates/chat-cli/src/cli/agent/wrapper_types.rs
+++ b/crates/chat-cli/src/cli/agent/wrapper_types.rs
@@ -13,6 +13,7 @@ use serde::{
     Serialize,
 };
 
+use super::McpServerConfig;
 use crate::cli::chat::cli::hooks::Hook;
 
 /// Subject of the tool name change. For tools in mcp servers, you would need to prefix them with
@@ -121,4 +122,36 @@ pub fn tool_settings_schema(generator: &mut SchemaGenerator) -> Schema {
             "description": key_description
         }
     })
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, JsonSchema)]
+#[serde(untagged)]
+pub enum McpServerConfigWrapper {
+    /// Array of servers to instantiate in accordance to what is in the global mcp.json
+    List(Vec<String>),
+    /// A map of mcp server configurations, identical in format to the value of mcpServers in
+    /// the global mcp.json
+    Map(McpServerConfig),
+}
+
+impl Default for McpServerConfigWrapper {
+    fn default() -> Self {
+        Self::Map(Default::default())
+    }
+}
+
+impl McpServerConfigWrapper {
+    pub fn get_server_names(&self) -> Vec<&str> {
+        match self {
+            Self::List(list) => list.iter().map(|name| name.as_str()).collect::<Vec<_>>(),
+            Self::Map(config) => config.mcp_servers.keys().map(|name| name.as_str()).collect::<Vec<_>>(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::List(list) => list.is_empty(),
+            Self::Map(config) => config.mcp_servers.is_empty(),
+        }
+    }
 }

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -233,10 +233,7 @@ impl ChatArgs {
             let mut agents = Agents::load(os, self.agent.as_deref(), skip_migration, &mut stderr).await;
             agents.trust_all_tools = self.trust_all_tools;
 
-            if agents
-                .get_active()
-                .is_some_and(|a| !a.mcp_servers.mcp_servers.is_empty())
-            {
+            if agents.get_active().is_some_and(|a| !a.mcp_servers.is_empty()) {
                 if !self.no_interactive && !os.database.settings.get_bool(Setting::McpLoadedBefore).unwrap_or(false) {
                     execute!(
                         stderr,

--- a/crates/chat-cli/src/cli/chat/tool_manager.rs
+++ b/crates/chat-cli/src/cli/chat/tool_manager.rs
@@ -61,6 +61,7 @@ use crate::api_client::model::{
 use crate::cli::agent::{
     Agent,
     McpServerConfig,
+    McpServerConfigWrapper,
 };
 use crate::cli::chat::cli::prompts::GetPromptError;
 use crate::cli::chat::message::AssistantToolUse;
@@ -173,7 +174,14 @@ impl ToolManagerBuilder {
     }
 
     pub fn agent(mut self, agent: Agent) -> Self {
-        self.mcp_server_config.replace(agent.mcp_servers.clone());
+        if let McpServerConfigWrapper::Map(config) = &agent.mcp_servers {
+            self.mcp_server_config.replace(config.clone());
+        } else {
+            error!(
+                "No valid mcp config valid in agent {}, no mcp config loaded",
+                &agent.name
+            );
+        }
         self.agent.replace(agent);
         self
     }

--- a/crates/chat-cli/src/cli/mcp.rs
+++ b/crates/chat-cli/src/cli/mcp.rs
@@ -22,6 +22,7 @@ use super::agent::{
     Agents,
     McpServerConfig,
 };
+use crate::cli::agent::McpServerConfigWrapper;
 use crate::cli::chat::tool_manager::{
     global_mcp_config_path,
     workspace_mcp_config_path,
@@ -89,7 +90,8 @@ pub struct AddArgs {
     /// Arguments to pass to the command
     #[arg(long, action = ArgAction::Append, allow_hyphen_values = true, value_delimiter = ',')]
     pub args: Vec<String>,
-    /// Where to add the server to.
+    /// Where to add the server to. If an agent name is not supplied, the changes shall be made to
+    /// the global mcp.json
     #[arg(long)]
     pub agent: Option<String>,
     /// Environment variables to use when launching the server
@@ -108,37 +110,71 @@ pub struct AddArgs {
 
 impl AddArgs {
     pub async fn execute(self, os: &Os, output: &mut impl Write) -> Result<()> {
-        let agent_name = self.agent.as_deref().unwrap_or("default");
-        let (mut agent, config_path) = Agent::get_agent_by_name(os, agent_name).await?;
+        match self.agent.as_deref() {
+            Some(agent_name) => {
+                let (mut agent, config_path) = Agent::get_agent_by_name(os, agent_name).await?;
+                let mcp_servers = if let McpServerConfigWrapper::Map(config) = &mut agent.mcp_servers {
+                    &mut config.mcp_servers
+                } else {
+                    bail!("Mcp server config not found on agent");
+                };
 
-        let mcp_servers = &mut agent.mcp_servers.mcp_servers;
-        if mcp_servers.contains_key(&self.name) && !self.force {
-            bail!(
-                "\nMCP server '{}' already exists in agent {} (path {}). Use --force to overwrite.",
-                self.name,
-                agent_name,
-                config_path.display(),
-            );
-        }
+                if mcp_servers.contains_key(&self.name) && !self.force {
+                    bail!(
+                        "\nMCP server '{}' already exists in agent {} (path {}). Use --force to overwrite.",
+                        self.name,
+                        agent_name,
+                        config_path.display(),
+                    );
+                }
 
-        let merged_env = self.env.into_iter().flatten().collect::<HashMap<_, _>>();
-        let tool: CustomToolConfig = serde_json::from_value(serde_json::json!({
-            "command": self.command,
-            "args": self.args,
-            "env": merged_env,
-            "timeout": self.timeout.unwrap_or(default_timeout()),
-            "disabled": self.disabled,
-        }))?;
+                let merged_env = self.env.into_iter().flatten().collect::<HashMap<_, _>>();
+                let tool: CustomToolConfig = serde_json::from_value(serde_json::json!({
+                    "command": self.command,
+                    "args": self.args,
+                    "env": merged_env,
+                    "timeout": self.timeout.unwrap_or(default_timeout()),
+                    "disabled": self.disabled,
+                }))?;
 
-        writeln!(
-            output,
-            "\nTo learn more about MCP safety, see https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-mcp-security.html\n\n"
-        )?;
+                mcp_servers.insert(self.name.clone(), tool);
+                let json = serde_json::to_string_pretty(&agent)?;
+                os.fs.write(config_path, json).await?;
+                writeln!(output, "✓ Added MCP server '{}' to agent {}\n", self.name, agent_name)?;
+            },
+            None => {
+                let global_config_path = directories::chat_legacy_mcp_config(os)?;
+                let mut mcp_servers = McpServerConfig::load_from_file(os, &global_config_path).await?;
 
-        mcp_servers.insert(self.name.clone(), tool);
-        let json = serde_json::to_string_pretty(&agent)?;
-        os.fs.write(config_path, json).await?;
-        writeln!(output, "✓ Added MCP server '{}' to agent {}\n", self.name, agent_name)?;
+                if mcp_servers.mcp_servers.contains_key(&self.name) && !self.force {
+                    bail!(
+                        "\nMCP server '{}' already exists in global config (path {}). Use --force to overwrite.",
+                        self.name,
+                        &global_config_path.display(),
+                    );
+                }
+
+                let merged_env = self.env.into_iter().flatten().collect::<HashMap<_, _>>();
+                let tool: CustomToolConfig = serde_json::from_value(serde_json::json!({
+                    "command": self.command,
+                    "args": self.args,
+                    "env": merged_env,
+                    "timeout": self.timeout.unwrap_or(default_timeout()),
+                    "disabled": self.disabled,
+                }))?;
+
+                mcp_servers.mcp_servers.insert(self.name.clone(), tool);
+                let json = serde_json::to_string_pretty(&mcp_servers)?;
+                os.fs.write(&global_config_path, json).await?;
+                writeln!(
+                    output,
+                    "✓ Added MCP server '{}' to global config in {}\n",
+                    self.name,
+                    global_config_path.display()
+                )?;
+            },
+        };
+
         Ok(())
     }
 }
@@ -153,33 +189,67 @@ pub struct RemoveArgs {
 
 impl RemoveArgs {
     pub async fn execute(self, os: &Os, output: &mut impl Write) -> Result<()> {
-        let agent_name = self.agent.as_deref().unwrap_or("default");
-        let (mut agent, config_path) = Agent::get_agent_by_name(os, agent_name).await?;
+        match self.agent.as_deref() {
+            Some(agent_name) => {
+                let (mut agent, config_path) = Agent::get_agent_by_name(os, agent_name).await?;
 
-        if !os.fs.exists(&config_path) {
-            writeln!(output, "\nNo MCP server configurations found.\n")?;
-            return Ok(());
-        }
+                if !os.fs.exists(&config_path) {
+                    writeln!(output, "\nNo MCP server configurations found.\n")?;
+                    return Ok(());
+                }
 
-        let config = &mut agent.mcp_servers.mcp_servers;
-        match config.remove(&self.name) {
-            Some(_) => {
-                let json = serde_json::to_string_pretty(&agent)?;
-                os.fs.write(config_path, json).await?;
-                writeln!(
-                    output,
-                    "\n✓ Removed MCP server '{}' from agent {}\n",
-                    self.name, agent_name,
-                )?;
+                let config = if let McpServerConfigWrapper::Map(config) = &mut agent.mcp_servers {
+                    &mut config.mcp_servers
+                } else {
+                    bail!("Mcp server config not found on agent");
+                };
+
+                match config.remove(&self.name) {
+                    Some(_) => {
+                        let json = serde_json::to_string_pretty(&agent)?;
+                        os.fs.write(config_path, json).await?;
+                        writeln!(
+                            output,
+                            "\n✓ Removed MCP server '{}' from agent {}\n",
+                            self.name, agent_name,
+                        )?;
+                    },
+                    None => {
+                        writeln!(
+                            output,
+                            "\nNo MCP server named '{}' found in agent {}\n",
+                            self.name, agent_name,
+                        )?;
+                    },
+                }
             },
             None => {
-                writeln!(
-                    output,
-                    "\nNo MCP server named '{}' found in agent {}\n",
-                    self.name, agent_name,
-                )?;
+                let global_config_path = directories::chat_legacy_mcp_config(os)?;
+                let mut config = McpServerConfig::load_from_file(os, &global_config_path).await?;
+
+                match config.mcp_servers.remove(&self.name) {
+                    Some(_) => {
+                        let json = serde_json::to_string_pretty(&config)?;
+                        os.fs.write(&global_config_path, json).await?;
+                        writeln!(
+                            output,
+                            "\n✓ Removed MCP server '{}' from global config (path {})\n",
+                            self.name,
+                            &global_config_path.display(),
+                        )?;
+                    },
+                    None => {
+                        writeln!(
+                            output,
+                            "\nNo MCP server named '{}' found in global config (path {})\n",
+                            self.name,
+                            &global_config_path.display(),
+                        )?;
+                    },
+                }
             },
         }
+
         Ok(())
     }
 }
@@ -335,11 +405,13 @@ async fn get_mcp_server_configs(
         } else {
             Scope::Workspace
         };
-        results.push((
-            scope,
-            agent.path.ok_or(eyre::eyre!("Agent missing path info"))?,
-            Some(agent.mcp_servers),
-        ));
+        if let McpServerConfigWrapper::Map(config) = agent.mcp_servers {
+            results.push((
+                scope,
+                agent.path.ok_or(eyre::eyre!("Agent missing path info"))?,
+                Some(config),
+            ));
+        }
     }
     Ok(results)
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Agent config now supports ["*"] in its tools and servers field
- Migration now fills the aforementioned field in `tools` and `mcp_servers`.
- Adds support for "@native" to specify all native tools in `tools`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
