### PR TITLE
Regex-formatted allowed commands for execute_bash tool

### DIFF
--- a/crates/chat-cli/src/cli/chat/tools/execute/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/execute/mod.rs
@@ -6,6 +6,7 @@ use crossterm::style::{
     Color,
 };
 use eyre::Result;
+use regex::Regex;
 use serde::Deserialize;
 use tracing::error;
 
@@ -47,6 +48,17 @@ impl ExecuteCommand {
     pub fn requires_acceptance(&self, allowed_commands: Option<&Vec<String>>, allow_read_only: bool) -> bool {
         let default_arr = vec![];
         let allowed_commands = allowed_commands.unwrap_or(&default_arr);
+
+        let has_regex_match = allowed_commands
+            .iter()
+            .map(|cmd| Regex::new(cmd))
+            .filter(Result::is_ok)
+            .flatten()
+            .any(|regex| regex.is_match(&self.command));
+        if has_regex_match {
+            return false;
+        }
+
         let Some(args) = shlex::split(&self.command) else {
             return true;
         };
@@ -328,6 +340,42 @@ mod tests {
             .unwrap();
             assert_eq!(
                 tool.requires_acceptance(None, true),
+                *expected,
+                "expected command: `{}` to have requires_acceptance: `{}`",
+                cmd,
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn test_requires_acceptance_allowed_commands() {
+        let allowed_cmds: &[String] = &[
+            String::from("git status"),
+            String::from("root"),
+            String::from("command subcommand a=[0-9]{10} b=[0-9]{10}"),
+            String::from("command subcommand && command subcommand"),
+        ];
+        let cmds = &[
+            // Command first argument 'root' allowed (allows all subcommands)
+            ("root", false),
+            ("root subcommand", false),
+            // Valid allowed_command_regex matching
+            ("git", true),
+            ("git status", false),
+            ("command subcommand a=0123456789 b=0123456789", false),
+            ("command subcommand a=0123456789 b=012345678", true),
+            ("command subcommand alternate a=0123456789 b=0123456789", true),
+            // Control characters ignored due to direct allowed_command_regex match
+            ("command subcommand && command subcommand", false),
+        ];
+        for (cmd, expected) in cmds {
+            let tool = serde_json::from_value::<ExecuteCommand>(serde_json::json!({
+                "command": cmd,
+            }))
+            .unwrap();
+            assert_eq!(
+                tool.requires_acceptance(Option::from(&allowed_cmds.to_vec()), true),
                 *expected,
                 "expected command: `{}` to have requires_acceptance: `{}`",
                 cmd,


### PR DESCRIPTION
*Issue #, if available:* None.

*Description of changes:*
- This PR adds support for regex-formatted allowed commands for the execute_bash tool. This will give developers greater flexibility to allowlist commands. For example, you could allowlist `aws authenticate --read-only --account-id [0-9]{10} (the main use case I had in mind when implementing this PR).
- Today, the allowed commands feature of the execute_bash tool supports only the *first* command in the chain. For example, allowlisting `git` would allow `git`, and all `git` subcommands. Allowing `git status` would *not* allow `git status`, since the current logic only examines the first argument in the command (`git status` != `git`). Adding regex support will add more flexibility to the allowed commands setting, and also allow users to allow commands that are longer than one argument in length (e.g. `git status`).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
