### PR TITLE
adds agent root command for migrate

### DIFF
--- a/crates/chat-cli/src/cli/agent/mod.rs
+++ b/crates/chat-cli/src/cli/agent/mod.rs
@@ -399,7 +399,7 @@ impl Agents {
         };
 
         let new_agents = if !skip_migration {
-            match legacy::migrate(os).await {
+            match legacy::migrate(os, false).await {
                 Ok(Some(new_agents)) => {
                     let migrated_count = new_agents.len();
                     info!(migrated_count, "Profile migration successful");


### PR DESCRIPTION
*Issue #, if available:*
This is for anyone who has used a previous version of beta with a different agent config schema to migrate (from profile to agent). 

*Description of changes:*
As titled

Happy path:
<img width="739" height="169" alt="image" src="https://github.com/user-attachments/assets/f84ecb2f-90c0-483e-930b-2905f1f34a29" />

Without using --force flag:
<img width="740" height="195" alt="image" src="https://github.com/user-attachments/assets/5b9b806c-ed2b-4f22-9df8-634a191f2500" />

Nothing to migrate:
<img width="737" height="179" alt="image" src="https://github.com/user-attachments/assets/03129a68-3a16-482c-aeb5-5364c7a309bf" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
