### PR TITLE
feat: restrict trust permissions for non-readonly AWS operations in use_aws tool

### DIFF
--- a/crates/chat-cli/src/cli/agent/mod.rs
+++ b/crates/chat-cli/src/cli/agent/mod.rs
@@ -314,6 +314,7 @@ impl Agent {
 pub enum PermissionEvalResult {
     Allow,
     Ask,
+    AskWithoutTrust,
     Deny,
 }
 


### PR DESCRIPTION
## Summary

This PR introduces enhanced security controls for the `use_aws` tool by implementing a new permission evaluation type that restricts session-wide trust for potentially destructive AWS operations.

## Changes

### Core Implementation
- **New Permission Type**: Added `PermissionEvalResult::AskWithoutTrust` to the permission evaluation system
- **Enhanced Security**: Modified `use_aws` tool to return `AskWithoutTrust` for write/modify operations, preventing users from accidentally granting session-wide trust for destructive AWS actions
- **Conditional Prompts**: Updated `ChatSession` to conditionally render acceptance prompts based on permission type:
  - `Ask`: Shows full `[y/n/t]` prompt with trust option
  - `AskWithoutTrust`: Shows restricted `[y/n]` prompt without trust option

### Security Model
- **Write Operations**: Always require per-action approval regardless of tool trust status
  - Examples: `put-object`, `delete-*`, `create-*`, `update-*`, etc.
- **Read Operations**: Continue to allow trust and session-wide approval
  - Examples: `list-*`, `describe-*`, `get-*`, etc.

### Technical Details
- Added `pending_tool_allows_trust` flag to track permission level during tool execution
- Updated trust option handling to respect the new permission constraints
- Comprehensive test coverage for both trusted and untrusted tool scenarios

## Motivation

Previously, users could grant session-wide trust to the `use_aws` tool for any operation, including potentially destructive actions like deleting S3 buckets or terminating EC2 instances. This created a security risk where a single trust decision could lead to unintended destructive operations throughout the session.

## Testing

- ✅ Added tests for trusted tools with write operations (should use `AskWithoutTrust`)
- ✅ Added tests for trusted tools with read operations (should use `Allow`)
- ✅ Added tests for untrusted tools with write operations (should use `AskWithoutTrust`)
- ✅ Added tests for untrusted tools with read operations (should use `Allow`)
- ✅ Verified prompt rendering logic for both permission types

## Impact

- **Security**: Reduces risk of accidental destructive AWS operations
- **User Experience**: Maintains smooth workflow for read-only operations while adding appropriate friction for write operations
- **Backward Compatibility**: No breaking changes to existing functionality

## Example

**Before**: User could trust `use_aws` once and all subsequent AWS operations (including destructive ones) would execute without confirmation.

**After**: 
- Read operations: Can still be trusted for session-wide approval
- Write operations: Always require individual confirmation, even for trusted tools

**Screenshot**:
<img width="557" height="306" alt="Screenshot 2025-07-31 at 1 10 39 PM" src="https://github.com/user-attachments/assets/3c4ddd85-ce16-4f3b-88de-35378846fd63" />
