### PR TITLE
Including images as part of chat history

### DIFF
--- a/crates/chat-cli/src/cli/chat/message.rs
+++ b/crates/chat-cli/src/cli/chat/message.rs
@@ -153,7 +153,7 @@ impl UserMessage {
     /// [api_client::model::ConversationState].
     pub fn into_history_entry(self) -> UserInputMessage {
         UserInputMessage {
-            images: None,
+            images: self.images.clone(),
             content: self.prompt().unwrap_or_default().to_string(),
             user_input_message_context: Some(UserInputMessageContext {
                 env_state: self.env_context.env_state,


### PR DESCRIPTION
*Issue #, if available:* #2256

*Description of changes:* Instead of none, included vector of images as part of UserInputMessage, which is preserved in conversation_state now. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Before vs After and real image

<img width="719" height="509" alt="image" src="https://github.com/user-attachments/assets/88a36851-67fa-4f06-a8e3-9de5eb6f1137" />
<img width="720" height="403" alt="image" src="https://github.com/user-attachments/assets/35bb1761-eb34-4254-a567-190112c25da9" />
<img width="720" height="103" alt="image" src="https://github.com/user-attachments/assets/c0c635a1-2727-4f71-b774-32795710d206" />
