### PR TITLE
suppressing prompt field in agent config doc

### DIFF
--- a/docs/agent-format.md
+++ b/docs/agent-format.md
@@ -38,15 +38,7 @@ The `description` field provides a description of what the agent does. This is p
 }
 ```
 
-## Prompt Field
 
-The `prompt` field is intended to provide high-level context to the agent, similar to a system prompt. This feature is not yet implemented.
-
-```json
-{
-  "prompt": "You are an expert AWS infrastructure specialist"
-}
-```
 
 ## McpServers Field
 


### PR DESCRIPTION
Since the feature and the main docs are live, let's not include this yet, at least not right here on the page with the live features.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
