### PR TITLE
fix(agent): deprecate slash profile subcommand

### DIFF
--- a/crates/chat-cli/src/cli/chat/consts.rs
+++ b/crates/chat-cli/src/cli/chat/consts.rs
@@ -32,3 +32,6 @@ pub const AGENT_FORMAT_HOOKS_DOC_URL: &str =
 
 pub const AGENT_FORMAT_TOOLS_DOC_URL: &str =
     "https://github.com/aws/amazon-q-developer-cli/blob/main/docs/agent-format.md#tools-field";
+
+pub const AGENT_MIGRATION_DOC_URL: &str =
+    "https://github.com/aws/amazon-q-developer-cli/blob/main/docs/legacy-profile-to-agent-migration.md";


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Deprecates slash profile subcommand.

<img width="1088" height="223" alt="image" src="https://github.com/user-attachments/assets/e19a8914-e938-451f-8777-a6319da21f4a" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
