### PR TITLE
Terminal bench manual trigger github action

### DIFF
--- a/.github/workflows/terminal-bench.yaml
+++ b/.github/workflows/terminal-bench.yaml
@@ -43,7 +43,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: arn:aws:iam::${{ secrets.TB_ACCOUNTID }}:role/ArjunPersonal
+        role-to-assume: arn:aws:iam::${{ secrets.AWS_ROLE }}:role/ArjunPersonal
         aws-region: us-east-1
        
 

--- a/.github/workflows/terminal-bench.yaml
+++ b/.github/workflows/terminal-bench.yaml
@@ -35,7 +35,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.13'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/terminal-bench.yaml
+++ b/.github/workflows/terminal-bench.yaml
@@ -1,0 +1,59 @@
+# This is a terminal-bench workflow that is manually triggered
+# Template taken from https://github.com/actions/starter-workflows/blob/main/automation/manual.yml for reference 
+
+name: TB workflow
+
+# Controls when the action will run. Workflow runs when manually triggered using the UI
+# or API.
+on:
+  workflow_dispatch:
+    # Inputs the workflow accepts.
+    inputs:
+      name:
+        # Friendly description to be shown in the UI instead of 'name'
+        description: 'Run terminal bench'
+        # Default value if no value is explicitly provided
+        default: 'all'
+        # Input has to be provided for the workflow to run
+        required: true
+        # The data type of the input
+        type: string
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  run-benchmark:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r terminal-bench-test/requirements.txt
+    
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: arn:aws:iam::${{ secrets.TB_ACCOUNTID }}:role/ArjunPersonal
+        aws-region: us-east-1
+       
+
+    - name: Run terminal benchmark
+      run: |
+        cd terminal-bench-test
+        tb run --agent-import-path main:AmazonQCLIAgent --dataset-name terminal-bench-core --dataset-version head
+
+    - name: Upload results
+      uses: actions/upload-artifact@v4
+      with:
+        name: benchmark-results
+        path: terminal-bench-test/results/

--- a/.github/workflows/terminal-bench.yaml
+++ b/.github/workflows/terminal-bench.yaml
@@ -18,8 +18,8 @@ on:
         required: true
         # The data type of the input
         type: string
-    push:
-      branches: [ terminal-bench-automation ]
+  push:
+    branches: [ terminal-bench-automation ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/terminal-bench.yaml
+++ b/.github/workflows/terminal-bench.yaml
@@ -18,9 +18,7 @@ on:
         required: true
         # The data type of the input
         type: string
-  push:
-    branches: [ terminal-bench-automation ]
-
+        
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   run-benchmark:

--- a/.github/workflows/terminal-bench.yaml
+++ b/.github/workflows/terminal-bench.yaml
@@ -40,7 +40,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r terminal-bench-test/requirements.txt
+        pip install terminal-bench
     
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/terminal-bench.yaml
+++ b/.github/workflows/terminal-bench.yaml
@@ -29,6 +29,16 @@ jobs:
       id-token: write
       contents: read
     steps:
+    - name: Cleanup and free disk space
+      run: |
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/ghc
+        sudo rm -rf "/usr/local/share/boost"
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /usr/share/swift
+        df -h
+
     - name: Checkout repository
       uses: actions/checkout@v4
 

--- a/.github/workflows/terminal-bench.yaml
+++ b/.github/workflows/terminal-bench.yaml
@@ -25,6 +25,8 @@ on:
 jobs:
   run-benchmark:
     runs-on: ubuntu-latest
+    env:
+      FIGCHAT_GAMMA_ID: ${{ secrets.figchat_gamma_id }}
     permissions:
       id-token: write
       contents: read
@@ -37,6 +39,7 @@ jobs:
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
         sudo rm -rf /usr/local/lib/android
         sudo rm -rf /usr/share/swift
+        sudo apt-get clean
         df -h
 
     - name: Checkout repository

--- a/.github/workflows/terminal-bench.yaml
+++ b/.github/workflows/terminal-bench.yaml
@@ -1,34 +1,32 @@
 # This is a terminal-bench workflow that is manually triggered
 # Template taken from https://github.com/actions/starter-workflows/blob/main/automation/manual.yml for reference 
 
-name: TB workflow
+name: Terminal-Bench
 
 # Controls when the action will run. Workflow runs when manually triggered using the UI
-# or API.
 on:
   workflow_dispatch:
-    # Inputs the workflow accepts.
     inputs:
       name:
-        # Friendly description to be shown in the UI instead of 'name'
-        description: 'Run terminal bench'
-        # Default value if no value is explicitly provided
+        description: 'Run terminal-bench workflow to test Q CLI in real terminal environments.' 
         default: 'all'
-        # Input has to be provided for the workflow to run
         required: true
-        # The data type of the input
         type: string
         
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   run-benchmark:
+    # avoids disk storage issues
     runs-on: ubuntu-latest-8-cores
+    # makes these env vars available in main.py
     env:
-      FIGCHAT_GAMMA_ID: ${{ secrets.FIGCHAT_GAMMA_ID }}
+      CHAT_DOWNLOAD_ROLE_ARN: ${{ secrets.CHAT_DOWNLOAD_ROLE_ARN }}
+      CHAT_BUILD_BUCKET_NAME: ${{ secrets.CHAT_BUILD_BUCKET_NAME }}
     permissions:
       id-token: write
       contents: read
     steps:
+
+    # clear unnecessary storage to ensure docker containers have space
     - name: Cleanup and free disk space
       run: |
         sudo rm -rf /usr/share/dotnet
@@ -43,6 +41,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    # Captures git hash of branch to query specific S3 bucket
     - name: Set git hash
       run: |
         if [ -n "$GITHUB_SHA" ]; then
@@ -64,18 +63,19 @@ jobs:
         python -m pip install --upgrade pip
         pip install terminal-bench
     
+    # OIDC enabled for github for ArjunPersonal
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: arn:aws:iam::${{ secrets.AWS_TB_ROLE }}:role/ArjunPersonal
+        role-to-assume: ${{ secrets.AWS_TB_ROLE }}
         aws-region: us-east-1
-       
 
     - name: Run terminal benchmark
       run: |
         cd terminal-bench-test
         tb run --agent-import-path main:AmazonQCLIAgent --dataset-name terminal-bench-core --dataset-version head
 
+    # uploads results if run fails as well to allow for easy log inspection
     - name: Upload results
       if: always()
       uses: actions/upload-artifact@v4

--- a/.github/workflows/terminal-bench.yaml
+++ b/.github/workflows/terminal-bench.yaml
@@ -18,6 +18,8 @@ on:
         required: true
         # The data type of the input
         type: string
+    push:
+      branches: [ terminal-bench-automation ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/terminal-bench.yaml
+++ b/.github/workflows/terminal-bench.yaml
@@ -48,7 +48,7 @@ jobs:
     - name: Set git hash
       run: |
         if [ -n "$GITHUB_SHA" ]; then
-          git_hash=$(git rev-parse --short "$GITHUB_SHA")
+          git_hash=$(git rev-parse "$GITHUB_SHA")
         else
           git_hash="latest"
         fi

--- a/.github/workflows/terminal-bench.yaml
+++ b/.github/workflows/terminal-bench.yaml
@@ -52,7 +52,7 @@ jobs:
     - name: Run terminal benchmark
       run: |
         cd terminal-bench-test
-        tb run --agent-import-path main:AmazonQCLIAgent --dataset-name terminal-bench-core --dataset-version head
+        tb run --agent-import-path main:AmazonQCLIAgent --task-id hello-world --livestream
 
     - name: Upload results
       uses: actions/upload-artifact@v4

--- a/.github/workflows/terminal-bench.yaml
+++ b/.github/workflows/terminal-bench.yaml
@@ -26,7 +26,7 @@ jobs:
   run-benchmark:
     runs-on: ubuntu-latest
     env:
-      FIGCHAT_GAMMA_ID: ${{ secrets.figchat_gamma_id }}
+      FIGCHAT_GAMMA_ID: ${{ secrets.FIGCHAT_GAMMA_ID }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/terminal-bench.yaml
+++ b/.github/workflows/terminal-bench.yaml
@@ -45,6 +45,17 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Set git hash
+      run: |
+        if [ -n "$GITHUB_SHA" ]; then
+          git_hash=$(git rev-parse --short "$GITHUB_SHA")
+        else
+          git_hash="latest"
+        fi
+        # appends to github_env file
+        echo "GIT_HASH=$git_hash" >> $GITHUB_ENV
+        echo "Git hash set to: $git_hash"
+
     - name: Set up Python
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/terminal-bench.yaml
+++ b/.github/workflows/terminal-bench.yaml
@@ -43,7 +43,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: arn:aws:iam::${{ secrets.AWS_ROLE }}:role/ArjunPersonal
+        role-to-assume: arn:aws:iam::${{ secrets.AWS_TB_ROLE }}:role/ArjunPersonal
         aws-region: us-east-1
        
 

--- a/.github/workflows/terminal-bench.yaml
+++ b/.github/workflows/terminal-bench.yaml
@@ -52,10 +52,11 @@ jobs:
     - name: Run terminal benchmark
       run: |
         cd terminal-bench-test
-        tb run --agent-import-path main:AmazonQCLIAgent --task-id hello-world --livestream
+        tb run --agent-import-path main:AmazonQCLIAgent --dataset-name terminal-bench-core --dataset-version head
 
     - name: Upload results
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: benchmark-results
-        path: terminal-bench-test/results/
+        path: terminal-bench-test/runs/

--- a/.github/workflows/terminal-bench.yaml
+++ b/.github/workflows/terminal-bench.yaml
@@ -24,7 +24,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   run-benchmark:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     env:
       FIGCHAT_GAMMA_ID: ${{ secrets.FIGCHAT_GAMMA_ID }}
     permissions:

--- a/terminal-bench-test/main.py
+++ b/terminal-bench-test/main.py
@@ -66,8 +66,8 @@ class AmazonQCLIAgent(AbstractInstalledAgent):
         # q chat with 30 min max timeout and also we wait on input. Using qchat cuz sigv4. 
         # non-interactive for now --> check if needed or not
             TerminalCommand(
-                command=f"cargo run --bin chat_cli -- chat --no-interactive --trust-all-tools {escaped_description}",
-                max_timeout_sec=1200, 
+                command=f"qchat chat --no-interactive --trust-all-tools {escaped_description}",
+                max_timeout_sec=370, 
                 block=True,
             )
         ]

--- a/terminal-bench-test/main.py
+++ b/terminal-bench-test/main.py
@@ -53,6 +53,7 @@ class AmazonQCLIAgent(AbstractInstalledAgent):
                     env["AWS_REGION"] = config["default"]["region"]
             except Exception as e:
                 print(f"Warning: Failed to read AWS config: {e}")
+        env['FIGCHAT_GAMMA_ID'] = os.environ.get('FIGCHAT_GAMMA_ID', '')
         return env
 
     @property

--- a/terminal-bench-test/main.py
+++ b/terminal-bench-test/main.py
@@ -25,7 +25,10 @@ class AmazonQCLIAgent(AbstractInstalledAgent):
         # SIGv4 = 1 for AWS credentials
         env = {}
         env["AMAZON_Q_SIGV4"] = 1
-        env['FIGCHAT_GAMMA_ID'] = os.environ.get('FIGCHAT_GAMMA_ID', '')
+        env["FIGCHAT_GAMMA_ID"] = os.environ.get("FIGCHAT_GAMMA_ID", '')
+        env["AWS_ACCESS_KEY_ID"] = os.environ.get("AWS_ACCESS_KEY_ID", '')
+        env["AWS_SECRET_ACCESS_KEY"] = os.environ.get("AWS_SECRET_ACCESS_KEY", '')
+        env["AWS_SESSION_TOKEN"] = os.environ.get("AWS_SESSION_TOKEN", '')
         return env
 
     @property

--- a/terminal-bench-test/main.py
+++ b/terminal-bench-test/main.py
@@ -21,6 +21,12 @@ class AmazonQCLIAgent(AbstractInstalledAgent):
         self.region = 'us-east-1'
 
     @property
+    def _env(self) -> dict[str, str]:
+        # SIGv4 = 1 for AWS credentials
+        env = {}
+        return env
+
+    @property
     def _install_agent_script_path(self) -> os.PathLike:
         return Path(__file__).parent / "setup_amazon_q.sh"
 

--- a/terminal-bench-test/main.py
+++ b/terminal-bench-test/main.py
@@ -23,7 +23,7 @@ class AmazonQCLIAgent(AbstractInstalledAgent):
     @property
     def _env(self) -> dict[str, str]:
         # SIGv4 = 1 for AWS credentials
-        env = {}
+        env = {"AMAZON_Q_SIGV4":1}
         return env
 
     @property
@@ -38,7 +38,7 @@ class AmazonQCLIAgent(AbstractInstalledAgent):
         # non-interactive for now --> check if needed or not
             TerminalCommand(
                 command=f"cargo run --bin chat_cli -- chat --no-interactive --trust-all-tools {escaped_description}",
-                max_timeout_sec=370, 
+                max_timeout_sec=1200, 
                 block=True,
             )
         ]

--- a/terminal-bench-test/main.py
+++ b/terminal-bench-test/main.py
@@ -1,0 +1,47 @@
+import os
+import shlex
+from pathlib import Path
+
+from terminal_bench.agents.installed_agents.abstract_installed_agent import (
+    AbstractInstalledAgent,
+)
+from terminal_bench.terminal.models import TerminalCommand
+
+
+class AmazonQCLIAgent(AbstractInstalledAgent):
+
+    @staticmethod
+    def name() -> str:
+        return "Amazon Q CLI"
+
+    def __init__(self, model_name: str | None = None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._model_name = model_name
+        self._start_url = 'https://amzn.awsapps.com/start'
+        self.region = 'us-east-1'
+
+    @property
+    def _env(self) -> dict[str, str]:
+        # SIGv4 = 1 for AWS credentials
+        env = {}
+        for q_var in ["CODEWHISPERER_TOKEN", "CODEWHISPERER_DEVICE_REGISTRATION", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS", "AWS_SESSION_TOKEN", "AMAZON_Q_SIGV4"]:
+            if q_var in os.environ:
+                env[q_var] = os.environ[q_var]
+        return env
+
+    @property
+    def _install_agent_script_path(self) -> os.PathLike:
+        return Path(__file__).parent / "setup_amazon_q.sh"
+
+    def _run_agent_commands(self, task_description: str) -> list[TerminalCommand]:
+        escaped_description = shlex.quote(task_description)
+        
+        return [
+        # q chat with 30 min max timeout and also we wait on input. Using qchat cuz sigv4. 
+        # non-interactive for now --> check if needed or not
+            TerminalCommand(
+                command=f"qchat chat --no-interactive --trust-all-tools {escaped_description}",
+                max_timeout_sec=370, 
+                block=True,
+            )
+        ]

--- a/terminal-bench-test/main.py
+++ b/terminal-bench-test/main.py
@@ -21,15 +21,6 @@ class AmazonQCLIAgent(AbstractInstalledAgent):
         self.region = 'us-east-1'
 
     @property
-    def _env(self) -> dict[str, str]:
-        # SIGv4 = 1 for AWS credentials
-        env = {}
-        for q_var in ["CODEWHISPERER_TOKEN", "CODEWHISPERER_DEVICE_REGISTRATION", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS", "AWS_SESSION_TOKEN", "AMAZON_Q_SIGV4"]:
-            if q_var in os.environ:
-                env[q_var] = os.environ[q_var]
-        return env
-
-    @property
     def _install_agent_script_path(self) -> os.PathLike:
         return Path(__file__).parent / "setup_amazon_q.sh"
 

--- a/terminal-bench-test/main.py
+++ b/terminal-bench-test/main.py
@@ -23,36 +23,8 @@ class AmazonQCLIAgent(AbstractInstalledAgent):
     @property
     def _env(self) -> dict[str, str]:
         # SIGv4 = 1 for AWS credentials
-        env = {"AMAZON_Q_SIGV4":1}
-        aws_credentials_path = os.path.expanduser("~/.aws/credentials")
-        aws_config_path = os.path.expanduser("~/.aws/config")
-        
-        if os.path.exists(aws_credentials_path):
-            try:
-                import configparser
-                config = configparser.ConfigParser()
-                config.read(aws_credentials_path)
-                
-                if "default" in config:
-                    if "aws_access_key_id" in config["default"]:
-                        env["AWS_ACCESS_KEY_ID"] = config["default"]["aws_access_key_id"]
-                    if "aws_secret_access_key" in config["default"]:
-                        env["AWS_SECRET_ACCESS_KEY"] = config["default"]["aws_secret_access_key"]
-                    if "aws_session_token" in config["default"]:
-                        env["AWS_SESSION_TOKEN"] = config["default"]["aws_session_token"]
-            except Exception as e:
-                print(f"Warning: Failed to read AWS credentials: {e}")
-        
-        if os.path.exists(aws_config_path):
-            try:
-                import configparser
-                config = configparser.ConfigParser()
-                config.read(aws_config_path)
-                
-                if "default" in config and "region" in config["default"]:
-                    env["AWS_REGION"] = config["default"]["region"]
-            except Exception as e:
-                print(f"Warning: Failed to read AWS config: {e}")
+        env = {}
+        env["AMAZON_Q_SIGV4"] = 1
         env['FIGCHAT_GAMMA_ID'] = os.environ.get('FIGCHAT_GAMMA_ID', '')
         return env
 

--- a/terminal-bench-test/main.py
+++ b/terminal-bench-test/main.py
@@ -24,6 +24,35 @@ class AmazonQCLIAgent(AbstractInstalledAgent):
     def _env(self) -> dict[str, str]:
         # SIGv4 = 1 for AWS credentials
         env = {"AMAZON_Q_SIGV4":1}
+        aws_credentials_path = os.path.expanduser("~/.aws/credentials")
+        aws_config_path = os.path.expanduser("~/.aws/config")
+        
+        if os.path.exists(aws_credentials_path):
+            try:
+                import configparser
+                config = configparser.ConfigParser()
+                config.read(aws_credentials_path)
+                
+                if "default" in config:
+                    if "aws_access_key_id" in config["default"]:
+                        env["AWS_ACCESS_KEY_ID"] = config["default"]["aws_access_key_id"]
+                    if "aws_secret_access_key" in config["default"]:
+                        env["AWS_SECRET_ACCESS_KEY"] = config["default"]["aws_secret_access_key"]
+                    if "aws_session_token" in config["default"]:
+                        env["AWS_SESSION_TOKEN"] = config["default"]["aws_session_token"]
+            except Exception as e:
+                print(f"Warning: Failed to read AWS credentials: {e}")
+        
+        if os.path.exists(aws_config_path):
+            try:
+                import configparser
+                config = configparser.ConfigParser()
+                config.read(aws_config_path)
+                
+                if "default" in config and "region" in config["default"]:
+                    env["AWS_REGION"] = config["default"]["region"]
+            except Exception as e:
+                print(f"Warning: Failed to read AWS config: {e}")
         return env
 
     @property

--- a/terminal-bench-test/main.py
+++ b/terminal-bench-test/main.py
@@ -29,6 +29,7 @@ class AmazonQCLIAgent(AbstractInstalledAgent):
         env["AWS_ACCESS_KEY_ID"] = os.environ.get("AWS_ACCESS_KEY_ID", '')
         env["AWS_SECRET_ACCESS_KEY"] = os.environ.get("AWS_SECRET_ACCESS_KEY", '')
         env["AWS_SESSION_TOKEN"] = os.environ.get("AWS_SESSION_TOKEN", '')
+        env["GIT_HASH"] = os.environ.get("GIT_HASH", '')
         return env
 
     @property

--- a/terminal-bench-test/main.py
+++ b/terminal-bench-test/main.py
@@ -40,7 +40,7 @@ class AmazonQCLIAgent(AbstractInstalledAgent):
         # q chat with 30 min max timeout and also we wait on input. Using qchat cuz sigv4. 
         # non-interactive for now --> check if needed or not
             TerminalCommand(
-                command=f"qchat chat --no-interactive --trust-all-tools {escaped_description}",
+                command=f"cargo run --bin chat_cli -- chat --no-interactive --trust-all-tools {escaped_description}",
                 max_timeout_sec=370, 
                 block=True,
             )

--- a/terminal-bench-test/main.py
+++ b/terminal-bench-test/main.py
@@ -14,22 +14,24 @@ class AmazonQCLIAgent(AbstractInstalledAgent):
     def name() -> str:
         return "Amazon Q CLI"
 
-    def __init__(self, model_name: str | None = None, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._model_name = model_name
-        self._start_url = 'https://amzn.awsapps.com/start'
-        self.region = 'us-east-1'
 
+    """
+    Makes necessary env vars available in docker containers
+    """
     @property
     def _env(self) -> dict[str, str]:
         # SIGv4 = 1 for AWS credentials
-        env = {}
-        env["AMAZON_Q_SIGV4"] = 1
-        env["FIGCHAT_GAMMA_ID"] = os.environ.get("FIGCHAT_GAMMA_ID", '')
-        env["AWS_ACCESS_KEY_ID"] = os.environ.get("AWS_ACCESS_KEY_ID", '')
-        env["AWS_SECRET_ACCESS_KEY"] = os.environ.get("AWS_SECRET_ACCESS_KEY", '')
-        env["AWS_SESSION_TOKEN"] = os.environ.get("AWS_SESSION_TOKEN", '')
-        env["GIT_HASH"] = os.environ.get("GIT_HASH", '')
+        env = {
+            "AMAZON_Q_SIGV4": 1,
+            "AWS_ACCESS_KEY_ID": os.environ.get("AWS_ACCESS_KEY_ID", ''),
+            "AWS_SECRET_ACCESS_KEY": os.environ.get("AWS_SECRET_ACCESS_KEY", ''),
+            "AWS_SESSION_TOKEN": os.environ.get("AWS_SESSION_TOKEN", ''),
+            "GIT_HASH": os.environ.get("GIT_HASH", ''),
+            "CHAT_DOWNLOAD_ROLE_ARN": os.environ.get("CHAT_DOWNLOAD_ROLE_ARN", ''),
+            "CHAT_BUILD_BUCKET_NAME": os.environ.get("CHAT_BUILD_BUCKET_NAME", '')
+        }
         return env
 
     @property
@@ -40,11 +42,10 @@ class AmazonQCLIAgent(AbstractInstalledAgent):
         escaped_description = shlex.quote(task_description)
         
         return [
-        # q chat with 30 min max timeout and also we wait on input. Using qchat cuz sigv4. 
-        # non-interactive for now --> check if needed or not
+        # q chat with 30 min max timeout and also we wait on input. Using qchat because of sigv4. 
             TerminalCommand(
                 command=f"qchat chat --no-interactive --trust-all-tools {escaped_description}",
-                max_timeout_sec=370, 
+                max_timeout_sec=1800, 
                 block=True,
             )
         ]

--- a/terminal-bench-test/setup_amazon_q.sh
+++ b/terminal-bench-test/setup_amazon_q.sh
@@ -34,7 +34,7 @@ ORIGINAL_AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
 ORIGINAL_AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
 
 # Assume role and capture temporary credentials --> needed for s3 bucket access for build
-echo "Assuming role FigIoChat-S3Access-Role-Gamma..."
+echo "Assuming arn:aws:iam::${FIGCHAT_GAMMA_ID}:role/FigIoChat-S3Access-Role-Gamma..."
 if [ -n "${FIGCHAT_GAMMA_ID}" ]; then
   TEMP_CREDENTIALS=$(aws sts assume-role --role-arn arn:aws:iam::${FIGCHAT_GAMMA_ID}:role/FigIoChat-S3Access-Role-Gamma --role-session-name S3AccessSession 2>/dev/null || echo '{}')
   

--- a/terminal-bench-test/setup_amazon_q.sh
+++ b/terminal-bench-test/setup_amazon_q.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -e
+apt-get update
+apt-get install -y curl wget gnupg2 software-properties-common git
 
 # Install Node.js and npm
 curl -fsSL https://deb.nodesource.com/setup_18.x | bash -

--- a/terminal-bench-test/setup_amazon_q.sh
+++ b/terminal-bench-test/setup_amazon_q.sh
@@ -2,54 +2,8 @@
 set -e
 
 echo "Installing Amazon Q for command line (Linux)..."
-
-# Update package lists and install required tools
-apt-get update
-apt-get install -y curl unzip sqlite3 bc
 export AMAZON_Q_SIGV4=1
-
-# Check glibc version and architecture
-GLIBC_VERSION=$(ldd --version | head -n1 | grep -o '[0-9]\+\.[0-9]\+' | head -n1)
-ARCH=$(uname -m)
-
-echo "Detected architecture: $ARCH"
-echo "Detected glibc version: $GLIBC_VERSION"
-
-# Determine download URL based on architecture and glibc version
-if [ "$ARCH" = "x86_64" ]; then
-    if [ "$(echo "$GLIBC_VERSION >= 2.34" | bc -l 2>/dev/null || echo 0)" = "1" ]; then
-        Q_URL="https://desktop-release.q.us-east-1.amazonaws.com/latest/q-x86_64-linux.zip"
-        echo "Using standard x86_64 version"
-    else
-        Q_URL="https://desktop-release.q.us-east-1.amazonaws.com/latest/q-x86_64-linux-musl.zip"
-        echo "Using musl x86_64 version for older glibc"
-    fi
-elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
-    if [ "$(echo "$GLIBC_VERSION >= 2.34" | bc -l 2>/dev/null || echo 0)" = "1" ]; then
-        Q_URL="https://desktop-release.q.us-east-1.amazonaws.com/latest/q-aarch64-linux.zip"
-        echo "Using standard aarch64 version"
-    else
-        Q_URL="https://desktop-release.q.us-east-1.amazonaws.com/latest/q-aarch64-linux-musl.zip"
-        echo "Using musl aarch64 version for older glibc"
-    fi
-else
-    echo "Unsupported architecture: $ARCH"
-    exit 1
-fi
-
-# Download Amazon Q
-echo "Downloading from: $Q_URL"
-curl --proto '=https' --tlsv1.2 -sSf "$Q_URL" -o "q.zip"
-
-# Extract and install w/o  interactive installer
-unzip q.zip
-cp q/bin/q /usr/local/bin/q
-cp q/bin/qchat /usr/local/bin/qchat
-chmod +x /usr/local/bin/q
-chmod +x /usr/local/bin/qchat
-
-# Test qchat installation without hanging
-echo "Testing qchat version..."
-q --version
-echo "Cleaning q zip"
-rm -f q.zip
+ 
+# Install the Q branch code into machine + dependencies
+cd /home/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/
+npm run setup

--- a/terminal-bench-test/setup_amazon_q.sh
+++ b/terminal-bench-test/setup_amazon_q.sh
@@ -49,14 +49,24 @@ S3_PREFIX="main/${git_hash}/x86_64-unknown-linux-musl"
 echo "Downloading qchat.zip from s3://${S3_BUCKET}/${S3_PREFIX}/qchat.zip"
 aws s3 cp s3://${S3_BUCKET}/${S3_PREFIX}/qchat.zip ./qchat.zip --region us-east-1
 
-
 # Handle the zip file, copy the qchat executable to /usr/local/bin + symlink from old code
 echo "Extracting qchat.zip..."
 unzip -q qchat.zip
 mkdir -p /usr/local/bin
-cp -f ./qchat/qchat /usr/local/bin/qchat
-chmod +x /usr/local/bin/qchat
-ln -sf /usr/local/bin/qchat /usr/local/bin/q
+
+# Find the qchat executable -> copy
+find . -type f -name "qchat" -exec cp {} /usr/local/bin/qchat \;
+
+if [ -f "/usr/local/bin/qchat" ]; then
+    chmod +x /usr/local/bin/qchat
+    ln -sf /usr/local/bin/qchat /usr/local/bin/q
+    echo "qchat installed successfully"
+else
+    echo "ERROR: qchat executable not found in the zip file"
+    # List the contents of the extracted files to debug
+    find . -type f | grep -v "aws" | head -20
+    exit 1
+fi
 
 # Restore credentials to run Q
 export AWS_ACCESS_KEY_ID=${ORIGINAL_AWS_ACCESS_KEY_ID}
@@ -73,9 +83,3 @@ EOF
 echo "Cleaning q zip"
 rm -f qchat.zip
 rm -rf qchat
-
-
-
-
-
-

--- a/terminal-bench-test/setup_amazon_q.sh
+++ b/terminal-bench-test/setup_amazon_q.sh
@@ -38,17 +38,9 @@ S3_BUCKET="fig-io-chat-build-output-${FIGCHAT_GAMMA_ID}-us-east-1"
 S3_PREFIX="main/${GIT_HASH}/x86_64-unknown-linux-musl"
 echo "Downloading qchat.zip from s3://.../${S3_PREFIX}/qchat.zip"
 
-# Try download, fall back to latest commit hash if it fails
-# exit code = 0 means success/true in bash, all others are false
+# Try download, if hash is invalid we fail.
 AWS_ACCESS_KEY_ID="$QCHAT_ACCESSKEY" AWS_SECRET_ACCESS_KEY="$Q_SECRET_ACCESS_KEY" AWS_SESSION_TOKEN="$Q_SESSION_TOKEN" \
-  aws s3 cp s3://${S3_BUCKET}/${S3_PREFIX}/qchat.zip ./qchat.zip --region us-east-1 || {
-    echo "Falling back to latest build"
-    S3_PREFIX="main/latest/x86_64-unknown-linux-musl"
-    AWS_ACCESS_KEY_ID="$QCHAT_ACCESSKEY" AWS_SECRET_ACCESS_KEY="$Q_SECRET_ACCESS_KEY" AWS_SESSION_TOKEN="$Q_SESSION_TOKEN" \
-      aws s3 cp s3://${S3_BUCKET}/${S3_PREFIX}/qchat.zip ./qchat.zip --region us-east-1
-  }
-
-
+  aws s3 cp s3://${S3_BUCKET}/${S3_PREFIX}/qchat.zip ./qchat.zip --region us-east-1
 
 # Handle the zip file, copy the qchat executable to /usr/local/bin + symlink from old code
 echo "Extracting qchat.zip..."

--- a/terminal-bench-test/setup_amazon_q.sh
+++ b/terminal-bench-test/setup_amazon_q.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -e
+
+echo "Installing Amazon Q for command line (Linux)..."
+
+# Update package lists and install required tools
+apt-get update
+apt-get install -y curl unzip sqlite3 bc
+export AMAZON_Q_SIGV4=1
+
+# Check glibc version and architecture
+GLIBC_VERSION=$(ldd --version | head -n1 | grep -o '[0-9]\+\.[0-9]\+' | head -n1)
+ARCH=$(uname -m)
+
+echo "Detected architecture: $ARCH"
+echo "Detected glibc version: $GLIBC_VERSION"
+
+# Determine download URL based on architecture and glibc version
+if [ "$ARCH" = "x86_64" ]; then
+    if [ "$(echo "$GLIBC_VERSION >= 2.34" | bc -l 2>/dev/null || echo 0)" = "1" ]; then
+        Q_URL="https://desktop-release.q.us-east-1.amazonaws.com/latest/q-x86_64-linux.zip"
+        echo "Using standard x86_64 version"
+    else
+        Q_URL="https://desktop-release.q.us-east-1.amazonaws.com/latest/q-x86_64-linux-musl.zip"
+        echo "Using musl x86_64 version for older glibc"
+    fi
+elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
+    if [ "$(echo "$GLIBC_VERSION >= 2.34" | bc -l 2>/dev/null || echo 0)" = "1" ]; then
+        Q_URL="https://desktop-release.q.us-east-1.amazonaws.com/latest/q-aarch64-linux.zip"
+        echo "Using standard aarch64 version"
+    else
+        Q_URL="https://desktop-release.q.us-east-1.amazonaws.com/latest/q-aarch64-linux-musl.zip"
+        echo "Using musl aarch64 version for older glibc"
+    fi
+else
+    echo "Unsupported architecture: $ARCH"
+    exit 1
+fi
+
+# Download Amazon Q
+echo "Downloading from: $Q_URL"
+curl --proto '=https' --tlsv1.2 -sSf "$Q_URL" -o "q.zip"
+
+# Extract and install w/o  interactive installer
+unzip q.zip
+cp q/bin/q /usr/local/bin/q
+cp q/bin/qchat /usr/local/bin/qchat
+chmod +x /usr/local/bin/q
+chmod +x /usr/local/bin/qchat
+
+# Test qchat installation without hanging
+echo "Testing qchat version..."
+q --version
+echo "Cleaning q zip"
+rm -f q.zip

--- a/terminal-bench-test/setup_amazon_q.sh
+++ b/terminal-bench-test/setup_amazon_q.sh
@@ -21,3 +21,20 @@ export AMAZON_Q_SIGV4=1
 git clone https://github.com/aws/amazon-q-developer-cli.git
 cd amazon-q-developer-cli
 echo "Amazon Q CLI installation completed successfully"
+
+
+# Create AWS credentials from environment variables
+mkdir -p ~/.aws
+cat > ~/.aws/credentials << EOF
+[default]
+aws_access_key_id = ${AWS_ACCESS_KEY_ID}
+aws_secret_access_key = ${AWS_SECRET_ACCESS_KEY}
+aws_session_token = ${AWS_SESSION_TOKEN}
+EOF
+chmod 600 ~/.aws/credentials
+
+cat > ~/.aws/config << EOF
+[default]
+region = us-east-1
+EOF
+chmod 600 ~/.aws/config

--- a/terminal-bench-test/setup_amazon_q.sh
+++ b/terminal-bench-test/setup_amazon_q.sh
@@ -27,20 +27,19 @@ chmod 600 ~/.aws/config
 
 # Assume role and capture temporary credentials --> needed for s3 bucket access for build
 echo "Assuming AWS s3 role"
-TEMP_CREDENTIALS=$(aws sts assume-role --role-arn arn:aws:iam::${FIGCHAT_GAMMA_ID}:role/FigIoChat-S3Access-Role-Gamma --role-session-name S3AccessSession 2>/dev/null || echo '{}')
+TEMP_CREDENTIALS=$(aws sts assume-role --role-arn ${CHAT_DOWNLOAD_ROLE_ARN} --role-session-name S3AccessSession 2>/dev/null || echo '{}')
 QCHAT_ACCESSKEY=$(echo $TEMP_CREDENTIALS | jq -r '.Credentials.AccessKeyId')
 Q_SECRET_ACCESS_KEY=$(echo $TEMP_CREDENTIALS | jq -r '.Credentials.SecretAccessKey')
 Q_SESSION_TOKEN=$(echo $TEMP_CREDENTIALS | jq -r '.Credentials.SessionToken')
 
 # Download specific build from S3 based on commit hash
 echo "Downloading Amazon Q CLI build from S3..."
-S3_BUCKET="fig-io-chat-build-output-${FIGCHAT_GAMMA_ID}-us-east-1"
 S3_PREFIX="main/${GIT_HASH}/x86_64-unknown-linux-musl"
 echo "Downloading qchat.zip from s3://.../${S3_PREFIX}/qchat.zip"
 
 # Try download, if hash is invalid we fail.
 AWS_ACCESS_KEY_ID="$QCHAT_ACCESSKEY" AWS_SECRET_ACCESS_KEY="$Q_SECRET_ACCESS_KEY" AWS_SESSION_TOKEN="$Q_SESSION_TOKEN" \
-  aws s3 cp s3://${S3_BUCKET}/${S3_PREFIX}/qchat.zip ./qchat.zip --region us-east-1
+  aws s3 cp s3://${CHAT_BUILD_BUCKET_NAME}/${S3_PREFIX}/qchat.zip ./qchat.zip --region us-east-1
 
 # Handle the zip file, copy the qchat executable to /usr/local/bin + symlink from old code
 echo "Extracting qchat.zip..."

--- a/terminal-bench-test/setup_amazon_q.sh
+++ b/terminal-bench-test/setup_amazon_q.sh
@@ -1,9 +1,21 @@
 #!/bin/bash
 set -e
 
+# Install Node.js and npm
+curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
+apt-get install -y nodejs
+
+# Install Rust and Cargo
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+source ~/.cargo/env
+
+# get the github code
 echo "Installing Amazon Q for command line (Linux)..."
+mkdir -p /app/amazon-q-developer-cli
+cd /app
 export AMAZON_Q_SIGV4=1
- 
-# Install the Q branch code into machine + dependencies
-cd /home/runner/work/amazon-q-developer-cli/amazon-q-developer-cli/
+git clone https://github.com/aws/amazon-q-developer-cli.git
+cd amazon-q-developer-cli
 npm run setup
+
+echo "Amazon Q CLI installation completed successfully"

--- a/terminal-bench-test/setup_amazon_q.sh
+++ b/terminal-bench-test/setup_amazon_q.sh
@@ -6,6 +6,8 @@ apt-get install -y curl wget gnupg2 software-properties-common git
 # Install Node.js and npm
 curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
 apt-get install -y nodejs
+apt-get install -y build-essential gcc g++ make
+apt-get install -y pkg-config libssl-dev
 
 # Install Rust and Cargo
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/terminal-bench-test/setup_amazon_q.sh
+++ b/terminal-bench-test/setup_amazon_q.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
-# if git hash empty then set to latest automatically.
+# if git hash empty then set to latest auto
 git_hash=${GITHUB_SHA:+"$(git rev-parse --short "$GITHUB_SHA")"}
-git_hash=${git_hash:-"00286fbe0688fe19fef9a5149bb9f9172f96783c"}
+git_hash=${git_hash:-"latest"}
 apt-get update
 apt-get install -y curl wget unzip jq
 

--- a/terminal-bench-test/setup_amazon_q.sh
+++ b/terminal-bench-test/setup_amazon_q.sh
@@ -20,6 +20,4 @@ cd /app
 export AMAZON_Q_SIGV4=1
 git clone https://github.com/aws/amazon-q-developer-cli.git
 cd amazon-q-developer-cli
-npm run setup
-
 echo "Amazon Q CLI installation completed successfully"

--- a/terminal-bench-test/setup_amazon_q.sh
+++ b/terminal-bench-test/setup_amazon_q.sh
@@ -1,27 +1,15 @@
 #!/bin/bash
 set -e
+# if git hash empty then set to latest automatically.
+git_hash=${GITHUB_SHA:+"$(git rev-parse --short "$GITHUB_SHA")"}
+git_hash=${git_hash:-"00286fbe0688fe19fef9a5149bb9f9172f96783c"}
 apt-get update
-apt-get install -y curl wget gnupg2 software-properties-common git
+apt-get install -y curl wget unzip jq
 
-# Install Node.js and npm
-curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
-apt-get install -y nodejs
-apt-get install -y build-essential gcc g++ make
-apt-get install -y pkg-config libssl-dev
-
-# Install Rust and Cargo
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-source ~/.cargo/env
-
-# get the github code
-echo "Installing Amazon Q for command line (Linux)..."
-mkdir -p /app/amazon-q-developer-cli
-cd /app
-export AMAZON_Q_SIGV4=1
-git clone https://github.com/aws/amazon-q-developer-cli.git
-cd amazon-q-developer-cli
-echo "Amazon Q CLI installation completed successfully"
-
+echo "Installing AWS CLI..."
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+unzip -q awscliv2.zip
+./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli
 
 # Create AWS credentials from environment variables
 mkdir -p ~/.aws
@@ -38,3 +26,56 @@ cat > ~/.aws/config << EOF
 region = us-east-1
 EOF
 chmod 600 ~/.aws/config
+
+
+# Save original credentials
+ORIGINAL_AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+ORIGINAL_AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+ORIGINAL_AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
+
+# Assume role and capture temporary credentials --> needed for s3 bucket access for build
+echo "Assuming role FigIoChat-S3Access-Role-Gamma..."
+TEMP_CREDENTIALS=$(aws sts assume-role --role-arn arn:aws:iam::${FIGCHAT_GAMMA_ID}:role/FigIoChat-S3Access-Role-Gamma --role-session-name S3AccessSession)
+
+# Extract and export temporary credentials -> jq is just used 
+export AWS_ACCESS_KEY_ID=$(echo $TEMP_CREDENTIALS | jq -r '.Credentials.AccessKeyId')
+export AWS_SECRET_ACCESS_KEY=$(echo $TEMP_CREDENTIALS | jq -r '.Credentials.SecretAccessKey')
+export AWS_SESSION_TOKEN=$(echo $TEMP_CREDENTIALS | jq -r '.Credentials.SessionToken')
+
+# Download specific build from S3 based on commit hash
+echo "Downloading Amazon Q CLI build from S3..."
+S3_BUCKET="fig-io-chat-build-output-${FIGCHAT_GAMMA_ID}-us-east-1"
+S3_PREFIX="main/${git_hash}/x86_64-unknown-linux-musl"
+echo "Downloading qchat.zip from s3://${S3_BUCKET}/${S3_PREFIX}/qchat.zip"
+aws s3 cp s3://${S3_BUCKET}/${S3_PREFIX}/qchat.zip ./qchat.zip --region us-east-1
+
+
+# Handle the zip file, copy the qchat executable to /usr/local/bin + symlink from old code
+echo "Extracting qchat.zip..."
+unzip -q qchat.zip
+mkdir -p /usr/local/bin
+cp -f ./qchat/qchat /usr/local/bin/qchat
+chmod +x /usr/local/bin/qchat
+ln -sf /usr/local/bin/qchat /usr/local/bin/q
+
+# Restore credentials to run Q
+export AWS_ACCESS_KEY_ID=${ORIGINAL_AWS_ACCESS_KEY_ID}
+export AWS_SECRET_ACCESS_KEY=${ORIGINAL_AWS_SECRET_ACCESS_KEY}
+export AWS_SESSION_TOKEN=${ORIGINAL_AWS_SESSION_TOKEN}
+
+cat > ~/.aws/credentials << EOF
+[default]
+aws_access_key_id = ${ORIGINAL_AWS_ACCESS_KEY_ID}
+aws_secret_access_key = ${ORIGINAL_AWS_SECRET_ACCESS_KEY}
+aws_session_token = ${ORIGINAL_AWS_SESSION_TOKEN}
+EOF
+
+echo "Cleaning q zip"
+rm -f qchat.zip
+rm -rf qchat
+
+
+
+
+
+


### PR DESCRIPTION
*Description of changes:* Adds a new yaml, bash script, and python file that allow terminal-bench to run on a GitHub runner through a manual trigger as a github action. These runs use arjbal AWS credentials for sigv4 + s3 bucket access.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
