### PR TITLE
feat(chat): enhance --resume to show complete last exchange context

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -563,7 +563,81 @@ impl ChatSession {
                 let mut cs = previous_conversation.unwrap();
                 existing_conversation = true;
                 cs.reload_serialized_state(os).await;
-                input = Some(input.unwrap_or("In a few words, summarize our conversation so far.".to_owned()));
+
+                // Extract last exchange (user question + assistant response)
+                let resume_prompt = if let Some((user_msg, assistant_msg)) = cs.history().back() {
+                    let user_question = match &user_msg.content {
+                        message::UserMessageContent::Prompt { prompt } => prompt.clone(),
+                        message::UserMessageContent::CancelledToolUses { prompt, .. } => {
+                            prompt.clone().unwrap_or_else(|| "[Tool use cancelled]".to_string())
+                        },
+                        message::UserMessageContent::ToolUseResults { .. } => "[Tool results provided]".to_string(),
+                    };
+
+                    let assistant_response = assistant_msg.content();
+                    let tool_summary = assistant_msg
+                        .tool_uses()
+                        .filter(|tools| !tools.is_empty())
+                        .map(|tools| {
+                            tools
+                                .iter()
+                                .map(|tool| {
+                                    let purpose = tool
+                                        .args
+                                        .get("summary")
+                                        .or_else(|| tool.args.get("description"))
+                                        .or_else(|| tool.args.get("command"))
+                                        .or_else(|| tool.args.get("path"))
+                                        .and_then(|v| v.as_str())
+                                        .unwrap_or("perform an action");
+                                    format!("- Used tool '{}' to: {}", tool.name, purpose)
+                                })
+                                .collect::<Vec<_>>()
+                                .join("\n")
+                        });
+
+                    if user_question.trim().is_empty() || assistant_response.trim().is_empty() {
+                        "In a few words, summarize our conversation so far.".to_string()
+                    } else {
+                        // Smart truncation - keep meaningful length but not overwhelming
+                        let max_question_len = 800;
+                        let max_response_len = 1200;
+
+                        let truncated_question = if user_question.len() > max_question_len {
+                            format!("{}...", &user_question[..max_question_len].trim())
+                        } else {
+                            user_question
+                        };
+
+                        let truncated_response = if assistant_response.len() > max_response_len {
+                            format!("{}...", &assistant_response[..max_response_len].trim())
+                        } else {
+                            assistant_response.to_string()
+                        };
+
+                        let mut parts = vec![
+                            "Please show our last exchange, then provide a summary:\n".to_string(),
+                            "--- Resuming from our last conversation ---".to_string(),
+                            format!("User prompt:\n{}", truncated_question),
+                            format!("Amazon Q response:\n{}", truncated_response),
+                        ];
+
+                        if let Some(tools) = tool_summary {
+                            parts.push(format!("Tool actions performed:\n{}", tools));
+                        }
+
+                        parts.extend([
+                            "--- End of previous conversation ---".to_string(),
+                            "Now provide a brief summary of our conversation so far.".to_string(),
+                        ]);
+
+                        parts.join("\n\n")
+                    }
+                } else {
+                    "In a few words, summarize our conversation so far.".to_string()
+                };
+
+                input = Some(input.unwrap_or(resume_prompt));
                 cs.tool_manager = tool_manager;
                 cs.update_state(true).await;
                 cs.enforce_tool_use_history_invariants();


### PR DESCRIPTION
## Summary
Enhances the `q chat --resume` functionality to provide better conversation continuity by showing the complete last exchange (user prompt + Amazon Q response) along with contextual summaries.

## Changes
- Display exact last user prompt and Amazon Q response when resuming
- Show tool actions performed in the last interaction
- Implement smart truncation for long messages (800/1200 char limits)
- Provide enhanced context to model for better summaries
- Use consistent Amazon Q branding in messaging

## Benefits
- Better mental context recovery when resuming after time gaps
- Complete visibility into previous conversation state
- Enhanced conversation continuity
- Professional, consistent messaging

## Testing
- [x] Tested with regular conversations
- [x] Tested with tool usage scenarios  
- [x] Tested smart truncation with long messages
- [x] Verified backward compatibility

## Implementation Details
- Modified `crates/chat-cli/src/cli/chat/mod.rs` to enhance resume prompt generation
- Added smart truncation logic (800 chars for user prompts, 1200 for responses)
- Improved tool action display with meaningful context extraction
- Maintained backward compatibility with existing resume functionality

## Migration Note
This PR was moved from the autocomplete repository (`aws/amazon-q-developer-cli-autocomplete`) to the main repository (`aws/amazon-q-developer-cli`) as requested by the maintainers.

🤖 Assisted by Amazon Q Developer