### PR TITLE
feat: add experimental model for amazon users

### DIFF
--- a/crates/chat-cli/src/auth/builder_id.rs
+++ b/crates/chat-cli/src/auth/builder_id.rs
@@ -303,8 +303,19 @@ impl BuilderIdToken {
 
     /// Load the token from the keychain, refresh the token if it is expired and return it
     pub async fn load(database: &Database) -> Result<Option<Self>, AuthError> {
-        #[cfg(test)]
-        return Ok(Some(Self::test()));
+        // Can't use #[cfg(test)] without breaking lints, and we don't want to require
+        // authentication in order to run ChatSession tests. Hence, adding this here with cfg!(test)
+        if cfg!(test) {
+            return Ok(Some(Self {
+                access_token: Secret("test_access_token".to_string()),
+                expires_at: time::OffsetDateTime::now_utc() + time::Duration::minutes(60),
+                refresh_token: Some(Secret("test_refresh_token".to_string())),
+                region: Some(OIDC_BUILDER_ID_REGION.to_string()),
+                start_url: Some(START_URL.to_string()),
+                oauth_flow: OAuthFlow::DeviceCode,
+                scopes: Some(SCOPES.iter().map(|s| (*s).to_owned()).collect()),
+            }));
+        }
 
         trace!("loading builder id token from the secret store");
         match database.get_secret(Self::SECRET_KEY).await {

--- a/crates/chat-cli/src/auth/builder_id.rs
+++ b/crates/chat-cli/src/auth/builder_id.rs
@@ -303,6 +303,9 @@ impl BuilderIdToken {
 
     /// Load the token from the keychain, refresh the token if it is expired and return it
     pub async fn load(database: &Database) -> Result<Option<Self>, AuthError> {
+        #[cfg(test)]
+        return Ok(Some(Self::test()));
+
         trace!("loading builder id token from the secret store");
         match database.get_secret(Self::SECRET_KEY).await {
             Ok(Some(secret)) => {

--- a/crates/chat-cli/src/cli/chat/cli/context.rs
+++ b/crates/chat-cli/src/cli/chat/cli/context.rs
@@ -10,10 +10,8 @@ use crossterm::{
     style,
 };
 
-use crate::cli::chat::consts::{
-    AGENT_FORMAT_HOOKS_DOC_URL,
-    CONTEXT_FILES_MAX_SIZE,
-};
+use crate::cli::chat::consts::AGENT_FORMAT_HOOKS_DOC_URL;
+use crate::cli::chat::context::calc_max_context_files_size;
 use crate::cli::chat::token_counter::TokenCounter;
 use crate::cli::chat::util::drop_matched_context_files;
 use crate::cli::chat::{
@@ -167,8 +165,9 @@ impl ContextSubcommand {
                         execute!(session.stderr, style::Print(format!("{}\n\n", "▔".repeat(3))),)?;
                     }
 
+                    let context_files_max_size = calc_max_context_files_size(session.conversation.model.as_deref());
                     let mut files_as_vec = profile_context_files.iter().cloned().collect::<Vec<_>>();
-                    let dropped_files = drop_matched_context_files(&mut files_as_vec, CONTEXT_FILES_MAX_SIZE).ok();
+                    let dropped_files = drop_matched_context_files(&mut files_as_vec, context_files_max_size).ok();
 
                     execute!(
                         session.stderr,
@@ -182,7 +181,7 @@ impl ContextSubcommand {
                                 style::SetForegroundColor(Color::DarkYellow),
                                 style::Print(format!(
                                     "Total token count exceeds limit: {}. The following files will be automatically dropped when interacting with Q. Consider removing them. \n\n",
-                                    CONTEXT_FILES_MAX_SIZE
+                                    context_files_max_size
                                 )),
                                 style::SetForegroundColor(Color::Reset)
                             )?;

--- a/crates/chat-cli/src/cli/chat/cli/mod.rs
+++ b/crates/chat-cli/src/cli/chat/cli/mod.rs
@@ -134,7 +134,7 @@ impl SlashCommand {
             Self::Hooks(args) => args.execute(session).await,
             Self::Usage(args) => args.execute(os, session).await,
             Self::Mcp(args) => args.execute(session).await,
-            Self::Model(args) => args.execute(session).await,
+            Self::Model(args) => args.execute(os, session).await,
             Self::Subscribe(args) => args.execute(os, session).await,
             Self::Persist(subcommand) => subcommand.execute(os, session).await,
             // Self::Root(subcommand) => {

--- a/crates/chat-cli/src/cli/chat/cli/model.rs
+++ b/crates/chat-cli/src/cli/chat/cli/model.rs
@@ -9,6 +9,7 @@ use crossterm::{
 };
 use dialoguer::Select;
 
+use crate::auth::AuthError;
 use crate::auth::builder_id::{
     BuilderIdToken,
     TokenType,
@@ -21,18 +22,37 @@ use crate::cli::chat::{
 use crate::os::Os;
 
 pub struct ModelOption {
+    /// Display name
     pub name: &'static str,
+    /// Actual model id to send in the API
     pub model_id: &'static str,
+    /// Size of the model's context window, in tokens
+    pub context_window_tokens: usize,
 }
 
-pub const MODEL_OPTIONS: [ModelOption; 2] = [
+const MODEL_OPTIONS: [ModelOption; 2] = [
     ModelOption {
         name: "claude-4-sonnet",
         model_id: "CLAUDE_SONNET_4_20250514_V1_0",
+        context_window_tokens: 200_000,
     },
     ModelOption {
         name: "claude-3.7-sonnet",
         model_id: "CLAUDE_3_7_SONNET_20250219_V1_0",
+        context_window_tokens: 200_000,
+    },
+];
+
+const OPENAI_MODEL_OPTIONS: [ModelOption; 2] = [
+    ModelOption {
+        name: "experimental-gpt-oss-120b",
+        model_id: "OPENAI_GPT_OSS_120B_1_0",
+        context_window_tokens: 128_000,
+    },
+    ModelOption {
+        name: "experimental-gpt-oss-20b",
+        model_id: "OPENAI_GPT_OSS_20B_1_0",
+        context_window_tokens: 128_000,
     },
 ];
 
@@ -41,17 +61,19 @@ pub const MODEL_OPTIONS: [ModelOption; 2] = [
 pub struct ModelArgs;
 
 impl ModelArgs {
-    pub async fn execute(self, session: &mut ChatSession) -> Result<ChatState, ChatError> {
-        Ok(select_model(session)?.unwrap_or(ChatState::PromptUser {
+    pub async fn execute(self, os: &Os, session: &mut ChatSession) -> Result<ChatState, ChatError> {
+        Ok(select_model(os, session).await?.unwrap_or(ChatState::PromptUser {
             skip_printing_tools: false,
         }))
     }
 }
 
-pub fn select_model(session: &mut ChatSession) -> Result<Option<ChatState>, ChatError> {
+pub async fn select_model(os: &Os, session: &mut ChatSession) -> Result<Option<ChatState>, ChatError> {
     queue!(session.stderr, style::Print("\n"))?;
     let active_model_id = session.conversation.model.as_deref();
-    let labels: Vec<String> = MODEL_OPTIONS
+    let model_options = get_model_options(os).await?;
+
+    let labels: Vec<String> = model_options
         .iter()
         .map(|opt| {
             if (opt.model_id.is_empty() && active_model_id.is_none()) || Some(opt.model_id) == active_model_id {
@@ -83,7 +105,7 @@ pub fn select_model(session: &mut ChatSession) -> Result<Option<ChatState>, Chat
     queue!(session.stderr, style::ResetColor)?;
 
     if let Some(index) = selection {
-        let selected = &MODEL_OPTIONS[index];
+        let selected = &model_options[index];
         let model_id_str = selected.model_id.to_string();
         session.conversation.model = Some(model_id_str);
 
@@ -104,6 +126,8 @@ pub fn select_model(session: &mut ChatSession) -> Result<Option<ChatState>, Chat
     }))
 }
 
+/// Returns a default model id to use if none has been otherwise provided.
+///
 /// Returns Claude 3.7 for: Amazon IDC users, FRA region users
 /// Returns Claude 4.0 for: Builder ID users, other regions
 pub async fn default_model_id(os: &Os) -> &'static str {
@@ -123,4 +147,36 @@ pub async fn default_model_id(os: &Os) -> &'static str {
 
     // Default to 4.0
     "CLAUDE_SONNET_4_20250514_V1_0"
+}
+
+/// Returns the available models for use.
+pub async fn get_model_options(os: &Os) -> Result<Vec<ModelOption>, ChatError> {
+    let is_amzn_user = BuilderIdToken::load(&os.database)
+        .await?
+        .ok_or(AuthError::NoToken)?
+        .is_amzn_user();
+
+    let mut model_options = MODEL_OPTIONS.into_iter().collect::<Vec<_>>();
+    if is_amzn_user {
+        for opt in OPENAI_MODEL_OPTIONS {
+            model_options.push(opt);
+        }
+    }
+
+    Ok(model_options)
+}
+
+/// Returns the context window length in tokens for the given model_id.
+pub fn context_window_tokens(model_id: Option<&str>) -> usize {
+    const DEFAULT_CONTEXT_WINDOW_LENGTH: usize = 200_000;
+
+    let Some(model_id) = model_id else {
+        return DEFAULT_CONTEXT_WINDOW_LENGTH;
+    };
+
+    MODEL_OPTIONS
+        .iter()
+        .chain(OPENAI_MODEL_OPTIONS.iter())
+        .find(|m| m.model_id == model_id)
+        .map_or(DEFAULT_CONTEXT_WINDOW_LENGTH, |m| m.context_window_tokens)
 }

--- a/crates/chat-cli/src/cli/chat/cli/usage.rs
+++ b/crates/chat-cli/src/cli/chat/cli/usage.rs
@@ -9,7 +9,7 @@ use crossterm::{
     style,
 };
 
-use crate::cli::chat::consts::CONTEXT_WINDOW_SIZE;
+use super::model::context_window_tokens;
 use crate::cli::chat::token_counter::{
     CharCount,
     TokenCount,
@@ -62,14 +62,16 @@ impl UsageArgs {
         // set a max width for the progress bar for better aesthetic
         let progress_bar_width = std::cmp::min(window_width, 80);
 
+        let context_window_size = context_window_tokens(session.conversation.model.as_deref());
+
         let context_width =
-            ((context_token_count.value() as f64 / CONTEXT_WINDOW_SIZE as f64) * progress_bar_width as f64) as usize;
+            ((context_token_count.value() as f64 / context_window_size as f64) * progress_bar_width as f64) as usize;
         let assistant_width =
-            ((assistant_token_count.value() as f64 / CONTEXT_WINDOW_SIZE as f64) * progress_bar_width as f64) as usize;
+            ((assistant_token_count.value() as f64 / context_window_size as f64) * progress_bar_width as f64) as usize;
         let tools_width =
-            ((tools_token_count.value() as f64 / CONTEXT_WINDOW_SIZE as f64) * progress_bar_width as f64) as usize;
+            ((tools_token_count.value() as f64 / context_window_size as f64) * progress_bar_width as f64) as usize;
         let user_width =
-            ((user_token_count.value() as f64 / CONTEXT_WINDOW_SIZE as f64) * progress_bar_width as f64) as usize;
+            ((user_token_count.value() as f64 / context_window_size as f64) * progress_bar_width as f64) as usize;
 
         let left_over_width = progress_bar_width
             - std::cmp::min(
@@ -85,7 +87,7 @@ impl UsageArgs {
                 style::Print(format!(
                     "\nCurrent context window ({} of {}k tokens used)\n",
                     total_token_used,
-                    CONTEXT_WINDOW_SIZE / 1000
+                    context_window_size / 1000
                 )),
                 style::SetForegroundColor(Color::DarkRed),
                 style::Print("█".repeat(progress_bar_width)),
@@ -93,7 +95,7 @@ impl UsageArgs {
                 style::Print(" "),
                 style::Print(format!(
                     "{:.2}%",
-                    (total_token_used.value() as f32 / CONTEXT_WINDOW_SIZE as f32) * 100.0
+                    (total_token_used.value() as f32 / context_window_size as f32) * 100.0
                 )),
             )?;
         } else {
@@ -102,7 +104,7 @@ impl UsageArgs {
                 style::Print(format!(
                     "\nCurrent context window ({} of {}k tokens used)\n",
                     total_token_used,
-                    CONTEXT_WINDOW_SIZE / 1000
+                    context_window_size / 1000
                 )),
                 // Context files
                 style::SetForegroundColor(Color::DarkCyan),
@@ -140,7 +142,7 @@ impl UsageArgs {
                 style::SetForegroundColor(Color::Reset),
                 style::Print(format!(
                     "{:.2}%",
-                    (total_token_used.value() as f32 / CONTEXT_WINDOW_SIZE as f32) * 100.0
+                    (total_token_used.value() as f32 / context_window_size as f32) * 100.0
                 )),
             )?;
         }
@@ -155,7 +157,7 @@ impl UsageArgs {
             style::Print(format!(
                 "~{} tokens ({:.2}%)\n",
                 context_token_count,
-                (context_token_count.value() as f32 / CONTEXT_WINDOW_SIZE as f32) * 100.0
+                (context_token_count.value() as f32 / context_window_size as f32) * 100.0
             )),
             style::SetForegroundColor(Color::DarkRed),
             style::Print("█ Tools:    "),
@@ -163,7 +165,7 @@ impl UsageArgs {
             style::Print(format!(
                 " ~{} tokens ({:.2}%)\n",
                 tools_token_count,
-                (tools_token_count.value() as f32 / CONTEXT_WINDOW_SIZE as f32) * 100.0
+                (tools_token_count.value() as f32 / context_window_size as f32) * 100.0
             )),
             style::SetForegroundColor(Color::Blue),
             style::Print("█ Q responses: "),
@@ -171,7 +173,7 @@ impl UsageArgs {
             style::Print(format!(
                 "  ~{} tokens ({:.2}%)\n",
                 assistant_token_count,
-                (assistant_token_count.value() as f32 / CONTEXT_WINDOW_SIZE as f32) * 100.0
+                (assistant_token_count.value() as f32 / context_window_size as f32) * 100.0
             )),
             style::SetForegroundColor(Color::Magenta),
             style::Print("█ Your prompts: "),
@@ -179,7 +181,7 @@ impl UsageArgs {
             style::Print(format!(
                 " ~{} tokens ({:.2}%)\n\n",
                 user_token_count,
-                (user_token_count.value() as f32 / CONTEXT_WINDOW_SIZE as f32) * 100.0
+                (user_token_count.value() as f32 / context_window_size as f32) * 100.0
             )),
         )?;
 

--- a/crates/chat-cli/src/cli/chat/consts.rs
+++ b/crates/chat-cli/src/cli/chat/consts.rs
@@ -1,5 +1,3 @@
-use super::token_counter::TokenCounter;
-
 // These limits are the internal undocumented values from the service for each item
 
 pub const MAX_CURRENT_WORKING_DIRECTORY_LEN: usize = 256;
@@ -12,13 +10,6 @@ pub const MAX_TOOL_RESPONSE_SIZE: usize = 400_000;
 
 /// Actual service limit is 600_000
 pub const MAX_USER_MESSAGE_SIZE: usize = 400_000;
-
-/// In tokens
-pub const CONTEXT_WINDOW_SIZE: usize = 200_000;
-
-pub const CONTEXT_FILES_MAX_SIZE: usize = 150_000;
-
-pub const MAX_CHARS: usize = TokenCounter::token_to_chars(CONTEXT_WINDOW_SIZE); // Character-based warning threshold
 
 pub const DUMMY_TOOL_NAME: &str = "dummy";
 

--- a/crates/chat-cli/src/cli/chat/context.rs
+++ b/crates/chat-cli/src/cli/chat/context.rs
@@ -12,7 +12,7 @@ use serde::{
     Serialize,
 };
 
-use super::consts::CONTEXT_FILES_MAX_SIZE;
+use super::cli::model::context_window_tokens;
 use super::util::drop_matched_context_files;
 use crate::cli::agent::Agent;
 use crate::cli::agent::hook::{
@@ -38,7 +38,7 @@ pub struct ContextManager {
 }
 
 impl ContextManager {
-    pub fn from_agent(agent: &Agent, max_context_files_size: Option<usize>) -> Result<Self> {
+    pub fn from_agent(agent: &Agent, max_context_files_size: usize) -> Result<Self> {
         let paths = agent
             .resources
             .iter()
@@ -47,7 +47,7 @@ impl ContextManager {
             .collect::<Vec<_>>();
 
         Ok(Self {
-            max_context_files_size: max_context_files_size.unwrap_or(CONTEXT_FILES_MAX_SIZE),
+            max_context_files_size,
             current_profile: agent.name.clone(),
             paths,
             hooks: agent.hooks.clone(),
@@ -184,6 +184,12 @@ impl ContextManager {
         hooks.retain(|t, _| *t == trigger);
         self.hook_executor.run_hooks(hooks, output, prompt).await
     }
+}
+
+/// Calculates the maximum context files size to use for the given model id.
+pub fn calc_max_context_files_size(model_id: Option<&str>) -> usize {
+    // Sets the max as 75% of the context window
+    context_window_tokens(model_id).saturating_mul(3) / 4
 }
 
 /// Process a path, handling glob patterns and file types.
@@ -355,5 +361,14 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[test]
+    fn test_calc_max_context_files_size() {
+        assert_eq!(
+            calc_max_context_files_size(Some("CLAUDE_SONNET_4_20250514_V1_0")),
+            150_000
+        );
+        assert_eq!(calc_max_context_files_size(Some("OPENAI_GPT_OSS_120B_1_0")), 96_000);
     }
 }

--- a/crates/chat-cli/src/cli/chat/util/test.rs
+++ b/crates/chat-cli/src/cli/chat/util/test.rs
@@ -1,7 +1,6 @@
 use eyre::Result;
 
 use crate::cli::agent::Agent;
-use crate::cli::chat::consts::CONTEXT_FILES_MAX_SIZE;
 use crate::cli::chat::context::ContextManager;
 use crate::os::Os;
 
@@ -17,9 +16,9 @@ pub const TEST_HIDDEN_FILE_PATH: &str = "/aaaa2/.hidden";
 
 // Helper function to create a test ContextManager with Context
 pub fn create_test_context_manager(context_file_size: Option<usize>) -> Result<ContextManager> {
-    let context_file_size = context_file_size.unwrap_or(CONTEXT_FILES_MAX_SIZE);
+    let context_file_size = context_file_size.unwrap_or(150_000);
     let agent = Agent::default();
-    ContextManager::from_agent(&agent, Some(context_file_size))
+    ContextManager::from_agent(&agent, context_file_size)
 }
 
 /// Sets up the following filesystem structure:


### PR DESCRIPTION
*Description of changes:*
- Adding new experimental models for internal Amazon users. This required some refactoring around the model selection logic for checking against the authentication state.

Examples of behavior when authenticated as a non-Amazon user are provided below.

Trying to launch with `--model`:

<img width="1339" height="108" alt="Screenshot 2025-08-04 at 4 24 16 PM" src="https://github.com/user-attachments/assets/180409e6-882c-4a53-bc5f-a66a1d9dbcb4" />

Trying to launch with `chat.defaultModel` set to one of the new models:

<img width="1014" height="618" alt="Screenshot 2025-08-04 at 4 28 12 PM" src="https://github.com/user-attachments/assets/7aa3e0a0-b862-4f34-acbb-71110a17612b" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
