### PR TITLE
fix: load workspace MCP config in default agent (#2478)

### DIFF
--- a/crates/chat-cli/src/cli/agent/root_command_args.rs
+++ b/crates/chat-cli/src/cli/agent/root_command_args.rs
@@ -133,7 +133,8 @@ impl AgentArgs {
             },
             Some(AgentSubcommands::Validate { path }) => {
                 let mut global_mcp_config = None::<McpServerConfig>;
-                let agent = Agent::load(os, path.as_str(), &mut global_mcp_config).await;
+                let mut workspace_mcp_config = None::<McpServerConfig>;
+                let agent = Agent::load(os, path.as_str(), &mut global_mcp_config, &mut workspace_mcp_config).await;
 
                 'validate: {
                     match agent {

--- a/crates/chat-cli/src/cli/chat/cli/profile.rs
+++ b/crates/chat-cli/src/cli/chat/cli/profile.rs
@@ -140,7 +140,7 @@ impl AgentSubcommand {
                     return Err(ChatError::Custom("Editor process did not exit with success".into()));
                 }
 
-                let new_agent = Agent::load(os, &path_with_file_name, &mut None).await;
+                let new_agent = Agent::load(os, &path_with_file_name, &mut None, &mut None).await;
                 match new_agent {
                     Ok(agent) => {
                         session.conversation.agents.agents.insert(agent.name.clone(), agent);


### PR DESCRIPTION
The default agent was not loading workspace-specific MCP configuration (.amazonq/mcp.json), only the global config (~/.aws/amazonq/mcp.json). This fix ensures workspace MCP configs are loaded and take precedence over global configs when using the default agent.

*Issue #, if available:*
#2478

*Description of changes:*
- Modified `Agents::load()` to read workspace MCP configuration (`.amazonq/mcp.json`) for the default agent
- Workspace configs now override global configs as expected

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
