### PR TITLE
feat: add telemetry for agent config and tool execution timing

### DIFF
--- a/crates/chat-cli/src/cli/agent/legacy/mod.rs
+++ b/crates/chat-cli/src/cli/agent/legacy/mod.rs
@@ -20,10 +20,15 @@ use crate::cli::agent::legacy::context::LegacyContextConfig;
 use crate::os::Os;
 use crate::util::directories;
 
-pub async fn migrate(os: &mut Os) -> eyre::Result<Vec<Agent>> {
+/// Performs the migration from legacy profile configuration to agent configuration if it hasn't
+/// already been done.
+///
+/// Returns [Some] with the newly migrated agents if the migration was performed, [None] if the
+/// migration was already done previously.
+pub async fn migrate(os: &mut Os) -> eyre::Result<Option<Vec<Agent>>> {
     let has_migrated = os.database.get_has_migrated()?;
     if has_migrated.is_some_and(|has_migrated| has_migrated) {
-        bail!("Nothing to migrate");
+        return Ok(None);
     }
 
     let legacy_global_context_path = directories::chat_global_context_path(os)?;
@@ -216,5 +221,5 @@ pub async fn migrate(os: &mut Os) -> eyre::Result<Vec<Agent>> {
 
     os.database.set_has_migrated()?;
 
-    Ok(new_agents)
+    Ok(Some(new_agents))
 }

--- a/crates/chat-cli/src/cli/agent/root_command_args.rs
+++ b/crates/chat-cli/src/cli/agent/root_command_args.rs
@@ -75,7 +75,7 @@ impl AgentArgs {
         let mut stderr = std::io::stderr();
         match self.cmd {
             Some(AgentSubcommands::List) | None => {
-                let agents = Agents::load(os, None, true, &mut stderr).await;
+                let agents = Agents::load(os, None, true, &mut stderr).await.0;
                 let agent_with_path =
                     agents
                         .agents
@@ -100,7 +100,7 @@ impl AgentArgs {
                 writeln!(stderr, "{}", output_str)?;
             },
             Some(AgentSubcommands::Create { name, directory, from }) => {
-                let mut agents = Agents::load(os, None, true, &mut stderr).await;
+                let mut agents = Agents::load(os, None, true, &mut stderr).await.0;
                 let path_with_file_name = create_agent(os, &mut agents, name.clone(), directory, from).await?;
                 let editor_cmd = std::env::var("EDITOR").unwrap_or_else(|_| "vi".to_string());
                 let mut cmd = std::process::Command::new(editor_cmd);
@@ -131,7 +131,7 @@ impl AgentArgs {
                 )?;
             },
             Some(AgentSubcommands::Rename { agent, new_name }) => {
-                let mut agents = Agents::load(os, None, true, &mut stderr).await;
+                let mut agents = Agents::load(os, None, true, &mut stderr).await.0;
                 rename_agent(os, &mut agents, agent.clone(), new_name.clone()).await?;
                 writeln!(stderr, "\n✓ Renamed agent '{}' to '{}'\n", agent, new_name)?;
             },

--- a/crates/chat-cli/src/cli/chat/cli/profile.rs
+++ b/crates/chat-cli/src/cli/chat/cli/profile.rs
@@ -133,7 +133,7 @@ impl AgentSubcommand {
                     .map_err(|e| ChatError::Custom(format!("Error printing agent schema: {e}").into()))?;
             },
             Self::Create { name, directory, from } => {
-                let mut agents = Agents::load(os, None, true, &mut session.stderr).await;
+                let mut agents = Agents::load(os, None, true, &mut session.stderr).await.0;
                 let path_with_file_name = create_agent(os, &mut agents, name.clone(), directory, from)
                     .await
                     .map_err(|e| ChatError::Custom(Cow::Owned(e.to_string())))?;
@@ -177,7 +177,7 @@ impl AgentSubcommand {
                 )?;
             },
             Self::Rename { agent, new_name } => {
-                let mut agents = Agents::load(os, None, true, &mut session.stderr).await;
+                let mut agents = Agents::load(os, None, true, &mut session.stderr).await.0;
                 rename_agent(os, &mut agents, agent.clone(), new_name.clone())
                     .await
                     .map_err(|e| ChatError::Custom(Cow::Owned(e.to_string())))?;

--- a/crates/chat-cli/src/cli/mcp.rs
+++ b/crates/chat-cli/src/cli/mcp.rs
@@ -382,7 +382,7 @@ async fn get_mcp_server_configs(
 
     let mut results = Vec::new();
     let mut stderr = std::io::stderr();
-    let agents = Agents::load(os, None, true, &mut stderr).await;
+    let agents = Agents::load(os, None, true, &mut stderr).await.0;
     let global_path = directories::chat_global_agent_path(os)?;
     for (_, agent) in agents.agents {
         let scope = if agent

--- a/crates/chat-cli/telemetry_definitions.json
+++ b/crates/chat-cli/telemetry_definitions.json
@@ -101,6 +101,11 @@
       "description": "Denotes if a tool use event has been fulfilled"
     },
     {
+      "name": "codewhispererterminal_isToolUseTrusted",
+      "type": "boolean",
+      "description": "Whether or not the tool use was automatically trusted (instead of manually approved)"
+    },
+    {
       "name": "codewhispererterminal_toolUseIsSuccess",
       "type": "boolean",
       "description": "The outcome of a tool use"
@@ -171,11 +176,6 @@
       "description": "Total amount of time the tool turn took, including waiting for user input if required. In milliseconds (ms)."
     },
     {
-      "name": "codewhispererterminal_isToolUseTrusted",
-      "type": "int",
-      "description": "The amount of time taken to execute a tool. In milliseconds (ms)."
-    },
-    {
       "name": "codewhispererterminal_model",
       "type": "string",
       "description": "The underlying LLM used by the service, set by the client"
@@ -223,6 +223,31 @@
       "name": "codewhispererterminal_userTurnDurationSeconds",
       "type": "int",
       "description": "Total time spent in the user turn, starting from when the first request is sent."
+    },
+    {
+      "name": "codewhispererterminal_agentsLoadedCount",
+      "type": "int",
+      "description": "The number of agents loaded"
+    },
+    {
+      "name": "codewhispererterminal_agentsFailedToLoadCount",
+      "type": "int",
+      "description": "The number of agents that failed to load"
+    },
+    {
+      "name": "codewhispererterminal_legacyProfileMigrationExecuted",
+      "type": "boolean",
+      "description": "Whether or not the legacy profile configuration migration was executed"
+    },
+    {
+      "name": "codewhispererterminal_legacyProfileMigratedCount",
+      "type": "int",
+      "description": "The number of agent configs created from a legacy profile migration"
+    },
+    {
+      "name": "codewhispererterminal_launchedAgent",
+      "type": "string",
+      "description": "The name of the agent launched by the user on startup"
     }
   ],
   "metrics": [
@@ -385,6 +410,20 @@
           "required": false
         },
         { "type": "codewhispererterminal_toolsPerMcpServer" }
+      ]
+    },
+    {
+      "name": "codewhispererterminal_agentConfigInit",
+      "description": "Emitted once when starting a new q chat session after agent configuration is initialized",
+      "passive": false,
+      "metadata": [
+        { "type": "credentialStartUrl" },
+        { "type": "amazonqConversationId" },
+        { "type": "codewhispererterminal_agentsLoadedCount" },
+        { "type": "codewhispererterminal_agentsFailedToLoadCount" },
+        { "type": "codewhispererterminal_legacyProfileMigrationExecuted", "required": false },
+        { "type": "codewhispererterminal_legacyProfileMigratedCount", "required": false },
+        { "type": "codewhispererterminal_launchedAgent", "required": false }
       ]
     },
     {


### PR DESCRIPTION
*Description of changes:*
- Adding telemetry for agent configuration initialization on `q chat` startup. See the `telemetry_definitions.json` file for the spec
- Adding telemetry for tool execution timing
- Fixing `codewhispererterminal_mcpServerInit` to include credential start url

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
