### PR TITLE
Created centralized colour scheme management, and add support for the…

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/subscribe.rs
+++ b/crates/chat-cli/src/cli/chat/cli/subscribe.rs
@@ -43,7 +43,7 @@ impl SubscribeArgs {
         {
             execute!(
                 session.stderr,
-                style::SetForegroundColor(Color::Yellow),
+                style::SetForegroundColor(session.colors.warning()),
                 style::Print("\nYour Q Developer Pro subscription is managed through IAM Identity Center.\n\n"),
                 style::SetForegroundColor(Color::Reset),
             )?;
@@ -54,13 +54,13 @@ impl SubscribeArgs {
                     if status != ActualSubscriptionStatus::Active {
                         queue!(
                             session.stderr,
-                            style::SetForegroundColor(Color::Yellow),
+                            style::SetForegroundColor(session.colors.warning()),
                             style::Print("You don't seem to have a Q Developer Pro subscription. "),
-                            style::SetForegroundColor(Color::DarkGrey),
+                            style::SetForegroundColor(session.colors.secondary()),
                             style::Print("Use "),
-                            style::SetForegroundColor(Color::Green),
+                            style::SetForegroundColor(session.colors.success()),
                             style::Print("/subscribe"),
-                            style::SetForegroundColor(Color::DarkGrey),
+                            style::SetForegroundColor(session.colors.secondary()),
                             style::Print(" to upgrade your subscription.\n\n"),
                             style::SetForegroundColor(Color::Reset),
                         )?;

--- a/crates/chat-cli/src/cli/chat/cli/tools.rs
+++ b/crates/chat-cli/src/cli/chat/cli/tools.rs
@@ -153,13 +153,13 @@ impl ToolsArgs {
         queue!(
             session.stderr,
             style::Print("\nTrusted tools will run without confirmation."),
-            style::SetForegroundColor(Color::DarkGrey),
+            style::SetForegroundColor(session.colors.secondary()),
             style::Print(format!("\n{}\n", "* Default settings")),
             style::Print("\n💡 Use "),
-            style::SetForegroundColor(Color::Green),
+            style::SetForegroundColor(session.colors.success()),
             style::Print("/tools help"),
             style::SetForegroundColor(Color::Reset),
-            style::SetForegroundColor(Color::DarkGrey),
+            style::SetForegroundColor(session.colors.secondary()),
             style::Print(" to edit permissions.\n\n"),
             style::SetForegroundColor(Color::Reset),
         )?;
@@ -240,7 +240,7 @@ impl ToolsSubcommand {
                 if !invalid_tools.is_empty() {
                     queue!(
                         session.stderr,
-                        style::SetForegroundColor(Color::Red),
+                        style::SetForegroundColor(session.colors.error()),
                         style::Print(format!("\nCannot trust '{}', ", invalid_tools.join("', '"))),
                         if invalid_tools.len() > 1 {
                             style::Print("they do not exist.")
@@ -266,7 +266,7 @@ impl ToolsSubcommand {
 
                     queue!(
                         session.stderr,
-                        style::SetForegroundColor(Color::Green),
+                        style::SetForegroundColor(session.colors.success()),
                         if tools_to_trust.len() > 1 {
                             style::Print(format!("\nTools '{}' are ", tools_to_trust.join("', '")))
                         } else {
@@ -276,7 +276,7 @@ impl ToolsSubcommand {
                         style::SetAttribute(Attribute::Bold),
                         style::Print("not"),
                         style::SetAttribute(Attribute::Reset),
-                        style::SetForegroundColor(Color::Green),
+                        style::SetForegroundColor(session.colors.success()),
                         style::Print(format!(
                             " ask for confirmation before running {}.",
                             if tools_to_trust.len() > 1 {
@@ -301,7 +301,7 @@ impl ToolsSubcommand {
                 if !invalid_tools.is_empty() {
                     queue!(
                         session.stderr,
-                        style::SetForegroundColor(Color::Red),
+                        style::SetForegroundColor(session.colors.error()),
                         style::Print(format!("\nCannot untrust '{}', ", invalid_tools.join("', '"))),
                         if invalid_tools.len() > 1 {
                             style::Print("they do not exist.")
@@ -329,7 +329,7 @@ impl ToolsSubcommand {
 
                     queue!(
                         session.stderr,
-                        style::SetForegroundColor(Color::Green),
+                        style::SetForegroundColor(session.colors.success()),
                         if tools_to_untrust.len() > 1 {
                             style::Print(format!("\nTools '{}' are ", tools_to_untrust.join("', '")))
                         } else {
@@ -376,7 +376,7 @@ impl ToolsSubcommand {
                 }
                 queue!(
                     session.stderr,
-                    style::SetForegroundColor(Color::Green),
+                    style::SetForegroundColor(session.colors.success()),
                     style::Print("\nReset all tools to the permission levels as defined in agent."),
                     style::SetForegroundColor(Color::Reset),
                 )?;

--- a/crates/chat-cli/src/cli/chat/cli/usage.rs
+++ b/crates/chat-cli/src/cli/chat/cli/usage.rs
@@ -34,11 +34,11 @@ impl UsageArgs {
         if !state.dropped_context_files.is_empty() {
             execute!(
                 session.stderr,
-                style::SetForegroundColor(Color::DarkYellow),
+                style::SetForegroundColor(session.colors.warning()),
                 style::Print("\nSome context files are dropped due to size limit, please run "),
-                style::SetForegroundColor(Color::DarkGreen),
+                style::SetForegroundColor(session.colors.success()),
                 style::Print("/context show "),
-                style::SetForegroundColor(Color::DarkYellow),
+                style::SetForegroundColor(session.colors.warning()),
                 style::Print("to learn more.\n"),
                 style::SetForegroundColor(style::Color::Reset)
             )?;
@@ -87,7 +87,7 @@ impl UsageArgs {
                     total_token_used,
                     CONTEXT_WINDOW_SIZE / 1000
                 )),
-                style::SetForegroundColor(Color::DarkRed),
+                style::SetForegroundColor(session.colors.error()),
                 style::Print("█".repeat(progress_bar_width)),
                 style::SetForegroundColor(Color::Reset),
                 style::Print(" "),
@@ -105,7 +105,7 @@ impl UsageArgs {
                     CONTEXT_WINDOW_SIZE / 1000
                 )),
                 // Context files
-                style::SetForegroundColor(Color::DarkCyan),
+                style::SetForegroundColor(session.colors.data()),
                 // add a nice visual to mimic "tiny" progress, so the overral progress bar doesn't look too
                 // empty
                 style::Print("|".repeat(if context_width == 0 && *context_token_count > 0 {
@@ -115,7 +115,7 @@ impl UsageArgs {
                 })),
                 style::Print("█".repeat(context_width)),
                 // Tools
-                style::SetForegroundColor(Color::DarkRed),
+                style::SetForegroundColor(session.colors.error()),
                 style::Print("|".repeat(if tools_width == 0 && *tools_token_count > 0 {
                     1
                 } else {
@@ -123,7 +123,7 @@ impl UsageArgs {
                 })),
                 style::Print("█".repeat(tools_width)),
                 // Assistant responses
-                style::SetForegroundColor(Color::Blue),
+                style::SetForegroundColor(session.colors.info()),
                 style::Print("|".repeat(if assistant_width == 0 && *assistant_token_count > 0 {
                     1
                 } else {
@@ -131,10 +131,10 @@ impl UsageArgs {
                 })),
                 style::Print("█".repeat(assistant_width)),
                 // User prompts
-                style::SetForegroundColor(Color::Magenta),
+                style::SetForegroundColor(session.colors.action()),
                 style::Print("|".repeat(if user_width == 0 && *user_token_count > 0 { 1 } else { 0 })),
                 style::Print("█".repeat(user_width)),
-                style::SetForegroundColor(Color::DarkGrey),
+                style::SetForegroundColor(session.colors.secondary()),
                 style::Print("█".repeat(left_over_width)),
                 style::Print(" "),
                 style::SetForegroundColor(Color::Reset),
@@ -149,7 +149,7 @@ impl UsageArgs {
 
         queue!(
             session.stderr,
-            style::SetForegroundColor(Color::DarkCyan),
+            style::SetForegroundColor(session.colors.data()),
             style::Print("█ Context files: "),
             style::SetForegroundColor(Color::Reset),
             style::Print(format!(
@@ -157,7 +157,7 @@ impl UsageArgs {
                 context_token_count,
                 (context_token_count.value() as f32 / CONTEXT_WINDOW_SIZE as f32) * 100.0
             )),
-            style::SetForegroundColor(Color::DarkRed),
+            style::SetForegroundColor(session.colors.error()),
             style::Print("█ Tools:    "),
             style::SetForegroundColor(Color::Reset),
             style::Print(format!(
@@ -165,7 +165,7 @@ impl UsageArgs {
                 tools_token_count,
                 (tools_token_count.value() as f32 / CONTEXT_WINDOW_SIZE as f32) * 100.0
             )),
-            style::SetForegroundColor(Color::Blue),
+            style::SetForegroundColor(session.colors.info()),
             style::Print("█ Q responses: "),
             style::SetForegroundColor(Color::Reset),
             style::Print(format!(
@@ -173,7 +173,7 @@ impl UsageArgs {
                 assistant_token_count,
                 (assistant_token_count.value() as f32 / CONTEXT_WINDOW_SIZE as f32) * 100.0
             )),
-            style::SetForegroundColor(Color::Magenta),
+            style::SetForegroundColor(session.colors.action()),
             style::Print("█ Your prompts: "),
             style::SetForegroundColor(Color::Reset),
             style::Print(format!(
@@ -188,21 +188,21 @@ impl UsageArgs {
             style::SetAttribute(Attribute::Bold),
             style::Print("\n💡 Pro Tips:\n"),
             style::SetAttribute(Attribute::Reset),
-            style::SetForegroundColor(Color::DarkGrey),
+            style::SetForegroundColor(session.colors.secondary()),
             style::Print("Run "),
-            style::SetForegroundColor(Color::DarkGreen),
+            style::SetForegroundColor(session.colors.success()),
             style::Print("/compact"),
-            style::SetForegroundColor(Color::DarkGrey),
+            style::SetForegroundColor(session.colors.secondary()),
             style::Print(" to replace the conversation history with its summary\n"),
             style::Print("Run "),
-            style::SetForegroundColor(Color::DarkGreen),
+            style::SetForegroundColor(session.colors.success()),
             style::Print("/clear"),
-            style::SetForegroundColor(Color::DarkGrey),
+            style::SetForegroundColor(session.colors.secondary()),
             style::Print(" to erase the entire chat history\n"),
             style::Print("Run "),
-            style::SetForegroundColor(Color::DarkGreen),
+            style::SetForegroundColor(session.colors.success()),
             style::Print("/context show"),
-            style::SetForegroundColor(Color::DarkGrey),
+            style::SetForegroundColor(session.colors.secondary()),
             style::Print(" to see tokens per context file\n\n"),
             style::SetForegroundColor(Color::Reset),
         )?;

--- a/crates/chat-cli/src/cli/chat/colors.rs
+++ b/crates/chat-cli/src/cli/chat/colors.rs
@@ -1,0 +1,196 @@
+//! Centralized color management for Amazon Q CLI
+//! 
+//! This module provides a centralized way to manage colors throughout the CLI,
+//! ensuring consistent theming and accessibility support.
+
+use crossterm::style::Color;
+
+use crate::database::settings::{ColorCategory, ColorTheme, Settings};
+
+/// Color manager that provides semantic color access
+pub struct ColorManager {
+    theme: ColorTheme,
+}
+
+impl ColorManager {
+    /// Create a new color manager from settings
+    pub fn from_settings(settings: &Settings) -> Self {
+        Self {
+            theme: settings.get_color_theme(),
+        }
+    }
+
+    /// Create a new color manager with default theme
+    pub fn default() -> Self {
+        Self {
+            theme: ColorTheme::default(),
+        }
+    }
+
+    /// Create a new color manager with high contrast theme
+    pub fn high_contrast() -> Self {
+        Self {
+            theme: ColorTheme::high_contrast_theme(),
+        }
+    }
+
+    /// Get color for a specific category
+    pub fn get(&self, category: ColorCategory) -> Color {
+        self.theme.get_color(category)
+    }
+
+    /// Get success color (for completions, positive feedback)
+    pub fn success(&self) -> Color {
+        self.get(ColorCategory::Success)
+    }
+
+    /// Get error color (for failures, critical issues)
+    pub fn error(&self) -> Color {
+        self.get(ColorCategory::Error)
+    }
+
+    /// Get warning color (for cautions, informational alerts)
+    pub fn warning(&self) -> Color {
+        self.get(ColorCategory::Warning)
+    }
+
+    /// Get info color (for informational content, references)
+    pub fn info(&self) -> Color {
+        self.get(ColorCategory::Info)
+    }
+
+    /// Get secondary color (for help text, less prominent elements)
+    pub fn secondary(&self) -> Color {
+        self.get(ColorCategory::Secondary)
+    }
+
+    /// Get primary color (for branding, important system messages)
+    pub fn primary(&self) -> Color {
+        self.get(ColorCategory::Primary)
+    }
+
+    /// Get action color (for tool usage, user interactions)
+    pub fn action(&self) -> Color {
+        self.get(ColorCategory::Action)
+    }
+
+    /// Get data color (for context files, data visualization)
+    pub fn data(&self) -> Color {
+        self.get(ColorCategory::Data)
+    }
+}
+
+/// Convenience macros for common color operations
+#[macro_export]
+macro_rules! with_color {
+    ($output:expr, $color_manager:expr, $category:expr, $($arg:tt)*) => {
+        {
+            use crossterm::{queue, style};
+            queue!(
+                $output,
+                style::SetForegroundColor($color_manager.get($category)),
+                style::Print(format!($($arg)*)),
+                style::SetForegroundColor(style::Color::Reset)
+            )
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! with_success {
+    ($output:expr, $color_manager:expr, $($arg:tt)*) => {
+        with_color!($output, $color_manager, $crate::database::settings::ColorCategory::Success, $($arg)*)
+    };
+}
+
+#[macro_export]
+macro_rules! with_error {
+    ($output:expr, $color_manager:expr, $($arg:tt)*) => {
+        with_color!($output, $color_manager, $crate::database::settings::ColorCategory::Error, $($arg)*)
+    };
+}
+
+#[macro_export]
+macro_rules! with_warning {
+    ($output:expr, $color_manager:expr, $($arg:tt)*) => {
+        with_color!($output, $color_manager, $crate::database::settings::ColorCategory::Warning, $($arg)*)
+    };
+}
+
+#[macro_export]
+macro_rules! with_info {
+    ($output:expr, $color_manager:expr, $($arg:tt)*) => {
+        with_color!($output, $color_manager, $crate::database::settings::ColorCategory::Info, $($arg)*)
+    };
+}
+
+#[macro_export]
+macro_rules! with_secondary {
+    ($output:expr, $color_manager:expr, $($arg:tt)*) => {
+        with_color!($output, $color_manager, $crate::database::settings::ColorCategory::Secondary, $($arg)*)
+    };
+}
+
+#[macro_export]
+macro_rules! with_primary {
+    ($output:expr, $color_manager:expr, $($arg:tt)*) => {
+        with_color!($output, $color_manager, $crate::database::settings::ColorCategory::Primary, $($arg)*)
+    };
+}
+
+#[macro_export]
+macro_rules! with_action {
+    ($output:expr, $color_manager:expr, $($arg:tt)*) => {
+        with_color!($output, $color_manager, $crate::database::settings::ColorCategory::Action, $($arg)*)
+    };
+}
+
+#[macro_export]
+macro_rules! with_data {
+    ($output:expr, $color_manager:expr, $($arg:tt)*) => {
+        with_color!($output, $color_manager, $crate::database::settings::ColorCategory::Data, $($arg)*)
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::settings::Settings;
+
+    #[tokio::test]
+    async fn test_color_manager_default() {
+        let manager = ColorManager::default();
+        assert_eq!(manager.success(), Color::Green);
+        assert_eq!(manager.error(), Color::Red);
+        assert_eq!(manager.warning(), Color::Yellow);
+        assert_eq!(manager.info(), Color::Blue);
+        assert_eq!(manager.secondary(), Color::DarkGrey);
+        assert_eq!(manager.primary(), Color::Cyan);
+        assert_eq!(manager.action(), Color::Magenta);
+        assert_eq!(manager.data(), Color::DarkCyan);
+    }
+
+    #[tokio::test]
+    async fn test_color_manager_high_contrast() {
+        let manager = ColorManager::high_contrast();
+        assert_eq!(manager.success(), Color::Green);
+        assert_eq!(manager.error(), Color::Red);
+        assert_eq!(manager.warning(), Color::Yellow);
+        assert_eq!(manager.info(), Color::Blue);
+        assert_eq!(manager.secondary(), Color::White); // Changed from DarkGrey
+        assert_eq!(manager.primary(), Color::Cyan);
+        assert_eq!(manager.action(), Color::Magenta);
+        assert_eq!(manager.data(), Color::DarkCyan);
+    }
+
+    #[tokio::test]
+    async fn test_color_manager_from_settings() {
+        let settings = Settings::new().await.unwrap();
+        let manager = ColorManager::from_settings(&settings);
+        
+        // Should use default colors when no settings are configured
+        assert_eq!(manager.success(), Color::Green);
+        assert_eq!(manager.error(), Color::Red);
+        assert_eq!(manager.secondary(), Color::DarkGrey);
+    }
+}

--- a/crates/chat-cli/src/cli/chat/tools/custom_tool.rs
+++ b/crates/chat-cli/src/cli/chat/tools/custom_tool.rs
@@ -22,7 +22,10 @@ use crate::cli::agent::{
     PermissionEvalResult,
 };
 use crate::cli::chat::CONTINUATION_LINE;
+use crate::cli::chat::colors::ColorManager;
 use crate::cli::chat::token_counter::TokenCounter;
+use crate::database::settings::Settings;
+use crate::{with_success, with_color};
 use crate::mcp_client::{
     Client as McpClient,
     ClientConfig as McpClientConfig,
@@ -221,13 +224,11 @@ impl CustomTool {
     }
 
     pub fn queue_description(&self, output: &mut impl Write) -> Result<()> {
-        queue!(
-            output,
-            style::Print("Running "),
-            style::SetForegroundColor(style::Color::Green),
-            style::Print(&self.name),
-            style::ResetColor,
-        )?;
+        let settings = Settings::default();
+        let color_manager = ColorManager::from_settings(&settings);
+
+        queue!(output, style::Print("Running "))?;
+        with_success!(output, &color_manager, "{}", &self.name)?;
         if let Some(params) = &self.params {
             let params = match serde_json::to_string_pretty(params) {
                 Ok(params) => params

--- a/crates/chat-cli/src/cli/chat/tools/gh_issue.rs
+++ b/crates/chat-cli/src/cli/chat/tools/gh_issue.rs
@@ -1,11 +1,14 @@
 use std::collections::VecDeque;
 use std::io::Write;
 
-use crossterm::style::Color;
 use crossterm::{
     queue,
     style,
 };
+
+use crate::cli::chat::colors::ColorManager;
+use crate::database::settings::Settings;
+use crate::{with_success, with_color};
 use eyre::{
     Result,
     WrapErr,
@@ -179,13 +182,18 @@ impl GhIssue {
     }
 
     pub fn queue_description(&self, output: &mut impl Write) -> Result<()> {
-        Ok(queue!(
+        // Create a default color manager for now - this could be passed as parameter in future
+        let settings = Settings::default();
+        let color_manager = ColorManager::from_settings(&settings);
+
+        queue!(
             output,
             style::Print("I will prepare a github issue with our conversation history.\n\n"),
-            style::SetForegroundColor(Color::Green),
-            style::Print(format!("Title: {}\n", &self.title)),
-            style::ResetColor
-        )?)
+        )?;
+
+        with_success!(output, &color_manager, "Title: {}\n", &self.title)?;
+
+        Ok(())
     }
 
     pub async fn validate(&mut self, _os: &Os) -> Result<()> {

--- a/crates/chat-cli/src/cli/chat/tools/thinking.rs
+++ b/crates/chat-cli/src/cli/chat/tools/thinking.rs
@@ -1,10 +1,7 @@
 use std::io::Write;
 
 use crossterm::queue;
-use crossterm::style::{
-    self,
-    Color,
-};
+use crossterm::style;
 use eyre::Result;
 use serde::Deserialize;
 
@@ -12,7 +9,9 @@ use super::{
     InvokeOutput,
     OutputKind,
 };
-use crate::database::settings::Setting;
+use crate::cli::chat::colors::ColorManager;
+use crate::database::settings::{Setting, Settings};
+use crate::{with_info, with_color};
 use crate::os::Os;
 
 /// The Think tool allows the model to reason through complex problems during response generation.
@@ -37,15 +36,12 @@ impl Thinking {
     pub fn queue_description(&self, output: &mut impl Write) -> Result<()> {
         // Only show a description if there's actual thought content
         if !self.thought.trim().is_empty() {
+            let settings = Settings::default();
+            let color_manager = ColorManager::from_settings(&settings);
+
             // Show a preview of the thought that will be displayed
-            queue!(
-                output,
-                style::SetForegroundColor(Color::Blue),
-                style::Print("I'll share my reasoning process: "),
-                style::SetForegroundColor(Color::Reset),
-                style::Print(&self.thought),
-                style::Print("\n")
-            )?;
+            with_info!(output, &color_manager, "I'll share my reasoning process: ")?;
+            queue!(output, style::Print(&self.thought), style::Print("\n"))?;
         }
         Ok(())
     }

--- a/crates/chat-cli/src/database/settings.rs
+++ b/crates/chat-cli/src/database/settings.rs
@@ -1,6 +1,7 @@
 use std::fmt::Display;
 use std::io::SeekFrom;
 
+use crossterm::style::Color;
 use fd_lock::RwLock;
 use serde_json::{
     Map,
@@ -37,6 +38,180 @@ pub enum Setting {
     ChatDefaultAgent,
     ChatDisableAutoCompaction,
     ChatEnableHistoryHints,
+
+    // Color theme settings
+    ChatTheme,
+    ChatThemeSuccess,
+    ChatThemeError,
+    ChatThemeWarning,
+    ChatThemeInfo,
+    ChatThemeSecondary,
+    ChatThemePrimary,
+    ChatThemeAction,
+    ChatThemeData,
+}
+
+/// Semantic color categories for consistent theming
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ColorCategory {
+    /// Success operations, completions, positive feedback
+    Success,
+    /// Errors, failures, critical issues
+    Error,
+    /// Warnings, cautions, informational alerts
+    Warning,
+    /// Informational content, references, system responses
+    Info,
+    /// Secondary information, help text, less prominent elements
+    Secondary,
+    /// Primary UI elements, branding, important system messages
+    Primary,
+    /// Tool usage, actions, user interactions
+    Action,
+    /// Context files, data visualization
+    Data,
+}
+
+/// Predefined theme names
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ThemeName {
+    Default,
+    HighContrast,
+    Light,
+}
+
+impl ThemeName {
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s.to_lowercase().as_str() {
+            "default" => Some(Self::Default),
+            "high-contrast" | "high_contrast" => Some(Self::HighContrast),
+            "light" => Some(Self::Light),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Default => "default",
+            Self::HighContrast => "high-contrast",
+            Self::Light => "light",
+        }
+    }
+}
+
+/// Color theme definitions
+#[derive(Clone, Debug, PartialEq)]
+pub struct ColorTheme {
+    pub success: Color,
+    pub error: Color,
+    pub warning: Color,
+    pub info: Color,
+    pub secondary: Color,
+    pub primary: Color,
+    pub action: Color,
+    pub data: Color,
+}
+
+impl Default for ColorTheme {
+    fn default() -> Self {
+        Self::default_theme()
+    }
+}
+
+impl ColorTheme {
+    /// Default color theme (current Amazon Q CLI colors)
+    pub fn default_theme() -> Self {
+        Self {
+            success: Color::Green,
+            error: Color::Red,
+            warning: Color::Yellow,
+            info: Color::Blue,
+            secondary: Color::DarkGrey,
+            primary: Color::Cyan,
+            action: Color::Magenta,
+            data: Color::DarkCyan,
+        }
+    }
+
+    /// High contrast theme for better accessibility
+    pub fn high_contrast_theme() -> Self {
+        Self {
+            success: Color::Green,
+            error: Color::Red,
+            warning: Color::Yellow,
+            info: Color::Blue,
+            secondary: Color::White,  // Changed from DarkGrey for better visibility
+            primary: Color::Cyan,
+            action: Color::Magenta,
+            data: Color::DarkCyan,
+        }
+    }
+
+    /// Terminal-friendly theme for terminals with light backgrounds
+    pub fn light_theme() -> Self {
+        Self {
+            success: Color::DarkGreen,
+            error: Color::DarkRed,
+            warning: Color::DarkYellow,
+            info: Color::DarkBlue,
+            secondary: Color::DarkGrey,
+            primary: Color::DarkCyan,
+            action: Color::DarkMagenta,
+            data: Color::DarkCyan,
+        }
+    }
+
+    /// Get color for a specific category
+    pub fn get_color(&self, category: ColorCategory) -> Color {
+        match category {
+            ColorCategory::Success => self.success,
+            ColorCategory::Error => self.error,
+            ColorCategory::Warning => self.warning,
+            ColorCategory::Info => self.info,
+            ColorCategory::Secondary => self.secondary,
+            ColorCategory::Primary => self.primary,
+            ColorCategory::Action => self.action,
+            ColorCategory::Data => self.data,
+        }
+    }
+
+    /// Create theme from settings
+    pub fn from_settings(settings: &Settings) -> Self {
+        // First check if a predefined theme is selected
+        if let Some(theme_name) = settings.get_string(Setting::ChatTheme) {
+            if let Some(theme) = ThemeName::from_str(&theme_name) {
+                let base_theme = match theme {
+                    ThemeName::Default => Self::default_theme(),
+                    ThemeName::HighContrast => Self::high_contrast_theme(),
+                    ThemeName::Light => Self::light_theme(),
+                };
+                
+                // Apply any individual color overrides on top of the base theme
+                return Self {
+                    success: settings.get_color(Setting::ChatThemeSuccess).unwrap_or(base_theme.success),
+                    error: settings.get_color(Setting::ChatThemeError).unwrap_or(base_theme.error),
+                    warning: settings.get_color(Setting::ChatThemeWarning).unwrap_or(base_theme.warning),
+                    info: settings.get_color(Setting::ChatThemeInfo).unwrap_or(base_theme.info),
+                    secondary: settings.get_color(Setting::ChatThemeSecondary).unwrap_or(base_theme.secondary),
+                    primary: settings.get_color(Setting::ChatThemePrimary).unwrap_or(base_theme.primary),
+                    action: settings.get_color(Setting::ChatThemeAction).unwrap_or(base_theme.action),
+                    data: settings.get_color(Setting::ChatThemeData).unwrap_or(base_theme.data),
+                };
+            }
+        }
+        
+        // Fallback to individual color settings (current behavior)
+        Self {
+            success: settings.get_color(Setting::ChatThemeSuccess).unwrap_or(Color::Green),
+            error: settings.get_color(Setting::ChatThemeError).unwrap_or(Color::Red),
+            warning: settings.get_color(Setting::ChatThemeWarning).unwrap_or(Color::Yellow),
+            info: settings.get_color(Setting::ChatThemeInfo).unwrap_or(Color::Blue),
+            secondary: settings.get_color(Setting::ChatThemeSecondary).unwrap_or(Color::DarkGrey),
+            primary: settings.get_color(Setting::ChatThemePrimary).unwrap_or(Color::Cyan),
+            action: settings.get_color(Setting::ChatThemeAction).unwrap_or(Color::Magenta),
+            data: settings.get_color(Setting::ChatThemeData).unwrap_or(Color::DarkCyan),
+        }
+    }
 }
 
 impl AsRef<str> for Setting {
@@ -62,6 +237,15 @@ impl AsRef<str> for Setting {
             Self::ChatDefaultAgent => "chat.defaultAgent",
             Self::ChatDisableAutoCompaction => "chat.disableAutoCompaction",
             Self::ChatEnableHistoryHints => "chat.enableHistoryHints",
+            Self::ChatTheme => "chat.theme",
+            Self::ChatThemeSuccess => "chat.theme.success",
+            Self::ChatThemeError => "chat.theme.error",
+            Self::ChatThemeWarning => "chat.theme.warning",
+            Self::ChatThemeInfo => "chat.theme.info",
+            Self::ChatThemeSecondary => "chat.theme.secondary",
+            Self::ChatThemePrimary => "chat.theme.primary",
+            Self::ChatThemeAction => "chat.theme.action",
+            Self::ChatThemeData => "chat.theme.data",
         }
     }
 }
@@ -97,6 +281,15 @@ impl TryFrom<&str> for Setting {
             "chat.defaultAgent" => Ok(Self::ChatDefaultAgent),
             "chat.disableAutoCompaction" => Ok(Self::ChatDisableAutoCompaction),
             "chat.enableHistoryHints" => Ok(Self::ChatEnableHistoryHints),
+            "chat.theme" => Ok(Self::ChatTheme),
+            "chat.theme.success" => Ok(Self::ChatThemeSuccess),
+            "chat.theme.error" => Ok(Self::ChatThemeError),
+            "chat.theme.warning" => Ok(Self::ChatThemeWarning),
+            "chat.theme.info" => Ok(Self::ChatThemeInfo),
+            "chat.theme.secondary" => Ok(Self::ChatThemeSecondary),
+            "chat.theme.primary" => Ok(Self::ChatThemePrimary),
+            "chat.theme.action" => Ok(Self::ChatThemeAction),
+            "chat.theme.data" => Ok(Self::ChatThemeData),
             _ => Err(DatabaseError::InvalidSetting(value.to_string())),
         }
     }
@@ -164,6 +357,70 @@ impl Settings {
 
     pub fn get_int(&self, key: Setting) -> Option<i64> {
         self.get(key).and_then(|value| value.as_i64())
+    }
+
+    /// Get a color setting, parsing from string representation
+    pub fn get_color(&self, key: Setting) -> Option<Color> {
+        self.get_string(key).and_then(|color_str| parse_color(&color_str))
+    }
+
+    /// Set a color setting
+    pub async fn set_color(&mut self, key: Setting, color: Color) -> Result<(), DatabaseError> {
+        self.set(key, color_to_string(color)).await
+    }
+
+    /// Get the current color theme
+    pub fn get_color_theme(&self) -> ColorTheme {
+        ColorTheme::from_settings(self)
+    }
+
+    /// Set a predefined color theme
+    pub async fn set_color_theme(&mut self, theme: ColorTheme) -> Result<(), DatabaseError> {
+        // Determine which predefined theme this matches (if any)
+        let theme_name = if theme == ColorTheme::default_theme() {
+            Some(ThemeName::Default)
+        } else if theme == ColorTheme::high_contrast_theme() {
+            Some(ThemeName::HighContrast)
+        } else if theme == ColorTheme::light_theme() {
+            Some(ThemeName::Light)
+        } else {
+            None
+        };
+        
+        // Set the theme name if it matches a predefined theme
+        if let Some(name) = theme_name {
+            self.set(Setting::ChatTheme, name.as_str()).await?;
+        } else {
+            // Clear theme name for custom themes
+            self.remove(Setting::ChatTheme).await?;
+        }
+        
+        // Set individual colors
+        self.set_color(Setting::ChatThemeSuccess, theme.success).await?;
+        self.set_color(Setting::ChatThemeError, theme.error).await?;
+        self.set_color(Setting::ChatThemeWarning, theme.warning).await?;
+        self.set_color(Setting::ChatThemeInfo, theme.info).await?;
+        self.set_color(Setting::ChatThemeSecondary, theme.secondary).await?;
+        self.set_color(Setting::ChatThemePrimary, theme.primary).await?;
+        self.set_color(Setting::ChatThemeAction, theme.action).await?;
+        self.set_color(Setting::ChatThemeData, theme.data).await?;
+        Ok(())
+    }
+
+    /// Set a predefined theme by name
+    pub async fn set_theme(&mut self, theme_name: ThemeName) -> Result<(), DatabaseError> {
+        self.set(Setting::ChatTheme, theme_name.as_str()).await
+    }
+    
+    /// Get the current theme name (if set)
+    pub fn get_theme(&self) -> Option<ThemeName> {
+        self.get_string(Setting::ChatTheme)
+            .and_then(|s| ThemeName::from_str(&s))
+    }
+    
+    /// Clear theme setting (fall back to individual colors)
+    pub async fn clear_theme(&mut self) -> Result<(), DatabaseError> {
+        self.remove(Setting::ChatTheme).await.map(|_| ())
     }
 
     pub async fn save_to_file(&self) -> Result<(), DatabaseError> {
@@ -258,5 +515,178 @@ mod test {
         assert_eq!(settings.get(Setting::ShareCodeWhispererContent), None);
         assert_eq!(settings.get(Setting::McpLoadedBefore), None);
         assert_eq!(settings.get(Setting::ChatDisableMarkdownRendering), None);
+    }
+
+    #[tokio::test]
+    async fn test_theme_name_parsing() {
+        assert_eq!(ThemeName::from_str("default"), Some(ThemeName::Default));
+        assert_eq!(ThemeName::from_str("Default"), Some(ThemeName::Default));
+        assert_eq!(ThemeName::from_str("DEFAULT"), Some(ThemeName::Default));
+        
+        assert_eq!(ThemeName::from_str("high-contrast"), Some(ThemeName::HighContrast));
+        assert_eq!(ThemeName::from_str("high_contrast"), Some(ThemeName::HighContrast));
+        assert_eq!(ThemeName::from_str("HIGH-CONTRAST"), Some(ThemeName::HighContrast));
+        
+        assert_eq!(ThemeName::from_str("light"), Some(ThemeName::Light));
+        assert_eq!(ThemeName::from_str("Light"), Some(ThemeName::Light));
+        
+        assert_eq!(ThemeName::from_str("invalid"), None);
+        assert_eq!(ThemeName::from_str(""), None);
+    }
+
+    #[tokio::test]
+    async fn test_theme_name_as_str() {
+        assert_eq!(ThemeName::Default.as_str(), "default");
+        assert_eq!(ThemeName::HighContrast.as_str(), "high-contrast");
+        assert_eq!(ThemeName::Light.as_str(), "light");
+    }
+
+    #[tokio::test]
+    async fn test_color_theme_from_settings_with_theme_name() {
+        let mut settings = Settings::new().await.unwrap();
+        
+        // Test default theme selection
+        settings.set(Setting::ChatTheme, "default").await.unwrap();
+        let theme = settings.get_color_theme();
+        assert_eq!(theme, ColorTheme::default_theme());
+        
+        // Test high contrast theme selection
+        settings.set(Setting::ChatTheme, "high-contrast").await.unwrap();
+        let theme = settings.get_color_theme();
+        assert_eq!(theme, ColorTheme::high_contrast_theme());
+        
+        // Test light theme selection
+        settings.set(Setting::ChatTheme, "light").await.unwrap();
+        let theme = settings.get_color_theme();
+        assert_eq!(theme, ColorTheme::light_theme());
+    }
+
+    #[tokio::test]
+    async fn test_color_theme_from_settings_with_overrides() {
+        let mut settings = Settings::new().await.unwrap();
+        
+        // Set a base theme
+        settings.set(Setting::ChatTheme, "default").await.unwrap();
+        
+        // Override the primary color
+        settings.set_color(Setting::ChatThemePrimary, Color::Blue).await.unwrap();
+        
+        let theme = settings.get_color_theme();
+        let default_theme = ColorTheme::default_theme();
+        
+        // Should use the base theme for most colors
+        assert_eq!(theme.success, default_theme.success);
+        assert_eq!(theme.error, default_theme.error);
+        
+        // But use the override for primary
+        assert_eq!(theme.primary, Color::Blue);
+    }
+
+    #[tokio::test]
+    async fn test_color_theme_from_settings_fallback() {
+        let mut settings = Settings::new().await.unwrap();
+        
+        // No theme set, should use individual colors or defaults
+        settings.set_color(Setting::ChatThemePrimary, Color::Blue).await.unwrap();
+        
+        let theme = settings.get_color_theme();
+        
+        // Should use default colors for unset values
+        assert_eq!(theme.success, Color::Green);
+        assert_eq!(theme.error, Color::Red);
+        
+        // Should use the individual setting
+        assert_eq!(theme.primary, Color::Blue);
+    }
+
+    #[tokio::test]
+    async fn test_theme_helper_methods() {
+        let mut settings = Settings::new().await.unwrap();
+        
+        // Test setting theme by name
+        settings.set_theme(ThemeName::HighContrast).await.unwrap();
+        assert_eq!(settings.get_theme(), Some(ThemeName::HighContrast));
+        assert_eq!(settings.get_string(Setting::ChatTheme), Some("high-contrast".to_string()));
+        
+        // Test getting theme
+        settings.set(Setting::ChatTheme, "light").await.unwrap();
+        assert_eq!(settings.get_theme(), Some(ThemeName::Light));
+        
+        // Test clearing theme
+        settings.clear_theme().await.unwrap();
+        assert_eq!(settings.get_theme(), None);
+        assert_eq!(settings.get(Setting::ChatTheme), None);
+    }
+}
+
+/// Parse a color from string representation
+fn parse_color(color_str: &str) -> Option<Color> {
+    match color_str.to_lowercase().as_str() {
+        "black" => Some(Color::Black),
+        "darkgrey" | "dark_grey" => Some(Color::DarkGrey),
+        "red" => Some(Color::Red),
+        "darkred" | "dark_red" => Some(Color::DarkRed),
+        "green" => Some(Color::Green),
+        "darkgreen" | "dark_green" => Some(Color::DarkGreen),
+        "yellow" => Some(Color::Yellow),
+        "darkyellow" | "dark_yellow" => Some(Color::DarkYellow),
+        "blue" => Some(Color::Blue),
+        "darkblue" | "dark_blue" => Some(Color::DarkBlue),
+        "magenta" => Some(Color::Magenta),
+        "darkmagenta" | "dark_magenta" => Some(Color::DarkMagenta),
+        "cyan" => Some(Color::Cyan),
+        "darkcyan" | "dark_cyan" => Some(Color::DarkCyan),
+        "white" => Some(Color::White),
+        "grey" | "gray" => Some(Color::Grey),
+        "reset" => Some(Color::Reset),
+        _ => {
+            // Try to parse RGB format: "rgb(r,g,b)" or "#rrggbb"
+            if color_str.starts_with("rgb(") && color_str.ends_with(')') {
+                let rgb_str = &color_str[4..color_str.len() - 1];
+                let parts: Vec<&str> = rgb_str.split(',').collect();
+                if parts.len() == 3 {
+                    if let (Ok(r), Ok(g), Ok(b)) = (
+                        parts[0].trim().parse::<u8>(),
+                        parts[1].trim().parse::<u8>(),
+                        parts[2].trim().parse::<u8>(),
+                    ) {
+                        return Some(Color::Rgb { r, g, b });
+                    }
+                }
+            } else if color_str.starts_with('#') && color_str.len() == 7 {
+                if let Ok(hex) = u32::from_str_radix(&color_str[1..], 16) {
+                    let r = ((hex >> 16) & 0xFF) as u8;
+                    let g = ((hex >> 8) & 0xFF) as u8;
+                    let b = (hex & 0xFF) as u8;
+                    return Some(Color::Rgb { r, g, b });
+                }
+            }
+            None
+        }
+    }
+}
+
+/// Convert a color to string representation
+fn color_to_string(color: Color) -> String {
+    match color {
+        Color::Black => "black".to_string(),
+        Color::DarkGrey => "darkgrey".to_string(),
+        Color::Red => "red".to_string(),
+        Color::DarkRed => "darkred".to_string(),
+        Color::Green => "green".to_string(),
+        Color::DarkGreen => "darkgreen".to_string(),
+        Color::Yellow => "yellow".to_string(),
+        Color::DarkYellow => "darkyellow".to_string(),
+        Color::Blue => "blue".to_string(),
+        Color::DarkBlue => "darkblue".to_string(),
+        Color::Magenta => "magenta".to_string(),
+        Color::DarkMagenta => "darkmagenta".to_string(),
+        Color::Cyan => "cyan".to_string(),
+        Color::DarkCyan => "darkcyan".to_string(),
+        Color::White => "white".to_string(),
+        Color::Grey => "grey".to_string(),
+        Color::Reset => "reset".to_string(),
+        Color::Rgb { r, g, b } => format!("rgb({},{},{})", r, g, b),
+        Color::AnsiValue(val) => format!("ansi({})", val),
     }
 }


### PR DESCRIPTION
The PR is first of a few to centralize colour scheme management in Q CLI. The scheme creates message categories based on existing code analysis, and then, centralizes the color mapping. The PR also adds supports 3 different colour themes (default, high-contrast, and light) which can be individually set using `q settings`. Besides, colours for individual categories can also be overridden by `q settings`. The PR fixes #2295.


*Issue #, if available:* : #2295 

*Description of changes:* 

## Color Classification Results

Based on comprehensive analysis of 477+ color usages across the codebase:

### Success/Completion Colors (`Color::Green`) - 89 instances
- **Contexts**: Tool execution completion, file operations, command execution, trust confirmations, interactive options
- **Files**: `mod.rs`, `tools.rs`, `execute/mod.rs`, `fs_read.rs`, `fs_write.rs`, `knowledge.rs`
- **Examples**: `" ● Completed in {}s"`, file paths, shell commands, `"now trusted"`

### Error/Warning Colors (`Color::Red`) - 34 instances  
- **Contexts**: Context window overflow, subscription errors, command failures, tool execution failures, validation errors
- **Files**: `mod.rs`, `tools.rs`, `subscribe.rs`, `usage.rs`
- **Examples**: `"Your conversation is too large to continue"`, `" ● Execution failed after {}s"`

### Warning/Caution Colors (`Color::Yellow`) - 18 instances
- **Contexts**: Monthly limits, conversation length warnings, subscription status, command exit warnings
- **Files**: `mod.rs`, `subscribe.rs`, `knowledge.rs`
- **Examples**: `"Monthly request limit reached"`, `"This conversation is getting lengthy"`

### Secondary/Help Text Colors (`Color::DarkGrey`) - 23 instances
- **Contexts**: **Tool confirmation dialogs** (the problematic text), subscription hints, usage instructions, citations
- **Files**: `mod.rs`, `tools.rs`, `usage.rs`
- **Critical Issue**: Confirmation dialog text invisible in Solarized theme

### Primary UI/Branding Colors (`Color::Cyan`) - 12 instances
- **Contexts**: Model selection, response prefix, conversation summaries
- **Files**: `mod.rs`
- **Examples**: `"🤖 You are chatting with {}"`, `"> "` response prefix

### Tool/Action Colors (`Color::Magenta`) - 8 instances
- **Contexts**: Tool usage indicators, user prompt visualization
- **Files**: `mod.rs`, `usage.rs`
- **Examples**: `"🛠️ Using tool: {}"`, user interaction indicators

### Information/Reference Colors (`Color::Blue`) - 15 instances
- **Contexts**: Citation markers, Q response visualization, thinking tool info
- **Files**: `mod.rs`, `usage.rs`, `thinking.rs`
- **Examples**: `"[^{i}]: "` citations, informational displays

### 1. Centralized Color Management System

#### New Color Categories (Semantic-Based)
```rust
pub enum ColorCategory {
    Success,    // Green - completions, positive feedback (89 instances)
    Error,      // Red - failures, critical issues (34 instances)
    Warning,    // Yellow - cautions, informational alerts (18 instances)
    Info,       // Blue - informational content, references (15 instances)
    Secondary,  // DarkGrey/White - help text, less prominent elements (23 instances)
    Primary,    // Cyan - branding, important system messages (12 instances)
    Action,     // Magenta - tool usage, user interactions (8 instances)
    Data,       // DarkCyan - context files, data visualization (varies)
}
```
### 2. Color Manager Implementation
```rust
pub struct ColorManager {
    theme: ColorTheme,
}

impl ColorManager {
    pub fn from_settings(settings: &Settings) -> Self
    pub fn default() -> Self
    pub fn high_contrast() -> Self
    
    // Semantic color accessors
    pub fn success(&self) -> Color      // Green for positive feedback
    pub fn error(&self) -> Color        // Red for failures
    pub fn warning(&self) -> Color      // Yellow for cautions
    pub fn info(&self) -> Color         // Blue for information
    pub fn secondary(&self) -> Color    // Theme-aware secondary text
    pub fn primary(&self) -> Color      // Cyan for branding
    pub fn action(&self) -> Color       // Magenta for actions
    pub fn data(&self) -> Color         // DarkCyan for data
}
```

### 3. Convenience Macros for Consistent Usage
```rust
with_success!(output, color_manager, "Success message");
with_error!(output, color_manager, "Error message");
with_warning!(output, color_manager, "Warning message");
with_info!(output, color_manager, "Info message");
with_secondary!(output, color_manager, "Help text");
with_primary!(output, color_manager, "System message");
with_action!(output, color_manager, "Tool action");
with_data!(output, color_manager, "Data display");
```

## Summary of changes
### Core Infrastructure 
1. **`crates/chat-cli/src/database/settings.rs`** - Core color management system
   - Added `ColorCategory` enum with 8 semantic categories
   - Implemented `ColorTheme` struct with predefined themes
   - Added color parsing and serialization functions
   - Extended `Setting` enum with theme-specific settings

2. **`crates/chat-cli/src/cli/chat/colors.rs`** - Color manager utility
   - Created `ColorManager` with theme-aware color accessors
   - Implemented convenience macros (`with_success!`, `with_error!`, etc.)
   - Added theme switching capabilities

3. **`crates/chat-cli/src/cli/chat/mod.rs`** - Integration and critical fixes
   - Fixed confirmation dialog visibility issue (DarkGrey → theme-aware secondary)
   - Updated 20+ color instances to use semantic categories
   - Integrated ColorManager throughout chat system

4. **`crates/chat-cli/src/cli/chat/cli/tools.rs`** - Tool system updates
   - Updated 8 color instances for tool trust/untrust operations
   - Applied semantic coloring for tool status messages

5. **`crates/chat-cli/src/cli/chat/cli/usage.rs`** - Usage visualization
   - Updated 10 color instances in usage charts and help text
   - Improved data visualization consistency

6. **`crates/chat-cli/src/cli/chat/cli/subscribe.rs`** - Subscription system
   - Updated 2 color instances for subscription status messages

### Tool Files Updated (6 total):
**1. `crates/chat-cli/src/cli/chat/tools/gh_issue.rs`**
- Updated GitHub issue title display to use `with_success!` macro

**2. `crates/chat-cli/src/cli/chat/tools/fs_write.rs`**
- Updated 5 file operation messages (create, update, insert, append, path display)
- All file paths now use consistent `with_success!` coloring

**3. `crates/chat-cli/src/cli/chat/tools/knowledge.rs`**
- Updated 10+ color instances across all knowledge base operations
- Applied semantic coloring:
  - `with_success!` for names, IDs, and file paths
  - `with_info!` for content previews
  - `with_warning!` for destructive actions (e.g., "Clear all entries")

**4. `crates/chat-cli/src/cli/chat/tools/custom_tool.rs`**
- Updated MCP tool name display to use `with_success!`

**5. `crates/chat-cli/src/cli/chat/tools/execute/mod.rs`**
- Updated bash command display to use `with_success!`

**6. `crates/chat-cli/src/cli/chat/tools/thinking.rs`**
- Updated AI reasoning process messages to use `with_info!`


## Configuration Examples 
```bash
# Set high contrast theme for better visibility
q settings chat.theme high-contrast

# Customize individual colors
q settings chat.theme.secondary white
q settings chat.theme.success brightgreen
q settings chat.theme.error brightred

# Reset to defaults
q settings chat.theme default
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
