### PR TITLE
fix(agent): local agents being sourced from incorrect local path

### DIFF
--- a/crates/chat-cli/src/cli/agent/mod.rs
+++ b/crates/chat-cli/src/cli/agent/mod.rs
@@ -217,6 +217,7 @@ impl Agent {
             .to_string();
 
         self.name = name.clone();
+        self.path = Some(path.to_path_buf());
 
         if let (true, Some(global_mcp_config)) = (self.use_legacy_mcp_json, global_mcp_config) {
             let mut stderr = std::io::stderr();

--- a/crates/chat-cli/src/cli/agent/root_command_args.rs
+++ b/crates/chat-cli/src/cli/agent/root_command_args.rs
@@ -216,17 +216,11 @@ pub async fn create_agent(
     let path = if let Some(path) = path {
         let path = PathBuf::from(path);
 
-        // If path points to a file, strip the filename to get the directory
         if !path.is_dir() {
             bail!("Path must be a directory");
         }
 
-        let last_three_segments = agent_config_dir();
-        if path.ends_with(&last_three_segments) {
-            path
-        } else {
-            path.join(&last_three_segments)
-        }
+        agent_config_dir(os, path)?
     } else {
         directories::chat_global_agent_path(os)?
     };

--- a/crates/chat-cli/src/cli/agent/root_command_args.rs
+++ b/crates/chat-cli/src/cli/agent/root_command_args.rs
@@ -223,7 +223,7 @@ pub async fn create_agent(
             bail!("Path must be a directory");
         }
 
-        agent_config_dir(os, path)?
+        agent_config_dir(path)?
     } else {
         directories::chat_global_agent_path(os)?
     };

--- a/crates/chat-cli/src/cli/agent/root_command_args.rs
+++ b/crates/chat-cli/src/cli/agent/root_command_args.rs
@@ -214,7 +214,10 @@ pub async fn create_agent(
     from: Option<String>,
 ) -> Result<PathBuf> {
     let path = if let Some(path) = path {
-        let path = PathBuf::from(path);
+        let mut path = PathBuf::from(path);
+        if path.is_relative() {
+            path = os.env.current_dir()?.join(path);
+        }
 
         if !path.is_dir() {
             bail!("Path must be a directory");

--- a/crates/chat-cli/src/util/directories.rs
+++ b/crates/chat-cli/src/util/directories.rs
@@ -28,8 +28,6 @@ pub enum DirectoryError {
     IntoString(#[from] std::ffi::IntoStringError),
     #[error(transparent)]
     StripPrefix(#[from] StripPrefixError),
-    #[error("Error converting path to str")]
-    PathToStr,
 }
 
 type Result<T, E = DirectoryError> = std::result::Result<T, E>;

--- a/crates/chat-cli/src/util/directories.rs
+++ b/crates/chat-cli/src/util/directories.rs
@@ -169,7 +169,7 @@ pub fn agent_config_dir(os: &Os, path: PathBuf) -> Result<PathBuf> {
 
     let home_path = home_dir(os)?;
     let path_as_str = path.to_str().ok_or(DirectoryError::PathToStr)?;
-    let expanded_path = PathBuf::from(shellexpand::tilde(path_as_str).as_ref());
+    let expanded_path = PathBuf::from(shellexpand::tilde(path_as_str).as_ref() as &str);
     let remainder = expanded_path.strip_prefix(&home_path)?;
     let remainder_as_str = remainder.to_str().ok_or(DirectoryError::PathToStr)?;
 

--- a/crates/chat-cli/src/util/directories.rs
+++ b/crates/chat-cli/src/util/directories.rs
@@ -163,26 +163,8 @@ pub fn chat_local_agent_dir() -> Result<PathBuf> {
 ///
 /// For example, if the given path is /path/one, then the derived config path would be
 /// `/path/one/.amazonq/agents`
-/// This is different for home directory, where the agents are expected to be stored in
-/// `~/.aws/amazonq/agents`
-pub fn agent_config_dir(os: &Os, workspace_dir: PathBuf) -> Result<PathBuf> {
-    const GLOBAL_CONFIG_SEGMENT: &str = ".aws/amazonq/agents";
-    const LOCAL_CONFIG_SEGMENT: &str = ".amazonq/agents";
-
-    let home_path = home_dir(os)?;
-    let path_as_str = workspace_dir.to_str().ok_or(DirectoryError::PathToStr)?;
-    let expanded_path = PathBuf::from(shellexpand::tilde(path_as_str).as_ref() as &str);
-    let remainder = expanded_path.strip_prefix(&home_path)?;
-    let remainder_as_str = remainder.to_str().ok_or(DirectoryError::PathToStr)?;
-
-    // The path given is the home directory
-    if remainder_as_str.is_empty() {
-        return Ok(home_path.join(GLOBAL_CONFIG_SEGMENT));
-    }
-
-    // The path given is local workspace directory, in which case we should append the path given
-    // with a local config segment
-    Ok(workspace_dir.join(LOCAL_CONFIG_SEGMENT))
+pub fn agent_config_dir(workspace_dir: PathBuf) -> Result<PathBuf> {
+    Ok(workspace_dir.join(".amazonq/agents"))
 }
 
 /// The directory to the directory containing config for the `/context` feature in `q chat`.


### PR DESCRIPTION
*Issue #, if available:*
Local agents should be sourced from `.amazonq/agents` and not `.aws/amazonq/agents`.

*Description of changes:*
As titled. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
