### PR TITLE
fix(agent): permission reset

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/tools.rs
+++ b/crates/chat-cli/src/cli/chat/cli/tools.rs
@@ -18,7 +18,10 @@ use crossterm::{
 };
 
 use crate::api_client::model::Tool as FigTool;
-use crate::cli::agent::Agent;
+use crate::cli::agent::{
+    Agent,
+    DEFAULT_AGENT_NAME,
+};
 use crate::cli::chat::consts::{
     AGENT_FORMAT_TOOLS_DOC_URL,
     DUMMY_TOOL_NAME,
@@ -371,7 +374,7 @@ impl ToolsSubcommand {
                     .conversation
                     .agents
                     .get_active()
-                    .is_some_and(|a| a.name.as_str() == "default")
+                    .is_some_and(|a| a.name.as_str() == DEFAULT_AGENT_NAME)
                 {
                     // We only want to reset the tool permission and nothing else
                     if let Some(active_agent) = session.conversation.agents.get_active_mut() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
As titled. 
This was a regression caused by the renaming of in memory default from "default" to something else (while references of this name was hardcoded elsewhere).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
