### PR TITLE
feat: add user turn metrics, and more info in request metadata

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/compact.rs
+++ b/crates/chat-cli/src/cli/chat/cli/compact.rs
@@ -57,6 +57,10 @@ impl CompactArgs {
             Some(self.prompt.join(" "))
         };
 
+        // Compact interrupts the current conversation so this will always result in a new user
+        // turn.
+        session.reset_user_turn();
+
         session
             .compact_history(os, prompt, self.show_summary, CompactStrategy {
                 messages_to_exclude: self.messages_to_exclude.unwrap_or(default.messages_to_exclude),

--- a/crates/chat-cli/src/cli/chat/tool_manager.rs
+++ b/crates/chat-cli/src/cli/chat/tool_manager.rs
@@ -611,7 +611,7 @@ impl ToolManagerBuilder {
                 Err(e) => {
                     error!("Error initializing mcp client for server {}: {:?}", name, &e);
                     os.telemetry
-                        .send_mcp_server_init(conversation_id.clone(), Some(e.to_string()), 0)
+                        .send_mcp_server_init(conversation_id.clone(), name, Some(e.to_string()), 0)
                         .ok();
                     let _ = messenger.send_tools_list_result(Err(e)).await;
                 },
@@ -1401,7 +1401,7 @@ fn process_tool_specs(
     specs.retain(|spec| !matches!(spec.tool_origin, ToolOrigin::Native));
     // Send server load success metric datum
     let conversation_id = conversation_id.to_string();
-    let _ = telemetry.send_mcp_server_init(conversation_id, None, number_of_tools);
+    let _ = telemetry.send_mcp_server_init(conversation_id, server_name.to_string(), None, number_of_tools);
     // Tool name translation. This is beyond of the scope of what is
     // considered a "server load". Reasoning being:
     // - Failures here are not related to server load

--- a/crates/chat-cli/src/cli/chat/tools/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/mod.rs
@@ -7,7 +7,10 @@ pub mod knowledge;
 pub mod thinking;
 pub mod use_aws;
 
-use std::borrow::Borrow;
+use std::borrow::{
+    Borrow,
+    Cow,
+};
 use std::io::Write;
 use std::path::{
     Path,
@@ -31,6 +34,7 @@ use serde::{
     Serialize,
 };
 use thinking::Thinking;
+use tracing::error;
 use use_aws::UseAws;
 
 use super::consts::MAX_TOOL_RESPONSE_SIZE;
@@ -239,12 +243,15 @@ pub struct InvokeOutput {
 }
 
 impl InvokeOutput {
-    pub fn as_str(&self) -> &str {
+    pub fn as_str(&self) -> Cow<'_, str> {
         match &self.output {
-            OutputKind::Text(s) => s.as_str(),
-            OutputKind::Json(j) => j.as_str().unwrap_or_default(),
-            OutputKind::Images(_) => "",
-            OutputKind::Mixed { text, .. } => text.as_str(), // Return the text part
+            OutputKind::Text(s) => s.as_str().into(),
+            OutputKind::Json(j) => serde_json::to_string(j)
+                .map_err(|err| error!(?err, "failed to serialize tool to json"))
+                .unwrap_or_default()
+                .into(),
+            OutputKind::Images(_) => "".into(),
+            OutputKind::Mixed { text, .. } => text.as_str().into(), // Return the text part
         }
     }
 }

--- a/crates/chat-cli/src/telemetry/definitions.rs
+++ b/crates/chat-cli/src/telemetry/definitions.rs
@@ -13,7 +13,10 @@ mod tests {
     use std::time::SystemTime;
 
     use super::*;
-    use crate::telemetry::core::ChatConversationType;
+    use crate::telemetry::core::{
+        ChatConversationType,
+        MessageMetaTag,
+    };
     use crate::telemetry::definitions::metrics::CodewhispererterminalAddChatMessage;
 
     #[test]
@@ -33,12 +36,13 @@ mod tests {
             reason_desc: None,
             status_code: None,
             codewhispererterminal_model: None,
-            codewhispererterminal_time_to_first_chunk_ms: Some(40.into()),
+            codewhispererterminal_time_to_first_chunks_ms: Some(40.to_string().into()),
             codewhispererterminal_time_between_chunks_ms: Some("1,2,3".to_string().into()),
             codewhispererterminal_chat_conversation_type: Some(ChatConversationType::NotToolUse.into()),
             codewhispererterminal_tool_use_id: None,
             codewhispererterminal_tool_name: None,
             codewhispererterminal_assistant_response_length: Some(20.into()),
+            codewhispererterminal_chat_message_meta_tags: Some([MessageMetaTag::Compact.to_string()].join(",").into()),
         });
 
         let s = serde_json::to_string_pretty(&metric_datum_init).unwrap();

--- a/crates/chat-cli/telemetry_definitions.json
+++ b/crates/chat-cli/telemetry_definitions.json
@@ -58,7 +58,7 @@
     {
       "name": "requestId",
       "type": "string",
-      "description": "The id assigned to an AWS request"
+      "description": "The id assigned to an AWS request. If referring to multiple requests, then the request id's are comma-delimited."
     },
     {
       "name": "oauthFlow",
@@ -126,6 +126,11 @@
       "description": "The length of the files included as part of context management"
     },
     {
+      "name": "codewhispererterminal_mcpServerName",
+      "type": "string",
+      "description": "Name of the MCP server"
+    },
+    {
       "name": "codewhispererterminal_mcpServerInitFailureReason",
       "type": "string",
       "description": "Reason for which a mcp server has failed to be initialized"
@@ -176,14 +181,19 @@
       "description": "The underlying LLM used by the service, set by the client"
     },
     {
-      "name": "codewhispererterminal_timeToFirstChunkMs",
-      "type": "int",
-      "description": "Time from sending the request to reading the first chunk in the stream. In milliseconds (ms)."
+      "name": "codewhispererterminal_timeToFirstChunksMs",
+      "type": "string",
+      "description": "Time from sending the request to reading the first chunk in the stream. If referring to multiple requests (e.g. when recording a user turn), then each time is comma-delimited. In milliseconds (ms)."
     },
     {
       "name": "codewhispererterminal_timeBetweenChunksMs",
       "type": "string",
       "description": "Comma-delimited times between reading each chunk, starting from the first chunk. In milliseconds (ms)."
+    },
+    {
+      "name": "codewhispererterminal_chatMessageMetaTags",
+      "type": "string",
+      "description": "Comma-delimited tags to optionally assign to a message. If recorded in the context of a user turn, then this refers to the last message in the turn."
     },
     {
       "name": "codewhispererterminal_chatConversationType",
@@ -192,7 +202,12 @@
           "NotToolUse",
           "ToolUse"
       ],
-      "description": "Identifies the role of the message in the conversation."
+      "description": "Identifies the role of the message in the conversation. If recorded in the context of a user turn, then this refers to the last message in the turn."
+    },
+    {
+      "name": "codewhispererterminal_userPromptLength",
+      "type": "int",
+      "description": "Total length of the user prompt, in bytes."
     },
     {
       "name": "codewhispererterminal_assistantResponseLength",
@@ -237,30 +252,36 @@
         { "type": "reasonDesc", "required": false },
         { "type": "statusCode", "required": false },
         { "type": "codewhispererterminal_model" },
-        { "type": "codewhispererterminal_timeToFirstChunkMs", "required": false },
+        { "type": "codewhispererterminal_timeToFirstChunksMs", "required": false },
         { "type": "codewhispererterminal_timeBetweenChunksMs", "required": false },
         { "type": "codewhispererterminal_chatConversationType", "required": false },
         { "type": "codewhispererterminal_toolUseId", "required": false },
         { "type": "codewhispererterminal_toolName", "required": false },
-        { "type": "codewhispererterminal_assistantResponseLength", "required": false }
+        { "type": "codewhispererterminal_assistantResponseLength", "required": false },
+        { "type": "codewhispererterminal_chatMessageMetaTags", "required": false }
       ]
     },
     {
       "name": "codewhispererterminal_recordUserTurnCompletion",
-      "description": "Captures information regarding a user turn (the chain of messages beginning with a user prompt, and ending with either an assistant stop event, or a tool use denial). Emitted once at the end of every user turn.",
+      "description": "Captures information regarding a user turn (the chain of messages beginning with a user prompt, and ending with either an assistant stop event, tool use denial, or a non-retryable error). Emitted once at the end of every user turn.",
       "metadata": [
         { "type": "amazonqConversationId" },
-        { "type": "codewhispererterminal_utteranceId" },
         { "type": "credentialStartUrl", "required": false },
         { "type": "ssoRegion", "required": false },
         { "type": "codewhispererterminal_inCloudshell" },
-        { "type": "codewhispererterminal_contextFileLength", "required": false },
         { "type": "requestId" },
+        { "type": "codewhispererterminal_utteranceId" },
         { "type": "result", "required": true },
         { "type": "reason", "required": false },
         { "type": "reasonDesc", "required": false },
         { "type": "statusCode", "required": false },
-        { "type": "codewhispererterminal_model" }
+        { "type": "codewhispererterminal_chatConversationType", "required": false },
+        { "type": "codewhispererterminal_timeToFirstChunksMs" },
+        { "type": "codewhispererterminal_userPromptLength" },
+        { "type": "codewhispererterminal_assistantResponseLength" },
+        { "type": "codewhispererterminal_userTurnDurationSeconds" },
+        { "type": "codewhispererterminal_followUpCount" },
+        { "type": "codewhispererterminal_chatMessageMetaTags", "required": false }
       ]
     },
     {
@@ -334,6 +355,7 @@
         { "type": "codewhispererterminal_isToolUseAccepted" },
         { "type": "codewhispererterminal_isToolValid" },
         { "type": "codewhispererterminal_toolUseIsSuccess", "required": false },
+        { "type": "reasonDesc", "required": false },
         { "type": "codewhispererterminal_isCustomTool" },
         {
           "type": "codewhispererterminal_customToolInputTokenSize",
@@ -357,6 +379,7 @@
       "metadata": [
         { "type": "credentialStartUrl" },
         { "type": "amazonqConversationId" },
+        { "type": "codewhispererterminal_mcpServerName" },
         {
           "type": "codewhispererterminal_mcpServerInitFailureReason",
           "required": false
@@ -396,6 +419,8 @@
           { "type": "credentialStartUrl", "required": false },
           { "type": "ssoRegion", "required": false },
           { "type": "amazonqConversationId" },
+          { "type": "requestId", "required": false },
+          { "type": "codewhispererterminal_utteranceId", "required": false },
           { "type": "codewhispererterminal_contextFileLength", "required": false },
           { "type": "result" },
           { "type": "reason", "required": false },


### PR DESCRIPTION
*Description of changes:*
- Fixing an issue with `codewhispererterminal_customToolOutputTokenSize` metric not recording the correct size - MCP tools always return JSON, but we would only return the token size if the JSON is a string rather than any arbitrary value
- Adding `codewhispererterminal_recordUserTurnCompletion` as a new telemetry event. This records telemetry for a **user turn**. This is done by adding additional fields to `RequestMetadata` returned by the response stream parser, and updating `ChatSession::send_chat_telemetry` to use an additional parameter  `is_end_turn`, which will send this additional telemetry event for requests that we know will end the current turn.
- Adding `codewhispererterminal_mcpServerName` to the `codewhispererterminal_mcpServerInit` telemetry event.

## Background

A **user turn** is the sequence of requests starting from an initial user prompt up to the next user prompt, or a request/stream failure. This means that a user turn is ended in the following scenarios:
1. The model responds with no tool uses
2. The user rejects a tool use with another prompt
3. The request fails to send, or a non-retryable response stream error is encountered.

In the implementation, telemetry then depends on the sequence of `RequestMetadata` stored during the user turn. Any new prompt that ends the user turn must call `ChatSession::reset_user_turn` - this decoupling of clearing the request metadata from the sending of telemetry is required for adding request metadata to the `amazonq_messageResponseError` event.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
