### PR TITLE
feat: Add 'q webchat' command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,7 +632,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tower",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -784,6 +784,64 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "rustc_version",
+ "tracing",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "base64 0.22.1",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
+ "sync_wrapper",
+ "tokio",
+ "tokio-tungstenite 0.24.0",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
  "tracing",
 ]
 
@@ -1298,7 +1356,7 @@ dependencies = [
  "thiserror 2.0.12",
  "time",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.26.2",
  "tokio-util",
  "toml",
  "tracing",
@@ -1310,6 +1368,7 @@ dependencies = [
  "url",
  "uuid",
  "walkdir",
+ "web-terminal",
  "webpki-roots 0.26.8",
  "whoami",
  "windows 0.61.3",
@@ -2973,6 +3032,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3630,6 +3695,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3696,6 +3767,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -5150,8 +5231,8 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.2",
  "tokio-util",
- "tower",
- "tower-http",
+ "tower 0.5.2",
+ "tower-http 0.6.6",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -5612,6 +5693,16 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+dependencies = [
+ "itoa",
  "serde",
 ]
 
@@ -6364,6 +6455,30 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.20.1",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.24.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
@@ -6371,7 +6486,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.26.2",
 ]
 
 [[package]]
@@ -6431,6 +6546,17 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
@@ -6442,6 +6568,32 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
+dependencies = [
+ "bitflags 2.9.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -6457,7 +6609,7 @@ dependencies = [
  "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]
@@ -6625,6 +6777,43 @@ dependencies = [
  "nix 0.24.3",
  "term",
  "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 0.2.12",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.3.1",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
 ]
 
 [[package]]
@@ -7096,6 +7285,25 @@ checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-terminal"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "eyre",
+ "futures-util",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite 0.20.1",
+ "tokio-util",
+ "tower 0.4.13",
+ "tower-http 0.4.4",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/chat-cli/Cargo.toml
+++ b/crates/chat-cli/Cargo.toml
@@ -118,6 +118,7 @@ url.workspace = true
 uuid.workspace = true
 walkdir.workspace = true
 webpki-roots.workspace = true
+web-terminal = { path = "../web-terminal" }
 whoami.workspace = true
 winnow.workspace = true
 schemars.workspace = true

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -196,9 +196,6 @@ pub struct ChatArgs {
     /// Whether the command should run without expecting user input
     #[arg(long, alias = "non-interactive")]
     pub no_interactive: bool,
-    /// Start a web server interface for chat
-    #[arg(long)]
-    pub web_server: bool,
     /// The first question to ask
     pub input: Option<String>,
 }

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -195,6 +195,9 @@ pub struct ChatArgs {
     /// Whether the command should run without expecting user input
     #[arg(long, alias = "non-interactive")]
     pub no_interactive: bool,
+    /// Start a web server interface for chat
+    #[arg(long)]
+    pub web_server: bool,
     /// The first question to ask
     pub input: Option<String>,
 }

--- a/crates/chat-cli/src/cli/mod.rs
+++ b/crates/chat-cli/src/cli/mod.rs
@@ -362,6 +362,7 @@ mod test {
                 trust_all_tools: false,
                 trust_tools: None,
                 no_interactive: false,
+                web_server: false,
             })),
             verbose: 2,
             help_all: false,
@@ -401,6 +402,7 @@ mod test {
                 trust_all_tools: false,
                 trust_tools: None,
                 no_interactive: false,
+                web_server: false,
             })
         );
     }
@@ -417,6 +419,7 @@ mod test {
                 trust_all_tools: false,
                 trust_tools: None,
                 no_interactive: false,
+                web_server: false,
             })
         );
     }
@@ -433,6 +436,7 @@ mod test {
                 trust_all_tools: true,
                 trust_tools: None,
                 no_interactive: false,
+                web_server: false,
             })
         );
     }
@@ -449,6 +453,7 @@ mod test {
                 trust_all_tools: false,
                 trust_tools: None,
                 no_interactive: true,
+                web_server: false,
             })
         );
         assert_parse!(
@@ -461,6 +466,7 @@ mod test {
                 trust_all_tools: false,
                 trust_tools: None,
                 no_interactive: true,
+                web_server: false,
             })
         );
     }
@@ -477,6 +483,7 @@ mod test {
                 trust_all_tools: true,
                 trust_tools: None,
                 no_interactive: false,
+                web_server: false,
             })
         );
     }
@@ -493,6 +500,7 @@ mod test {
                 trust_all_tools: false,
                 trust_tools: Some(vec!["".to_string()]),
                 no_interactive: false,
+                web_server: false,
             })
         );
     }
@@ -509,6 +517,24 @@ mod test {
                 trust_all_tools: false,
                 trust_tools: Some(vec!["fs_read".to_string(), "fs_write".to_string()]),
                 no_interactive: false,
+                web_server: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_chat_with_web_server() {
+        assert_parse!(
+            ["chat", "--web-server"],
+            RootSubcommand::Chat(ChatArgs {
+                resume: false,
+                input: None,
+                agent: None,
+                model: None,
+                trust_all_tools: false,
+                trust_tools: None,
+                no_interactive: false,
+                web_server: true,
             })
         );
     }

--- a/crates/chat-cli/src/cli/webchat.rs
+++ b/crates/chat-cli/src/cli/webchat.rs
@@ -1,0 +1,44 @@
+use std::process::ExitCode;
+
+use clap::Args;
+use eyre::Result;
+use tracing::info;
+
+use crate::os::Os;
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Args)]
+pub struct WebchatArgs {
+    /// Port to run the web server on
+    #[arg(short, long, default_value = "8080")]
+    pub port: u16,
+    /// Context profile to use
+    #[arg(long = "agent", alias = "profile")]
+    pub agent: Option<String>,
+    /// Current model to use
+    #[arg(long = "model")]
+    pub model: Option<String>,
+    /// Allows the model to use any tool to run commands without asking for confirmation.
+    #[arg(short = 'a', long)]
+    pub trust_all_tools: bool,
+    /// Trust only this set of tools. Example: trust some tools:
+    /// '--trust-tools=fs_read,fs_write', trust no tools: '--trust-tools='
+    #[arg(long, value_delimiter = ',', value_name = "TOOL_NAMES")]
+    pub trust_tools: Option<Vec<String>>,
+}
+
+impl WebchatArgs {
+    pub async fn execute(self, _os: &mut Os) -> Result<ExitCode> {
+        info!("Starting webchat on port {}", self.port);
+        
+        // Convert webchat args to chat args for compatibility
+        let chat_args = vec![
+            "q".to_string(),
+            "chat".to_string(),
+        ];
+        
+        // Start the web terminal server
+        web_terminal::start_web_server(self.port, chat_args).await?;
+        
+        Ok(ExitCode::SUCCESS)
+    }
+}

--- a/crates/web-terminal/Cargo.toml
+++ b/crates/web-terminal/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "web-terminal"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1.0", features = ["full"] }
+tokio-tungstenite = "0.20"
+futures-util = "0.3"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+uuid = { version = "1.0", features = ["v4"] }
+tracing = "0.1"
+tracing-subscriber = "0.3"
+tower = "0.4"
+tower-http = { version = "0.4", features = ["fs", "cors"] }
+axum = { version = "0.7", features = ["ws"] }
+tokio-util = { version = "0.7", features = ["codec"] }
+eyre = "0.6"

--- a/crates/web-terminal/src/lib.rs
+++ b/crates/web-terminal/src/lib.rs
@@ -1,0 +1,427 @@
+use axum::{
+    extract::{ws::WebSocket, WebSocketUpgrade},
+    response::{Html, IntoResponse},
+    routing::get,
+    Router,
+};
+use futures_util::{sink::SinkExt, stream::StreamExt};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::HashMap,
+    env,
+    process::Stdio,
+};
+use tokio::{
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+    process::{Child, Command},
+    sync::mpsc,
+    time::{timeout, Duration},
+};
+use tracing::{error, info};
+use uuid::Uuid;
+
+// Function to strip non-ASCII characters and ANSI escape sequences
+fn sanitize_output(input: &str) -> String {
+    let mut result = String::new();
+    let mut chars = input.chars().peekable();
+    
+    while let Some(ch) = chars.next() {
+        match ch {
+            // Handle ANSI escape sequences - skip them entirely
+            '\x1b' => {
+                if chars.peek() == Some(&'[') {
+                    chars.next(); // consume '['
+                    // Skip the entire ANSI sequence
+                    while let Some(next_ch) = chars.next() {
+                        if next_ch.is_ascii_alphabetic() {
+                            break;
+                        }
+                    }
+                }
+                // Don't add anything to result - just skip
+            }
+            // Keep only ASCII printable characters, tabs, newlines, and carriage returns
+            c if c.is_ascii() && (c.is_ascii_graphic() || c == ' ' || c == '\t' || c == '\n' || c == '\r') => {
+                result.push(c);
+            }
+            // Skip all other characters (non-ASCII and control characters)
+            _ => {}
+        }
+    }
+    
+    result
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+enum Message {
+    #[serde(rename = "command")]
+    Command { data: String },
+    #[serde(rename = "output")]
+    Output { data: String },
+    #[serde(rename = "error")]
+    Error { data: String },
+    #[serde(rename = "exit")]
+    Exit { code: i32 },
+}
+
+#[derive(Debug)]
+struct Terminal {
+    id: String,
+    shell_process: Option<Child>,
+    current_dir: String,
+    env_vars: HashMap<String, String>,
+}
+
+impl Terminal {
+    fn new() -> Self {
+        let mut env_vars = HashMap::new();
+        for (key, value) in env::vars() {
+            env_vars.insert(key, value);
+        }
+        
+        Self {
+            id: Uuid::new_v4().to_string(),
+            shell_process: None,
+            current_dir: env::current_dir()
+                .unwrap_or_else(|_| "/".into())
+                .to_string_lossy()
+                .to_string(),
+            env_vars,
+        }
+    }
+
+    fn get_prompt(&self) -> String {
+        let username = self.env_vars.get("USER")
+            .or_else(|| self.env_vars.get("USERNAME"))
+            .map(|s| s.as_str())
+            .unwrap_or("user");
+        
+        let hostname = self.env_vars.get("HOSTNAME")
+            .or_else(|| self.env_vars.get("COMPUTERNAME"))
+            .map(|s| s.as_str())
+            .unwrap_or("localhost");
+        
+        let home_dir = self.env_vars.get("HOME")
+            .map(|s| s.as_str())
+            .unwrap_or("/");
+            
+        let current_dir = if self.current_dir == home_dir {
+            "~".to_string()
+        } else if self.current_dir.starts_with(home_dir) {
+            format!("~{}", &self.current_dir[home_dir.len()..])
+        } else {
+            self.current_dir.clone()
+        };
+        
+        format!("{}@{} [Q]:{}", username, hostname, current_dir)
+    }
+
+    async fn start_shell(&mut self, chat_args: Vec<String>) -> Result<(mpsc::Sender<String>, mpsc::Receiver<String>), String> {
+        // Start Q chat process with provided arguments
+        let mut cmd = Command::new("q");
+        cmd.args(["chat"]);
+        
+        // Add any additional chat arguments
+        for arg in chat_args {
+            cmd.arg(arg);
+        }
+        
+        let mut child = cmd
+            .current_dir(&self.current_dir)
+            .envs(&self.env_vars)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| format!("Failed to start Q chat: {}", e))?;
+
+        let stdin = child.stdin.take().ok_or("Failed to get stdin")?;
+        let stdout = child.stdout.take().ok_or("Failed to get stdout")?;
+        let stderr = child.stderr.take().ok_or("Failed to get stderr")?;
+
+        // Create channels for communication
+        let (cmd_tx, mut cmd_rx) = mpsc::channel::<String>(100);
+        let (output_tx, output_rx) = mpsc::channel::<String>(100);
+
+        // Store the child process
+        self.shell_process = Some(child);
+
+        // Spawn task to handle stdin (commands to Q chat)
+        let output_tx_stdin = output_tx.clone();
+        tokio::spawn(async move {
+            let mut stdin = stdin;
+            while let Some(command) = cmd_rx.recv().await {
+                // Send the command to Q chat
+                if let Err(e) = stdin.write_all(format!("{}\n", command).as_bytes()).await {
+                    let _ = output_tx_stdin.send(format!("Error writing to Q chat: {}", e)).await;
+                    break;
+                }
+                if let Err(e) = stdin.flush().await {
+                    let _ = output_tx_stdin.send(format!("Error flushing Q chat input: {}", e)).await;
+                    break;
+                }
+            }
+        });
+
+        // Spawn task to handle stdout (responses from Q chat)
+        let output_tx_stdout = output_tx.clone();
+        tokio::spawn(async move {
+            let mut reader = BufReader::new(stdout);
+            let mut buffer = Vec::new();
+            
+            loop {
+                buffer.clear();
+                match timeout(Duration::from_secs(30), reader.read_until(b'\n', &mut buffer)).await {
+                    Ok(Ok(0)) => break, // EOF
+                    Ok(Ok(_)) => {
+                        if let Ok(line) = String::from_utf8(buffer.clone()) {
+                            // Sanitize the output before sending to browser
+                            let sanitized_line = sanitize_output(&line);
+                            if let Err(_) = output_tx_stdout.send(sanitized_line).await {
+                                break;
+                            }
+                        }
+                    }
+                    Ok(Err(e)) => {
+                        let _ = output_tx_stdout.send(format!("Error reading from Q chat: {}", e)).await;
+                        break;
+                    }
+                    Err(_) => {
+                        // Timeout - Q chat might be thinking, continue waiting
+                        continue;
+                    }
+                }
+            }
+        });
+
+        // Spawn task to handle stderr (errors from Q chat)
+        tokio::spawn(async move {
+            let mut reader = BufReader::new(stderr);
+            let mut buffer = Vec::new();
+            
+            loop {
+                buffer.clear();
+                match timeout(Duration::from_secs(5), reader.read_until(b'\n', &mut buffer)).await {
+                    Ok(Ok(0)) => break, // EOF
+                    Ok(Ok(_)) => {
+                        if let Ok(line) = String::from_utf8(buffer.clone()) {
+                            if !line.trim().is_empty() {
+                                // Sanitize error output and send without prefix
+                                let sanitized_line = sanitize_output(&line);
+                                let _ = output_tx.send(sanitized_line).await;
+                            }
+                        }
+                    }
+                    Ok(Err(e)) => {
+                        let _ = output_tx.send(format!("Error reading Q chat stderr: {}", e)).await;
+                        break;
+                    }
+                    Err(_) => {
+                        // Timeout - continue reading
+                        continue;
+                    }
+                }
+            }
+        });
+
+        Ok((cmd_tx, output_rx))
+    }
+
+    async fn handle_builtin_command(&mut self, command: &str) -> Option<Result<String, String>> {
+        let parts: Vec<&str> = command.split_whitespace().collect();
+        if parts.is_empty() {
+            return Some(Ok(String::new()));
+        }
+
+        match parts[0] {
+            "cd" => {
+                let target_dir = if parts.len() > 1 {
+                    parts[1].to_string()
+                } else {
+                    // Default to home directory
+                    self.env_vars.get("HOME").unwrap_or(&"/".to_string()).clone()
+                };
+
+                match self.change_directory(&target_dir) {
+                    Ok(_) => Some(Ok(String::new())),
+                    Err(e) => Some(Err(format!("cd: {}", e))),
+                }
+            }
+            "pwd" => Some(Ok(format!("{}\n", self.current_dir))),
+            "export" => {
+                if parts.len() > 1 {
+                    for part in &parts[1..] {
+                        if let Some((key, value)) = part.split_once('=') {
+                            self.env_vars.insert(key.to_string(), value.to_string());
+                        }
+                    }
+                }
+                Some(Ok(String::new()))
+            }
+            _ => None, // Not a builtin command
+        }
+    }
+
+    fn change_directory(&mut self, path: &str) -> Result<(), String> {
+        let new_path = if path.starts_with('/') {
+            // Absolute path
+            std::path::PathBuf::from(path)
+        } else if path.starts_with("~/") {
+            // Home directory relative path
+            let home = self.env_vars.get("HOME").ok_or("HOME not set")?;
+            std::path::PathBuf::from(home).join(&path[2..])
+        } else if path == "~" {
+            // Just home directory
+            let home = self.env_vars.get("HOME").ok_or("HOME not set")?;
+            std::path::PathBuf::from(home)
+        } else {
+            // Relative path
+            std::path::PathBuf::from(&self.current_dir).join(path)
+        };
+
+        let canonical_path = new_path.canonicalize()
+            .map_err(|e| format!("No such file or directory: {}", e))?;
+
+        if !canonical_path.is_dir() {
+            return Err("Not a directory".to_string());
+        }
+
+        self.current_dir = canonical_path.to_string_lossy().to_string();
+        Ok(())
+    }
+}
+
+async fn websocket_handler(ws: WebSocketUpgrade) -> impl IntoResponse {
+    ws.on_upgrade(handle_socket)
+}
+
+async fn handle_socket(socket: WebSocket) {
+    let mut terminal = Terminal::new();
+    let (sender, mut receiver) = socket.split();
+    let sender = std::sync::Arc::new(tokio::sync::Mutex::new(sender));
+    
+    // Start the Q chat shell with default arguments
+    let (cmd_tx, mut output_rx) = match terminal.start_shell(vec![]).await {
+        Ok((tx, rx)) => (tx, rx),
+        Err(e) => {
+            error!("Failed to start shell: {}", e);
+            let mut sender_guard = sender.lock().await;
+            let _ = sender_guard.send(axum::extract::ws::Message::Text(
+                serde_json::to_string(&Message::Error { 
+                    data: format!("Failed to start Q chat: {}", e) 
+                }).unwrap()
+            )).await;
+            return;
+        }
+    };
+
+    // Send initial prompt
+    let initial_prompt = terminal.get_prompt();
+    {
+        let mut sender_guard = sender.lock().await;
+        let _ = sender_guard.send(axum::extract::ws::Message::Text(
+            serde_json::to_string(&Message::Output { 
+                data: format!("{} $ ", initial_prompt) 
+            }).unwrap()
+        )).await;
+    }
+
+    // Spawn task to handle output from Q chat
+    let sender_clone = sender.clone();
+    tokio::spawn(async move {
+        while let Some(output) = output_rx.recv().await {
+            let message = Message::Output { data: output };
+            if let Ok(json) = serde_json::to_string(&message) {
+                let mut sender_guard = sender_clone.lock().await;
+                if sender_guard.send(axum::extract::ws::Message::Text(json)).await.is_err() {
+                    break;
+                }
+            }
+        }
+    });
+
+    // Handle incoming WebSocket messages
+    while let Some(msg) = receiver.next().await {
+        match msg {
+            Ok(axum::extract::ws::Message::Text(text)) => {
+                if let Ok(message) = serde_json::from_str::<Message>(&text) {
+                    match message {
+                        Message::Command { data } => {
+                            // Check for builtin commands first
+                            if let Some(result) = terminal.handle_builtin_command(&data).await {
+                                match result {
+                                    Ok(output) => {
+                                        if !output.is_empty() {
+                                            let msg = Message::Output { data: output };
+                                            if let Ok(json) = serde_json::to_string(&msg) {
+                                                let mut sender_guard = sender.lock().await;
+                                                let _ = sender_guard.send(axum::extract::ws::Message::Text(json)).await;
+                                            }
+                                        }
+                                        // Send new prompt
+                                        let prompt = terminal.get_prompt();
+                                        let msg = Message::Output { data: format!("{} $ ", prompt) };
+                                        if let Ok(json) = serde_json::to_string(&msg) {
+                                            let mut sender_guard = sender.lock().await;
+                                            let _ = sender_guard.send(axum::extract::ws::Message::Text(json)).await;
+                                        }
+                                    }
+                                    Err(error) => {
+                                        let msg = Message::Error { data: error };
+                                        if let Ok(json) = serde_json::to_string(&msg) {
+                                            let mut sender_guard = sender.lock().await;
+                                            let _ = sender_guard.send(axum::extract::ws::Message::Text(json)).await;
+                                        }
+                                        // Send new prompt even after error
+                                        let prompt = terminal.get_prompt();
+                                        let msg = Message::Output { data: format!("{} $ ", prompt) };
+                                        if let Ok(json) = serde_json::to_string(&msg) {
+                                            let mut sender_guard = sender.lock().await;
+                                            let _ = sender_guard.send(axum::extract::ws::Message::Text(json)).await;
+                                        }
+                                    }
+                                }
+                            } else {
+                                // Send command to Q chat
+                                if cmd_tx.send(data).await.is_err() {
+                                    break;
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            Ok(axum::extract::ws::Message::Close(_)) => {
+                info!("WebSocket connection closed");
+                break;
+            }
+            Err(e) => {
+                error!("WebSocket error: {}", e);
+                break;
+            }
+            _ => {}
+        }
+    }
+}
+
+async fn index_handler() -> Html<&'static str> {
+    Html(include_str!("../static/index.html"))
+}
+
+pub async fn start_web_server(port: u16, _chat_args: Vec<String>) -> eyre::Result<()> {
+    info!("Starting web terminal server on port {}", port);
+    
+    let app = Router::new()
+        .route("/", get(index_handler))
+        .route("/ws", get(websocket_handler));
+
+    let listener = tokio::net::TcpListener::bind(format!("127.0.0.1:{}", port)).await?;
+    
+    info!("Web terminal available at http://127.0.0.1:{}", port);
+    
+    axum::serve(listener, app).await?;
+    
+    Ok(())
+}

--- a/crates/web-terminal/static/index.html
+++ b/crates/web-terminal/static/index.html
@@ -1,0 +1,688 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Amazon Q webchat</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Courier New', monospace;
+            background-color: #0c0c0c;
+            color: #ffffff;
+            height: 100vh;
+            overflow: hidden;
+        }
+
+        .terminal-container {
+            height: 100vh;
+            display: flex;
+            flex-direction: column;
+            background-color: #0c0c0c;
+        }
+
+        .terminal-header {
+            background-color: #1e1e1e;
+            padding: 8px 15px;
+            border-bottom: 1px solid #333;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            font-size: 12px;
+        }
+
+        .terminal-title {
+            color: #cccccc;
+            font-size: 12px;
+            font-weight: normal;
+        }
+
+        .connection-status {
+            margin-left: auto;
+            padding: 3px 8px;
+            border-radius: 3px;
+            font-size: 10px;
+            font-weight: bold;
+        }
+
+        .connected {
+            background-color: #ff8c00;
+            color: #000;
+        }
+
+        .disconnected {
+            background-color: #ff5f57;
+            color: #fff;
+        }
+
+        .connecting {
+            background-color: #ffbd2e;
+            color: #000;
+        }
+
+        .terminal-content {
+            flex: 1;
+            padding: 15px;
+            overflow-y: auto;
+            font-size: 14px;
+            line-height: 1.4;
+            background-color: #0c0c0c;
+            position: relative;
+            padding-bottom: 80px; /* Space for search bar */
+        }
+
+        .conversation-entry {
+            margin-bottom: 10px;
+            padding-bottom: 5px;
+        }
+
+        .conversation-entry:last-child {
+            border-bottom: none;
+        }
+
+        .user-input {
+            color: #4CAF50;
+            font-weight: bold;
+            margin-bottom: 8px;
+        }
+
+        .user-input::before {
+            content: "You: ";
+            color: #4CAF50;
+        }
+
+        .ai-response {
+            color: #cccccc;
+            white-space: pre-wrap;
+            word-wrap: break-word;
+            margin-left: 0;
+            line-height: 1.2;
+            margin-bottom: 0;
+        }
+
+        .status-message {
+            color: #888;
+            font-style: italic;
+            margin: 10px 0;
+        }
+
+        .error-text {
+            color: #ff6b6b;
+            white-space: pre-wrap;
+            word-wrap: break-word;
+            margin-left: 0;
+        }
+
+        .search-container {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            background-color: #1e1e1e;
+            border-top: 1px solid #333;
+            padding: 15px;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+
+        .search-input {
+            flex: 1;
+            background-color: #0c0c0c;
+            border: 1px solid #333;
+            border-radius: 6px;
+            color: #ffffff;
+            font-family: 'Courier New', monospace;
+            font-size: 14px;
+            padding: 12px 15px;
+            outline: none;
+            transition: border-color 0.2s;
+        }
+
+        .search-input:focus {
+            border-color: #ff8c00;
+        }
+
+        .search-input::placeholder {
+            color: #666;
+        }
+
+        .send-button {
+            background-color: #ff8c00;
+            border: none;
+            border-radius: 6px;
+            color: #000;
+            font-weight: bold;
+            padding: 12px 20px;
+            cursor: pointer;
+            font-size: 14px;
+            transition: background-color 0.2s;
+        }
+
+        .send-button:hover {
+            background-color: #e67e00;
+        }
+
+        .send-button:disabled {
+            background-color: #333;
+            color: #666;
+            cursor: not-allowed;
+        }
+
+        /* Scrollbar styling */
+        .terminal-content::-webkit-scrollbar {
+            width: 8px;
+        }
+
+        .terminal-content::-webkit-scrollbar-track {
+            background: #1e1e1e;
+        }
+
+        .terminal-content::-webkit-scrollbar-thumb {
+            background: #555;
+            border-radius: 4px;
+        }
+
+        .terminal-content::-webkit-scrollbar-thumb:hover {
+            background: #777;
+        }
+
+        /* Cursor animation */
+        @keyframes blink {
+            0%, 50% { opacity: 1; }
+            51%, 100% { opacity: 0; }
+        }
+
+        .cursor {
+            animation: blink 1s infinite;
+            background-color: #ffffff;
+            width: 8px;
+            height: 16px;
+            display: inline-block;
+            margin-left: 2px;
+        }
+
+        /* Hide input when disabled */
+        .terminal-input:disabled {
+            display: none;
+        }
+
+        .session-ended {
+            color: #ff6b6b;
+            font-style: italic;
+            margin-top: 10px;
+        }
+    </style>
+</head>
+<body>
+    <div class="terminal-container">
+        <div class="terminal-header">
+            <div class="terminal-title">Amazon Q webchat</div>
+            <div id="connectionStatus" class="connection-status connecting">Connecting...</div>
+        </div>
+
+        <div id="terminalContent" class="terminal-content">
+            <!-- ASCII Art Banner -->
+            <div class="ai-response" style="color: #4CAF50; font-family: monospace; white-space: pre; margin-bottom: 10px;">    ⢠⣶⣶⣦⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣤⣶⣿⣿⣿⣶⣦⡀⠀
+ ⠀⠀⠀⣾⡿⢻⣿⡆⠀⠀⠀⢀⣄⡄⢀⣠⣤⣤⡀⢀⣠⣤⣤⡀⠀⠀⢀⣠⣤⣤⣤⣄⠀⠀⢀⣤⣤⣤⣤⣤⣤⡀⠀⠀⣀⣤⣤⣤⣀⠀⠀⠀⢠⣤⡀⣀⣤⣤⣄⡀⠀⠀⠀⠀⠀⠀⢠⣿⣿⠋⠀⠀⠀⠙⣿⣿⡆
+ ⠀⠀⣼⣿⠇⠀⣿⣿⡄⠀⠀⢸⣿⣿⠛⠉⠻⣿⣿⠛⠉⠛⣿⣿⠀⠀⠘⠛⠉⠉⠻⣿⣧⠀⠈⠛⠛⠛⣻⣿⡿⠀⢀⣾⣿⠛⠉⠻⣿⣷⡀⠀⢸⣿⡟⠛⠉⢻⣿⣷⠀⠀⠀⠀⠀⠀⣼⣿⡏⠀⠀⠀⠀⠀⢸⣿⣿
+ ⠀⢰⣿⣿⣤⣤⣼⣿⣷⠀⠀⢸⣿⣿⠀⠀⠀⣿⣿⠀⠀⠀⣿⣿⠀⠀⢀⣴⣶⣶⣶⣿⣿⠀⠀⠀⣠⣾⡿⠋⠀⠀⢸⣿⣿⠀⠀⠀⣿⣿⡇⠀⢸⣿⡇⠀⠀⢸⣿⣿⠀⠀⠀⠀⠀⠀⢹⣿⣇⠀⠀⠀⠀⠀⢸⣿⡿
+ ⢀⣿⣿⠋⠉⠉⠉⢻⣿⣇⠀⢸⣿⣿⠀⠀⠀⣿⣿⠀⠀⠀⣿⣿⠀⠀⣿⣿⡀⠀⣠⣿⣿⠀⢀⣴⣿⣋⣀⣀⣀⡀⠘⣿⣿⣄⣀⣠⣿⣿⠃⠀⢸⣿⡇⠀⠀⢸⣿⣿⠀⠀⠀⠀⠀⠀⠈⢿⣿⣦⣀⣀⣀⣴⣿⡿⠃
+ ⠚⠛⠋⠀⠀⠀⠀⠘⠛⠛⠀⠘⠛⠛⠀⠀⠀⠛⠛⠀⠀⠀⠛⠛⠀⠀⠙⠻⠿⠟⠋⠛⠛⠀⠘⠛⠛⠛⠛⠛⠛⠃⠀⠈⠛⠿⠿⠿⠛⠁⠀⠀⠘⠛⠃⠀⠀⠘⠛⠛⠀⠀⠀⠀⠀⠀⠀⠀⠙⠛⠿⢿⣿⣿⣋⠀⠀
+ ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠛⠿⢿⡧</div>
+            <div class="ai-response" style="color: #4CAF50; margin-bottom: 15px;">Welcome to Amazon Q webchat!</div>
+            <div class="ai-response" style="color: #cccccc; margin-bottom: 15px;">Ask me anything using the search bar below. I can help with AWS services, coding, troubleshooting, and more.</div>
+            <!-- Conversation entries will be added here dynamically -->
+        </div>
+
+        <div class="search-container">
+            <input type="text" id="searchInput" class="search-input" placeholder="Ask Amazon Q anything..." autocomplete="off" spellcheck="false">
+            <button id="sendButton" class="send-button">Send</button>
+        </div>
+    </div>
+
+    <script>
+        class WebTerminal {
+            constructor() {
+                this.socket = null;
+                this.content = document.getElementById('terminalContent');
+                this.searchInput = document.getElementById('searchInput');
+                this.sendButton = document.getElementById('sendButton');
+                this.status = document.getElementById('connectionStatus');
+                this.commandHistory = [];
+                this.historyIndex = -1;
+                this.currentCommand = '';
+                this.waitingForResponse = false;
+                this.startupPhase = true; // Track if we're still in startup phase
+
+                this.connect();
+                this.setupEventListeners();
+            }
+
+            connect() {
+                const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+                const wsUrl = `${protocol}//${window.location.host}/ws`;
+
+                this.updateStatus('connecting', 'Connecting...');
+
+                this.socket = new WebSocket(wsUrl);
+
+                this.socket.onopen = () => {
+                    this.updateStatus('connected', 'Connected');
+                    this.searchInput.focus();
+                };
+
+                this.socket.onmessage = (event) => {
+                    try {
+                        const message = JSON.parse(event.data);
+                        this.handleMessage(message);
+                    } catch (e) {
+                        console.error('Failed to parse message:', e);
+                    }
+                };
+
+                this.socket.onclose = () => {
+                    this.updateStatus('disconnected', 'Disconnected');
+                    // Attempt to reconnect after 3 seconds
+                    setTimeout(() => this.connect(), 3000);
+                };
+
+                this.socket.onerror = (error) => {
+                    console.error('WebSocket error:', error);
+                    this.updateStatus('disconnected', 'Connection Error');
+                };
+            }
+
+            updateStatus(status, text) {
+                this.status.className = `connection-status ${status}`;
+                this.status.textContent = text;
+            }
+
+            handleMessage(message) {
+                switch (message.type) {
+                    case 'output':
+                        this.handleOutput(message.data);
+                        break;
+                    case 'error':
+                        this.addErrorMessage(message.data);
+                        this.enableInput();
+                        break;
+                    case 'exit':
+                        this.handleExit();
+                        break;
+                }
+            }
+
+            handleOutput(data) {
+                // Clean up MCP server initialization messages
+                const cleanedData = this.cleanMCPMessage(data);
+
+                // Skip if message was completely filtered out
+                if (!cleanedData) {
+                    return;
+                }
+
+                // Check if output contains 'Allow this action' - special handling
+                if (cleanedData.includes('Allow this action')) {
+                    this.addPermissionPrompt(cleanedData);
+                    this.enableInput();
+                    return;
+                }
+
+                // Check if this is a prompt (ends with $ )
+                if (cleanedData.match(/.*\$ $/)) {
+                    // If we're in startup phase, filter out shell prompts
+                    if (this.startupPhase) {
+                        return; // Skip shell prompts during startup
+                    }
+                    // After startup, ignore prompts in search bar mode
+                    this.enableInput();
+                    return;
+                }
+
+                // If we get meaningful content, we're past startup phase
+                if (cleanedData.trim() !== '' && !this.isStartupMessage(cleanedData)) {
+                    this.startupPhase = false;
+                }
+
+                if (cleanedData.trim() !== '') {
+                    // Add AI response to conversation
+                    this.addAIResponse(cleanedData);
+                }
+
+                this.enableInput();
+                this.scrollToBottom();
+            }
+
+            isStartupMessage(data) {
+                // Check if this is still a startup/initialization message
+                const startupPatterns = [
+                    /connected to mcp/i,
+                    /loading/i,
+                    /initializing/i,
+                    /starting/i,
+                    /server/i,
+                    /mcp/i
+                ];
+
+                return startupPatterns.some(pattern => pattern.test(data));
+            }
+
+            cleanMCPMessage(data) {
+                // Remove non-ASCII characters (keep only printable ASCII)
+                let cleaned = data.replace(/[^\x20-\x7E\n\r\t]/g, '');
+
+                // Remove excessive newlines (more than 2 consecutive)
+                cleaned = cleaned.replace(/\n{3,}/g, '\n\n');
+
+                // Remove leading/trailing whitespace
+                cleaned = cleaned.trim();
+
+                // Filter out pure numeric strings or very short meaningless strings
+                if (/^\d+$/.test(cleaned) || cleaned.length < 3) {
+                    return null; // Filter out completely
+                }
+
+                // During startup, be more aggressive about filtering numeric/garbage strings
+                if (this.startupPhase) {
+                    // Filter strings that are mostly numbers with some non-letters
+                    if (/^\d{4,}/.test(cleaned)) { // 4+ consecutive digits at start
+                        return null;
+                    }
+                    
+                    // Filter strings with high ratio of numbers to letters
+                    const digitCount = (cleaned.match(/\d/g) || []).length;
+                    const letterCount = (cleaned.match(/[a-zA-Z]/g) || []).length;
+                    if (digitCount > letterCount && digitCount > 3) {
+                        return null;
+                    }
+                    
+                    // Filter out [Q] messages during startup
+                    if (/\[Q\]/i.test(cleaned)) {
+                        return null;
+                    }
+                    
+                    // Filter out other Q-related startup messages
+                    if (/^\[.*Q.*\]/i.test(cleaned)) {
+                        return null;
+                    }
+                }
+
+                // Filter out shell prompts (both during startup and after responses)
+                if (this.isShellPrompt(cleaned)) {
+                    return null; // Filter out completely
+                }
+
+                // Remove timestamp patterns at the beginning
+                cleaned = cleaned.replace(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[^\s]*\s*/, '');
+
+                // Remove debug/log level prefixes but keep the message
+                cleaned = cleaned.replace(/^(DEBUG|INFO|WARN|ERROR):\s*/i, '');
+
+                return cleaned.trim();
+            }
+
+            isShellPrompt(data) {
+                // Detect various shell prompt patterns
+                const shellPromptPatterns = [
+                    /^[a-zA-Z0-9_-]+@[a-zA-Z0-9_.-]+.*\[Q\].*\$\s*$/,  // username@hostname [Q] $
+                    /^[a-zA-Z0-9_-]+@[a-zA-Z0-9_.-]+.*\$\s*$/,         // username@hostname $
+                    /^[a-zA-Z0-9_-]+@[a-zA-Z0-9_.-]+.*>\s*$/,          // username@hostname >
+                    /^[a-zA-Z0-9_-]+@[a-zA-Z0-9_.-]+.*#\s*$/,          // username@hostname #
+                    /^\$\s*$/,                                          // Just $
+                    /^.*\$\s*Q-Chat>\s*$/,                              // Our custom prompt
+                    /^.*\$\s*$/                                         // Any path ending with $
+                ];
+
+                return shellPromptPatterns.some(pattern => pattern.test(data.trim()));
+            }
+
+            addConversationEntry(userInput, aiResponse = null, isError = false) {
+                const entry = document.createElement('div');
+                entry.className = 'conversation-entry';
+
+                // Add user input
+                const userDiv = document.createElement('div');
+                userDiv.className = 'user-input';
+                userDiv.textContent = userInput;
+                entry.appendChild(userDiv);
+
+                // Add AI response if provided
+                if (aiResponse) {
+                    const aiDiv = document.createElement('div');
+                    aiDiv.className = isError ? 'error-text' : 'ai-response';
+                    aiDiv.textContent = aiResponse;
+                    entry.appendChild(aiDiv);
+                }
+
+                this.content.appendChild(entry);
+                this.scrollToBottom();
+
+                return entry;
+            }
+
+            addAIResponse(response) {
+                // Find the last conversation entry and add response to it
+                const lastEntry = this.content.querySelector('.conversation-entry:last-child');
+                if (lastEntry && !lastEntry.querySelector('.ai-response, .error-text')) {
+                    const aiDiv = document.createElement('div');
+                    aiDiv.className = 'ai-response';
+                    // Remove trailing newlines and extra whitespace
+                    aiDiv.textContent = response.replace(/\n+$/, '').replace(/\n\n+/g, '\n');
+                    lastEntry.appendChild(aiDiv);
+                } else {
+                    // Create new entry with just AI response (shouldn't normally happen)
+                    const entry = document.createElement('div');
+                    entry.className = 'conversation-entry';
+
+                    const aiDiv = document.createElement('div');
+                    aiDiv.className = 'ai-response';
+                    // Remove trailing newlines and extra whitespace
+                    aiDiv.textContent = response.replace(/\n+$/, '').replace(/\n\n+/g, '\n');
+                    entry.appendChild(aiDiv);
+
+                    this.content.appendChild(entry);
+                }
+
+                this.scrollToBottom();
+            }
+
+            addErrorMessage(error) {
+                const lastEntry = this.content.querySelector('.conversation-entry:last-child');
+                if (lastEntry && !lastEntry.querySelector('.ai-response, .error-text')) {
+                    const errorDiv = document.createElement('div');
+                    errorDiv.className = 'error-text';
+                    errorDiv.textContent = error;
+                    lastEntry.appendChild(errorDiv);
+                } else {
+                    // Create new entry with just error
+                    const entry = document.createElement('div');
+                    entry.className = 'conversation-entry';
+
+                    const errorDiv = document.createElement('div');
+                    errorDiv.className = 'error-text';
+                    errorDiv.textContent = error;
+                    entry.appendChild(errorDiv);
+
+                    this.content.appendChild(entry);
+                }
+
+                this.scrollToBottom();
+            }
+
+            addPermissionPrompt(prompt) {
+                // Add permission prompt as a special AI response
+                const entry = document.createElement('div');
+                entry.className = 'conversation-entry';
+
+                const promptDiv = document.createElement('div');
+                promptDiv.className = 'ai-response';
+                promptDiv.textContent = prompt;
+                entry.appendChild(promptDiv);
+
+                this.content.appendChild(entry);
+                this.searchInput.placeholder = "Type your response (y/n)...";
+                this.scrollToBottom();
+            }
+
+            addStatusMessage(message) {
+                const statusDiv = document.createElement('div');
+                statusDiv.className = 'status-message';
+                statusDiv.textContent = message;
+
+                // Add to last conversation entry if it exists
+                const lastEntry = this.content.querySelector('.conversation-entry:last-child');
+                if (lastEntry) {
+                    lastEntry.appendChild(statusDiv);
+                } else {
+                    this.content.appendChild(statusDiv);
+                }
+
+                this.scrollToBottom();
+            }
+
+            setupEventListeners() {
+                // Search input event listeners
+                this.searchInput.addEventListener('keydown', (e) => {
+                    switch (e.key) {
+                        case 'Enter':
+                            e.preventDefault();
+                            this.executeCommand();
+                            break;
+                        case 'ArrowUp':
+                            e.preventDefault();
+                            this.navigateHistory(-1);
+                            break;
+                        case 'ArrowDown':
+                            e.preventDefault();
+                            this.navigateHistory(1);
+                            break;
+                    }
+                });
+
+                // Send button click
+                this.sendButton.addEventListener('click', () => {
+                    this.executeCommand();
+                });
+
+                // Keep input focused
+                document.addEventListener('click', (e) => {
+                    if (!e.target.closest('.search-container')) {
+                        this.searchInput.focus();
+                    }
+                });
+
+                // Handle window resize
+                window.addEventListener('resize', () => {
+                    this.scrollToBottom();
+                });
+            }
+
+            executeCommand() {
+                const command = this.searchInput.value.trim();
+
+                if (!command || this.waitingForResponse) return;
+
+                // Add to history
+                if (command) {
+                    this.commandHistory.push(command);
+                    if (this.commandHistory.length > 1000) {
+                        this.commandHistory.shift();
+                    }
+                }
+
+                this.historyIndex = -1;
+                this.currentCommand = '';
+
+                // Create conversation entry with user input
+                const entry = this.addConversationEntry(command);
+
+                // Add status message
+                this.addStatusMessage('Sending to Q...');
+
+                // Clear input and disable
+                this.searchInput.value = '';
+                this.disableInput();
+
+                // Send command to server
+                this.sendCommand(command);
+
+                this.scrollToBottom();
+            }
+
+            sendCommand(command) {
+                if (this.socket && this.socket.readyState === WebSocket.OPEN) {
+                    const message = {
+                        type: 'command',
+                        data: command
+                    };
+                    this.socket.send(JSON.stringify(message));
+                }
+            }
+
+            navigateHistory(direction) {
+                if (this.commandHistory.length === 0) return;
+
+                // Save current input if we're at the bottom
+                if (this.historyIndex === -1) {
+                    this.currentCommand = this.searchInput.value;
+                }
+
+                this.historyIndex += direction;
+
+                // Clamp to valid range
+                if (this.historyIndex < -1) {
+                    this.historyIndex = -1;
+                } else if (this.historyIndex >= this.commandHistory.length) {
+                    this.historyIndex = this.commandHistory.length - 1;
+                }
+
+                // Update input
+                if (this.historyIndex === -1) {
+                    this.searchInput.value = this.currentCommand;
+                } else {
+                    this.searchInput.value = this.commandHistory[this.commandHistory.length - 1 - this.historyIndex];
+                }
+
+                // Move cursor to end
+                this.searchInput.setSelectionRange(this.searchInput.value.length, this.searchInput.value.length);
+            }
+
+            disableInput() {
+                this.waitingForResponse = true;
+                this.searchInput.disabled = true;
+                this.sendButton.disabled = true;
+                this.searchInput.placeholder = "Waiting for response...";
+            }
+
+            enableInput() {
+                this.waitingForResponse = false;
+                this.searchInput.disabled = false;
+                this.sendButton.disabled = false;
+                this.searchInput.placeholder = "Ask Amazon Q anything...";
+                this.searchInput.focus();
+            }
+
+            handleExit() {
+                this.addStatusMessage('Session ended.');
+                this.searchInput.disabled = true;
+                this.sendButton.disabled = true;
+            }
+
+            scrollToBottom() {
+                this.content.scrollTop = this.content.scrollHeight;
+            }
+        }
+
+        // Initialize terminal when page loads
+        document.addEventListener('DOMContentLoaded', () => {
+            new WebTerminal();
+        });
+    </script>
+</body>
+</html>

--- a/crates/web-terminal/web-terminal.md
+++ b/crates/web-terminal/web-terminal.md
@@ -1,0 +1,162 @@
+# Web Terminal
+
+The web-terminal crate provides a web-based interface for Amazon Q CLI, allowing users to interact with Amazon Q through a browser instead of the command line.
+
+## Overview
+
+The web terminal creates a WebSocket-based terminal emulator that runs in the browser, providing a familiar terminal experience while leveraging the full power of Amazon Q CLI.
+
+## Features
+
+- **WebSocket Communication**: Real-time bidirectional communication between browser and terminal
+- **Terminal Emulation**: Full terminal emulation with support for colors, cursor movement, and control sequences
+- **Process Management**: Spawns and manages shell processes with proper I/O handling
+- **Cross-Platform**: Works on macOS and Linux
+- **Responsive Design**: Adapts to different screen sizes and devices
+
+## Architecture
+
+The web terminal consists of several key components:
+
+### Server Components
+
+- **Web Server**: Axum-based HTTP server that serves the web interface
+- **WebSocket Handler**: Manages WebSocket connections and message routing
+- **Terminal Manager**: Spawns and manages terminal processes
+- **Process I/O**: Handles stdin/stdout/stderr communication with spawned processes
+
+### Client Components
+
+- **HTML Interface**: Terminal emulator UI built with HTML/CSS/JavaScript
+- **WebSocket Client**: Handles communication with the server
+- **Terminal Renderer**: Renders terminal output and handles user input
+
+## Usage
+
+### Starting the Web Terminal
+
+Use the `webchat` command to start the web terminal server:
+
+```bash
+q webchat --port 8080
+```
+
+Available options:
+- `--port, -p`: Port to run the web server on (default: 8080)
+- `--agent`: Context profile to use
+- `--model`: Current model to use
+- `--trust-all-tools, -a`: Allow all tools without confirmation
+- `--trust-tools`: Trust only specific tools
+
+### Accessing the Interface
+
+Once started, open your browser and navigate to:
+```
+http://localhost:8080
+```
+
+The interface provides a full terminal experience where you can interact with Amazon Q just as you would in the command line.
+
+## Implementation Details
+
+### WebSocket Protocol
+
+The web terminal uses a simple JSON-based protocol over WebSocket:
+
+```json
+{
+  "type": "input",
+  "data": "user input text"
+}
+```
+
+```json
+{
+  "type": "output", 
+  "data": "terminal output text"
+}
+```
+
+### Process Management
+
+Each WebSocket connection spawns its own shell process using `/bin/bash`.
+
+The process lifecycle is managed automatically:
+- Process is spawned when WebSocket connects
+- Process is terminated when WebSocket disconnects
+- I/O is handled asynchronously using Tokio
+
+### Security Considerations
+
+- The web terminal runs locally and binds to `127.0.0.1` by default
+- No authentication is required for local access
+- All terminal operations run with the same permissions as the user who started the server
+- CORS is configured to allow local access only
+
+## Development
+
+### Building
+
+The web-terminal crate is built as part of the main Amazon Q CLI build:
+
+```bash
+cargo build
+```
+
+### Testing
+
+Run tests for the web-terminal crate:
+
+```bash
+cargo test --package web-terminal
+```
+
+### Dependencies
+
+Key dependencies include:
+- `axum`: Web framework for HTTP server
+- `tokio-tungstenite`: WebSocket implementation
+- `tokio`: Async runtime
+- `serde`: JSON serialization
+- `tower-http`: HTTP middleware
+
+## Troubleshooting
+
+### Common Issues
+
+**Port Already in Use**
+```
+Error: Address already in use (os error 48)
+```
+Solution: Use a different port with `--port` option or stop the process using the port.
+
+**WebSocket Connection Failed**
+- Check that the server is running
+- Verify the correct port is being used
+- Ensure no firewall is blocking the connection
+
+**Terminal Not Responding**
+- Refresh the browser page to reconnect
+- Check server logs for error messages
+- Restart the web terminal server
+
+### Logging
+
+Enable verbose logging to debug issues:
+
+```bash
+q webchat -v
+```
+
+This will show detailed information about WebSocket connections, process spawning, and I/O operations.
+
+## Future Enhancements
+
+Potential improvements for the web terminal:
+
+- **Authentication**: Add optional authentication for remote access
+- **Multiple Sessions**: Support multiple terminal sessions in tabs
+- **File Upload/Download**: Direct file transfer capabilities
+- **Themes**: Customizable terminal themes and colors
+- **Keyboard Shortcuts**: Additional keyboard shortcuts and hotkeys
+- **Session Persistence**: Save and restore terminal sessions

--- a/docs/web-terminal.md
+++ b/docs/web-terminal.md
@@ -1,0 +1,1 @@
+../crates/web-terminal/web-terminal.md


### PR DESCRIPTION
*Description of changes:*

Add a new command called 'q webchat'.
Run 'q webchat' using a browser at http://localhost:<port>.
Only 'localhost' is supported, other features such as drag-and-drop are TBD items.

Run as:
1) Start the q CLI as : q -- webchat --port 3000
2) Use a browser and paste http://localhost:3000 in the address bar

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
