### PR TITLE
fix: knowledge tool permission

### DIFF
--- a/crates/chat-cli/src/cli/chat/tools/knowledge.rs
+++ b/crates/chat-cli/src/cli/chat/tools/knowledge.rs
@@ -13,6 +13,10 @@ use super::{
     InvokeOutput,
     OutputKind,
 };
+use crate::cli::agent::{
+    Agent,
+    PermissionEvalResult,
+};
 use crate::database::settings::Setting;
 use crate::os::Os;
 use crate::util::knowledge_store::KnowledgeStore;
@@ -470,6 +474,15 @@ impl Knowledge {
         Ok(InvokeOutput {
             output: OutputKind::Text(result),
         })
+    }
+
+    pub fn eval_perm(&self, agent: &Agent) -> PermissionEvalResult {
+        _ = self;
+        if agent.allowed_tools.contains("knowledge") {
+            PermissionEvalResult::Allow
+        } else {
+            PermissionEvalResult::Ask
+        }
     }
 
     /// Format status data for display (UI rendering responsibility)

--- a/crates/chat-cli/src/cli/chat/tools/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/mod.rs
@@ -102,7 +102,7 @@ impl Tool {
             Tool::Custom(custom_tool) => custom_tool.eval_perm(agent),
             Tool::GhIssue(_) => PermissionEvalResult::Allow,
             Tool::Thinking(_) => PermissionEvalResult::Allow,
-            Tool::Knowledge(_) => PermissionEvalResult::Ask,
+            Tool::Knowledge(knowledge) => knowledge.eval_perm(agent),
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
As titled. 
Knowledge tool was previously written to always ask for permission. 
This PR fixes that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
