### PR TITLE
feat: Adding boolean setting for history hints

### DIFF
--- a/crates/chat-cli/src/database/settings.rs
+++ b/crates/chat-cli/src/database/settings.rs
@@ -35,6 +35,7 @@ pub enum Setting {
     ChatDefaultModel,
     ChatDefaultAgent,
     ChatDisableAutoCompaction,
+    ChatEnableHistoryHints,
 }
 
 impl AsRef<str> for Setting {
@@ -58,6 +59,7 @@ impl AsRef<str> for Setting {
             Self::ChatDefaultModel => "chat.defaultModel",
             Self::ChatDefaultAgent => "chat.defaultAgent",
             Self::ChatDisableAutoCompaction => "chat.disableAutoCompaction",
+            Self::ChatEnableHistoryHints => "chat.enableHistoryHints",
         }
     }
 }
@@ -91,6 +93,7 @@ impl TryFrom<&str> for Setting {
             "chat.defaultModel" => Ok(Self::ChatDefaultModel),
             "chat.defaultAgent" => Ok(Self::ChatDefaultAgent),
             "chat.disableAutoCompaction" => Ok(Self::ChatDisableAutoCompaction),
+            "chat.enableHistoryHints" => Ok(Self::ChatEnableHistoryHints),
             _ => Err(DatabaseError::InvalidSetting(value.to_string())),
         }
     }


### PR DESCRIPTION

Adding boolean setting for history hints. If the settings is not set, it's taken as false by default.


```
q settings chat.enableHistoryHints true
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
