### PR TITLE
Bug fix for /compact on large messages

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -791,6 +791,11 @@ impl ChatSession {
                             show_summary: false,
                             strategy: CompactStrategy {
                                 truncate_large_messages: self.conversation.history().len() <= 2,
+                                max_message_length: if self.conversation.history().len() <= 2 {
+                                    25_000
+                                } else {
+                                    Default::default()
+                                },
                                 ..Default::default()
                             },
                         });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Compact history was failing if tool_use_results was too long and we had <= 2 messages in history. The bug fix was that we need to truncate the long message down to 25,000 length at most if we have very few items in history. Otherwise, it would constantly enter the branch for ChatError::CompactHistoryFailure. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
