### PR TITLE
bskiser/merge prod

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,7 +1198,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chat_cli"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "amzn-codewhisperer-client",
  "amzn-codewhisperer-streaming-client",
@@ -5525,7 +5525,7 @@ dependencies = [
 
 [[package]]
 name = "semantic_search_client"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "bm25",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Amazon Q CLI Team (q-cli@amazon.com)", "Chay Nabors (nabochay@amazon
 edition = "2024"
 homepage = "https://aws.amazon.com/q/"
 publish = false
-version = "1.13.0"
+version = "1.13.1"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]

--- a/crates/chat-cli/src/cli/agent/mod.rs
+++ b/crates/chat-cli/src/cli/agent/mod.rs
@@ -700,7 +700,7 @@ impl Agents {
                 // Here the tool names can take the following forms:
                 // - @{server_name}{delimiter}{tool_name}
                 // - native_tool_name
-                name == tool_name
+                name == tool_name && matches!(origin, &ToolOrigin::Native)
                     || name.strip_prefix("@").is_some_and(|remainder| {
                         remainder
                             .split_once(MCP_SERVER_TOOL_DELIMITER)

--- a/crates/chat-cli/src/cli/agent/mod.rs
+++ b/crates/chat-cli/src/cli/agent/mod.rs
@@ -120,6 +120,8 @@ pub enum AgentConfigError {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[schemars(description = "An Agent is a declarative way of configuring a given instance of q chat.")]
 pub struct Agent {
+    #[serde(rename = "$schema", default = "default_schema")]
+    pub schema: String,
     /// Name of the agent
     pub name: String,
     /// This field is not model facing and is mostly here for users to discern between agents
@@ -166,6 +168,7 @@ pub struct Agent {
 impl Default for Agent {
     fn default() -> Self {
         Self {
+            schema: default_schema(),
             name: DEFAULT_AGENT_NAME.to_string(),
             description: Some("Default agent".to_string()),
             prompt: Default::default(),
@@ -764,6 +767,10 @@ async fn load_agents_from_entries(
     }
 
     res
+}
+
+fn default_schema() -> String {
+    "https://raw.githubusercontent.com/aws/amazon-q-developer-cli/refs/heads/main/schemas/agent-v1.json".into()
 }
 
 #[cfg(test)]

--- a/crates/chat-cli/src/cli/agent/root_command_args.rs
+++ b/crates/chat-cli/src/cli/agent/root_command_args.rs
@@ -368,5 +368,15 @@ mod tests {
                 })
             })
         );
+        assert_parse!(
+            ["agent", "create", "-n", "some_agent", "--from", "some_old_agent"],
+            RootSubcommand::Agent(AgentArgs {
+                cmd: Some(AgentSubcommands::Create {
+                    name: "some_agent".to_string(),
+                    directory: None,
+                    from: Some("some_old_agent".to_string())
+                })
+            })
+        );
     }
 }

--- a/crates/chat-cli/src/cli/chat/cli/profile.rs
+++ b/crates/chat-cli/src/cli/chat/cli/profile.rs
@@ -43,7 +43,7 @@ use crate::util::directories::chat_global_agent_path;
 
 Notes
 • Launch q chat with a specific agent with --agent
-• Construct an agent under ~/.aws/amazonq/agents/ (accessible globally) or cwd/.aws/amazonq/agents (accessible in workspace)
+• Construct an agent under ~/.aws/amazonq/cli-agents/ (accessible globally) or cwd/.aws/amazonq/cli-agents (accessible in workspace)
 • See example config under global directory
 • Set default agent to assume with settings by running \"q settings chat.defaultAgent agent_name\"
 • Each agent maintains its own set of context and customizations"

--- a/crates/chat-cli/src/cli/chat/cli/tools.rs
+++ b/crates/chat-cli/src/cli/chat/cli/tools.rs
@@ -18,7 +18,10 @@ use crossterm::{
 };
 
 use crate::api_client::model::Tool as FigTool;
-use crate::cli::agent::Agent;
+use crate::cli::agent::{
+    Agent,
+    DEFAULT_AGENT_NAME,
+};
 use crate::cli::chat::consts::{
     AGENT_FORMAT_TOOLS_DOC_URL,
     DUMMY_TOOL_NAME,
@@ -371,7 +374,7 @@ impl ToolsSubcommand {
                     .conversation
                     .agents
                     .get_active()
-                    .is_some_and(|a| a.name.as_str() == "default")
+                    .is_some_and(|a| a.name.as_str() == DEFAULT_AGENT_NAME)
                 {
                     // We only want to reset the tool permission and nothing else
                     if let Some(active_agent) = session.conversation.agents.get_active_mut() {

--- a/crates/chat-cli/src/cli/chat/cli/tools.rs
+++ b/crates/chat-cli/src/cli/chat/cli/tools.rs
@@ -63,7 +63,7 @@ impl ToolsArgs {
                 session
                     .conversation
                     .tools
-                    .get("native")
+                    .get(&ToolOrigin::Native)
                     .and_then(|tools| {
                         tools
                             .iter()
@@ -221,7 +221,7 @@ impl ToolsSubcommand {
         let native_tool_names = session
             .conversation
             .tools
-            .get("native")
+            .get(&ToolOrigin::Native)
             .map(|tools| {
                 tools
                     .iter()

--- a/crates/chat-cli/src/cli/chat/consts.rs
+++ b/crates/chat-cli/src/cli/chat/consts.rs
@@ -32,3 +32,6 @@ pub const AGENT_FORMAT_HOOKS_DOC_URL: &str =
 
 pub const AGENT_FORMAT_TOOLS_DOC_URL: &str =
     "https://github.com/aws/amazon-q-developer-cli/blob/main/docs/agent-format.md#tools-field";
+
+pub const AGENT_MIGRATION_DOC_URL: &str =
+    "https://github.com/aws/amazon-q-developer-cli/blob/main/docs/legacy-profile-to-agent-migration.md";

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -98,6 +98,7 @@ use tool_manager::{
 };
 use tools::gh_issue::GhIssueContext;
 use tools::{
+    NATIVE_TOOLS,
     OutputKind,
     QueuedTool,
     Tool,
@@ -280,6 +281,28 @@ impl ChatArgs {
             }
 
             if let Some(trust_tools) = self.trust_tools.take() {
+                for tool in &trust_tools {
+                    if !tool.starts_with("@") && !NATIVE_TOOLS.contains(&tool.as_str()) {
+                        let _ = queue!(
+                            stderr,
+                            style::SetForegroundColor(Color::Yellow),
+                            style::Print("WARNING: "),
+                            style::SetForegroundColor(Color::Reset),
+                            style::Print("--trust-tools arg for custom tool "),
+                            style::SetForegroundColor(Color::Cyan),
+                            style::Print(tool),
+                            style::SetForegroundColor(Color::Reset),
+                            style::Print(" needs to be prepended with "),
+                            style::SetForegroundColor(Color::Green),
+                            style::Print("@{MCPSERVERNAME}/"),
+                            style::SetForegroundColor(Color::Reset),
+                            style::Print("\n"),
+                        );
+                    }
+                }
+
+                let _ = stderr.flush();
+
                 if let Some(a) = agents.get_active_mut() {
                     a.allowed_tools.extend(trust_tools);
                 }

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -802,7 +802,7 @@ impl ChatSession {
                 )?;
                 ("Unable to compact the conversation history", eyre!(err), true)
             },
-            ChatError::Client(err) => match *err {
+            ChatError::SendMessage(err) => match err.source {
                 // Errors from attempting to send too large of a conversation history. In
                 // this case, attempt to automatically compact the history for the user.
                 ApiClientError::ContextWindowOverflow { .. } => {
@@ -1307,7 +1307,9 @@ impl ChatSession {
                 // retryable according to the passed strategy.
                 let history_len = self.conversation.history().len();
                 match err {
-                    ChatError::Client(err) if matches!(*err, ApiClientError::ContextWindowOverflow { .. }) => {
+                    ChatError::SendMessage(err)
+                        if matches!(err.source, ApiClientError::ContextWindowOverflow { .. }) =>
+                    {
                         error!(?strategy, "failed to send compaction request");
                         // If there's only two messages in the history, we have no choice but to
                         // truncate it. We use two messages since it's almost guaranteed to contain:

--- a/crates/chat-cli/src/cli/chat/tools/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/mod.rs
@@ -169,8 +169,9 @@ pub enum ToolOrigin {
 
 impl std::hash::Hash for ToolOrigin {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(self).hash(state);
         match self {
-            Self::Native => "native".hash(state),
+            Self::Native => {},
             Self::McpServer(name) => name.hash(state),
         }
     }

--- a/crates/chat-cli/src/cli/mcp.rs
+++ b/crates/chat-cli/src/cli/mcp.rs
@@ -550,7 +550,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mcp_subcomman_add() {
+    fn test_mcp_subcommand_add() {
         assert_parse!(
             [
                 "mcp",

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -3,5 +3,5 @@
 [Introduction](./introduction.md)
 
 - [The Agent Format](./agent-format.md)
-- [Native Tools](./native-tools.md)
+- [Built-in Tools](./built-in-tools.md)
 - [Knowledge Management](./knowledge-management.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -5,3 +5,4 @@
 - [The Agent Format](./agent-format.md)
 - [Built-in Tools](./built-in-tools.md)
 - [Knowledge Management](./knowledge-management.md)
+- [Profile to Agent Migration](./legacy-profile-to-agent-migration.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -2,6 +2,6 @@
 
 [Introduction](./introduction.md)
 
-- [The Agent Format](./the-agent-format.md)
+- [The Agent Format](./agent-format.md)
 - [Native Tools](./native-tools.md)
 - [Knowledge Management](./knowledge-management.md)

--- a/docs/agent-file-locations.md
+++ b/docs/agent-file-locations.md
@@ -7,7 +7,7 @@ Agent configuration files can be placed in two different locations, allowing for
 Local agents are stored in the current working directory under:
 
 ```
-.aws/amazonq/agents/
+.aws/amazonq/cli-agents/
 ```
 
 These agents are specific to the current workspace or project and are only available when running Q CLI from that directory or its subdirectories.
@@ -17,7 +17,7 @@ These agents are specific to the current workspace or project and are only avail
 my-project/
 ├── .aws/
 │   └── amazonq/
-│       └── agents/
+│       └── cli-agents/
 │           ├── dev-agent.json
 │           └── aws-specialist.json
 └── src/
@@ -29,14 +29,14 @@ my-project/
 Global agents are stored in your home directory under:
 
 ```
-~/.aws/amazonq/agents/
+~/.aws/amazonq/cli-agents/
 ```
 
 These agents are available from any directory when using Q CLI.
 
 **Example structure:**
 ```
-~/.aws/amazonq/agents/
+~/.aws/amazonq/cli-agents/
 ├── general-assistant.json
 ├── code-reviewer.json
 └── documentation-writer.json
@@ -46,8 +46,8 @@ These agents are available from any directory when using Q CLI.
 
 When Q CLI looks for an agent, it follows this precedence order:
 
-1. **Local first**: Checks `.aws/amazonq/agents/` in the current working directory
-2. **Global fallback**: If not found locally, checks `~/.aws/amazonq/agents/` in the home directory
+1. **Local first**: Checks `.aws/amazonq/cli-agents/` in the current working directory
+2. **Global fallback**: If not found locally, checks `~/.aws/amazonq/cli-agents/` in the home directory
 
 ## Naming Conflicts
 
@@ -78,8 +78,8 @@ The global agent with the same name will be ignored in favor of the local versio
 To create a local agent for your current project:
 
 ```bash
-mkdir -p .aws/amazonq/agents
-cat > .aws/amazonq/agents/project-helper.json << 'EOF'
+mkdir -p .aws/amazonq/cli-agents
+cat > .aws/amazonq/cli-agents/project-helper.json << 'EOF'
 {
   "description": "Helper agent for this specific project",
   "tools": ["fs_read", "fs_write", "execute_bash"],
@@ -94,8 +94,8 @@ EOF
 To create a global agent available everywhere:
 
 ```bash
-mkdir -p ~/.aws/amazonq/agents
-cat > ~/.aws/amazonq/agents/general-helper.json << 'EOF'
+mkdir -p ~/.aws/amazonq/cli-agents
+cat > ~/.aws/amazonq/cli-agents/general-helper.json << 'EOF'
 {
   "description": "General purpose assistant",
   "tools": ["*"],
@@ -106,4 +106,4 @@ EOF
 
 ## Directory Creation
 
-Q CLI will automatically create the global agents directory (`~/.aws/amazonq/agents/`) if it doesn't exist. However, you need to manually create the local agents directory (`.aws/amazonq/agents/`) in your workspace if you want to use local agents.
+Q CLI will automatically create the global agents directory (`~/.aws/amazonq/cli-agents/`) if it doesn't exist. However, you need to manually create the local agents directory (`.aws/amazonq/cli-agents/`) in your workspace if you want to use local agents.

--- a/docs/agent-format.md
+++ b/docs/agent-format.md
@@ -26,8 +26,6 @@ The `name` field specifies the name of the agent. This is used for identificatio
 }
 ```
 
-Note: While this field can be included in the configuration file, it will be overridden by the filename when the agent is loaded.
-
 ## Description Field
 
 The `description` field provides a description of what the agent does. This is primarily for human readability and helps users distinguish between different agents.

--- a/docs/agent-format.md
+++ b/docs/agent-format.md
@@ -207,15 +207,11 @@ The `hooks` field defines commands to run at specific trigger points. The output
     "agentSpawn": [
       {
         "command": "git status",
-        "timeout_ms": 30000,
-        "max_output_size": 10240,
-        "cache_ttl_seconds": 0
       }
     ],
     "userPromptSubmit": [
       {
         "command": "ls -la",
-        "timeout_ms": 5000
       }
     ]
   }
@@ -224,9 +220,6 @@ The `hooks` field defines commands to run at specific trigger points. The output
 
 Each hook is defined with:
 - `command` (required): The command to execute
-- `timeout_ms` (optional): Maximum execution time in milliseconds (default: 30000)
-- `max_output_size` (optional): Maximum output size in bytes (default: 10240)
-- `cache_ttl_seconds` (optional): How long to cache the output (default: 0)
 
 Available hook triggers:
 - `agentSpawn`: Triggered when the agent is initialized
@@ -294,13 +287,11 @@ Here's a complete example of an agent configuration file:
     "agentSpawn": [
       {
         "command": "git status",
-        "timeout_ms": 30000
       }
     ],
     "userPromptSubmit": [
       {
         "command": "ls -la",
-        "timeout_ms": 5000
       }
     ]
   },

--- a/docs/default-agent-behavior.md
+++ b/docs/default-agent-behavior.md
@@ -95,9 +95,9 @@ q chat --agent specialized-agent
 ```
 
 ### Create a Custom Default
-You can create your own "default" agent by placing a file named `default.json` in either:
-- `.aws/amazonq/agents/default.json` (local)
-- `~/.aws/amazonq/agents/default.json` (global)
+You can create your own "default" agent by placing an agent file with the name `q_cli_default` in either:
+- `.aws/amazonq/cli-agents/` (local)
+- `~/.aws/amazonq/cli-agents/` (global)
 
 This will override the built-in default agent configuration.
 

--- a/docs/legacy-profile-to-agent-migration.md
+++ b/docs/legacy-profile-to-agent-migration.md
@@ -1,0 +1,102 @@
+# Migrating Profiles to Agents
+
+All global profiles (created under `~/.aws/amazonq/profiles/`) support automatic migration to the global agents directory under `~/.aws/amazonq/cli-agents/` on initial startup.
+
+If you have local MCP configuration defined under `.amazonq/mcp.json`, then you can optionally add this configuration to a global agent, or create a new workspace agent.
+
+## Creating a New Workspace Agent
+
+Workspace agents are managed under the current working directory inside `.amazonq/cli-agents/`.
+
+You can create a new workspace agent with `q agent create --name my-agent -d .`.
+
+## Global Context
+
+Global context previously configured under `~/.aws/amazonq/global_context.json` is no longer supported. Global context will need to be manually added to agents (see the below section).
+
+## MCP Servers
+
+The agent configuration supports the same MCP format as previously configured.
+
+See [the agent format documentation for more details](./agent-format.md#mcpservers-field).
+
+## Context Files
+
+Context files are now [file URI's](https://en.wikipedia.org/wiki/File_URI_scheme) and configured under the `"resources"` field.
+
+Example from profiles:
+```json
+{
+    "paths": [
+        "~/my-files/**/*.txt"
+    ]
+}
+```
+
+Same example for agents:
+```json
+{
+    "resources": [
+        "file://~/my-files/**/*.txt"
+    ]
+}
+```
+
+## Hooks
+
+Hook triggers have been updated:
+- Hook name is no longer required
+- `conversation_start` is now `agentSpawn`
+- `per_prompt` is now `userPromptSubmit`
+
+See [the agent format documentation for more details](./agent-format.md#hooks-field).
+
+Example from profiles:
+```json
+{
+    "hooks": {
+        "sleep_conv_start": {
+            "trigger": "conversation_start",
+            "type": "inline",
+            "disabled": false,
+            "timeout_ms": 30000,
+            "max_output_size": 10240,
+            "cache_ttl_seconds": 0,
+            "command": "echo Conversation start hook"
+        },
+        "hello_world": {
+            "trigger": "per_prompt",
+            "type": "inline",
+            "disabled": false,
+            "timeout_ms": 30000,
+            "max_output_size": 10240,
+            "cache_ttl_seconds": 0,
+            "command": "echo Per prompt hook"
+        }
+    }
+}
+```
+
+Same example for agents:
+```json
+{
+    "hooks": {
+        "userPromptSubmit": [
+            {
+                "command": "echo Per prompt hook",
+                "timeout_ms": 30000,
+                "max_output_size": 10240,
+                "cache_ttl_seconds": 0
+            }
+        ],
+        "agentSpawn": [
+            {
+                "command": "echo Conversation start hook",
+                "timeout_ms": 30000,
+                "max_output_size": 10240,
+                "cache_ttl_seconds": 0
+            }
+        ]
+    }
+}
+```

--- a/schemas/agent-v1.json
+++ b/schemas/agent-v1.json
@@ -3,6 +3,21 @@
   "title": "Agent",
   "description": "An Agent is a declarative way of configuring a given instance of q chat.",
   "type": "object",
+  "definitions": {
+    "hookCommands": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "command": {
+            "description": "The command to run when the hook is triggered",
+            "type": "string"
+          }
+        },
+        "required": ["command"]
+      }
+    }
+  },
   "properties": {
     "$schema": {
       "description": "The schema to use for validating the agent",
@@ -14,12 +29,18 @@
     },
     "description": {
       "description": "This field is not model facing and is mostly here for users to discern between agents",
-      "type": ["string", "null"],
+      "type": [
+        "string",
+        "null"
+      ],
       "default": null
     },
     "prompt": {
       "description": "The intention for this field is to provide high level context to the\nagent. This should be seen as the same category of context as a system prompt.",
-      "type": ["string", "null"],
+      "type": [
+        "string",
+        "null"
+      ],
       "default": null
     },
     "mcpServers": {
@@ -42,7 +63,10 @@
           },
           "env": {
             "description": "A list of environment variables to run the command with",
-            "type": ["object", "null"],
+            "type": [
+              "object",
+              "null"
+            ],
             "additionalProperties": {
               "type": "string"
             }
@@ -60,7 +84,9 @@
             "default": false
           }
         },
-        "required": ["command"]
+        "required": [
+          "command"
+        ]
       },
       "default": {}
     },
@@ -106,17 +132,12 @@
     "hooks": {
       "description": "Commands to run when a chat session is created",
       "type": "object",
-      "additionalProperties": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "command": {
-              "description": "The command to run when the hook is triggered",
-              "type": "string"
-            }
-          },
-          "required": ["command"]
+      "properties": {
+        "userPromptSubmit": {
+          "$ref": "#/definitions/hookCommands"
+        },
+        "agentSpawn": {
+          "$ref": "#/definitions/hookCommands"
         }
       },
       "default": {}
@@ -141,5 +162,7 @@
     }
   },
   "additionalProperties": false,
-  "required": ["name"]
+  "required": [
+    "name"
+  ]
 }


### PR DESCRIPTION
- **Update SUMMARY.md**
- **fix: broken link in docs to built-in tools (#2445)**
- **chore: add docs on profile to agent migration (#2446)**
- **Update agent-format.md**
- **fix: compact not being retried correctly**
- **chore: fix references to the agent file location (#2455)**
- **chore: deprecate slash profile subcommand (#2468)**
- **fix(agent): permission reset (#2469)**
- **feat: add schema to agent (#2440)**
- **fix: uses struct discriminates as hash key for native tools (#2470)**
- **chore: bump version to 1.13.1 (#2456)**
- **fix: trust tools arg (#2471)**

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
