### PR TITLE
fix: broken link in docs to built-in tools

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -3,5 +3,5 @@
 [Introduction](./introduction.md)
 
 - [The Agent Format](./agent-format.md)
-- [Native Tools](./native-tools.md)
+- [Built-in Tools](./built-in-tools.md)
 - [Knowledge Management](./knowledge-management.md)


### PR DESCRIPTION
*Description of changes:*
- Currently the docs link to built-in tools are broken, this fixes it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
