### PR TITLE
fix: uses struct discriminates as hash key for native tools

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/tools.rs
+++ b/crates/chat-cli/src/cli/chat/cli/tools.rs
@@ -60,7 +60,7 @@ impl ToolsArgs {
                 session
                     .conversation
                     .tools
-                    .get("native")
+                    .get(&ToolOrigin::Native)
                     .and_then(|tools| {
                         tools
                             .iter()
@@ -218,7 +218,7 @@ impl ToolsSubcommand {
         let native_tool_names = session
             .conversation
             .tools
-            .get("native")
+            .get(&ToolOrigin::Native)
             .map(|tools| {
                 tools
                     .iter()

--- a/crates/chat-cli/src/cli/chat/tools/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/mod.rs
@@ -169,8 +169,9 @@ pub enum ToolOrigin {
 
 impl std::hash::Hash for ToolOrigin {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(self).hash(state);
         match self {
-            Self::Native => "native".hash(state),
+            Self::Native => {},
             Self::McpServer(name) => name.hash(state),
         }
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changes hashing of tool origin to use struct discriminate for native namespace. Previously native tool namespace is hashed as "native".
This potentially collides with mcp server names (i.e. should user wish to use the name "native" for an mcp server").

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
