### PR TITLE
Fix docs: Rust agent example JSON invalid

### DIFF
--- a/docs/agent-format.md
+++ b/docs/agent-format.md
@@ -284,12 +284,12 @@ Here's a complete example of an agent configuration file:
   "hooks": {
     "agentSpawn": [
       {
-        "command": "git status",
+        "command": "git status"
       }
     ],
     "userPromptSubmit": [
       {
-        "command": "ls -la",
+        "command": "ls -la"
       }
     ]
   },


### PR DESCRIPTION
Using the Rust agent example in Q Dev CLI threw an error because the JSON contained invalid commas. Fixed and tested locally.

*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
