### PR TITLE
Implementation of knowledge base directory setting

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -1881,7 +1881,10 @@ impl ChatSession {
                 ev.is_accepted = true;
             });
 
-            let invoke_result = tool.tool.invoke(os, &mut self.stdout).await;
+            let invoke_result = tool
+                .tool
+                .invoke(os, &mut self.stdout, self.conversation.agents.get_active())
+                .await;
 
             if self.spinner.is_some() {
                 queue!(

--- a/crates/chat-cli/src/cli/chat/tools/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/mod.rs
@@ -107,7 +107,7 @@ impl Tool {
     }
 
     /// Invokes the tool asynchronously
-    pub async fn invoke(&self, os: &Os, stdout: &mut impl Write) -> Result<InvokeOutput> {
+    pub async fn invoke(&self, os: &Os, stdout: &mut impl Write, agent: Option<&Agent>) -> Result<InvokeOutput> {
         match self {
             Tool::FsRead(fs_read) => fs_read.invoke(os, stdout).await,
             Tool::FsWrite(fs_write) => fs_write.invoke(os, stdout).await,
@@ -115,7 +115,7 @@ impl Tool {
             Tool::UseAws(use_aws) => use_aws.invoke(os, stdout).await,
             Tool::Custom(custom_tool) => custom_tool.invoke(os, stdout).await,
             Tool::GhIssue(gh_issue) => gh_issue.invoke(os, stdout).await,
-            Tool::Knowledge(knowledge) => knowledge.invoke(os, stdout).await,
+            Tool::Knowledge(knowledge) => knowledge.invoke(os, stdout, agent).await,
             Tool::Thinking(think) => think.invoke(stdout).await,
         }
     }


### PR DESCRIPTION
*Issue #, if available:* None.

*Description of changes:*
- This change adds support for setting a knowledge base `base_dir` in the tool settings. This would allow different agents to access different knowledge bases. This would keep the knowledge bases for a particular agent clean - e.g. an oncall-helper agent would not recieve documentation about the team charter, or other unnecessary information.
- This is a rough draft implementation. I am not sure about the pattern of passing the session or agent around, and would like feedback on the approach. I've left comments below in/around sections that I'm particularly unsure of.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
