### PR TITLE
chore(telemetry): make launchedAgent required for agentConfigInit

### DIFF
--- a/crates/chat-cli/src/cli/agent/mod.rs
+++ b/crates/chat-cli/src/cli/agent/mod.rs
@@ -322,7 +322,9 @@ pub enum PermissionEvalResult {
 
 #[derive(Clone, Default, Debug)]
 pub struct Agents {
+    /// Mapping from agent name to an [Agent].
     pub agents: HashMap<String, Agent>,
+    /// Agent name.
     pub active_idx: String,
     pub trust_all_tools: bool,
 }
@@ -384,10 +386,7 @@ impl Agents {
         output: &mut impl Write,
     ) -> (Self, AgentsLoadMetadata) {
         // Tracking metadata about the performed load operation.
-        let mut load_metadata = AgentsLoadMetadata {
-            launched_agent: agent_name.map(Into::into),
-            ..Default::default()
-        };
+        let mut load_metadata = AgentsLoadMetadata::default();
 
         let new_agents = if !skip_migration {
             match legacy::migrate(os, false).await {
@@ -683,6 +682,7 @@ impl Agents {
             }
         }
 
+        load_metadata.launched_agent = active_idx.clone();
         (
             Self {
                 agents,
@@ -745,7 +745,7 @@ pub struct AgentsLoadMetadata {
     pub migrated_count: u32,
     pub load_count: u32,
     pub load_failed_count: u32,
-    pub launched_agent: Option<String>,
+    pub launched_agent: String,
 }
 
 async fn load_agents_from_entries(

--- a/crates/chat-cli/src/telemetry/core.rs
+++ b/crates/chat-cli/src/telemetry/core.rs
@@ -368,7 +368,7 @@ impl Event {
                         legacy_profile_migration_executed.into(),
                     ),
                     codewhispererterminal_legacy_profile_migrated_count: Some(legacy_profile_migrated_count.into()),
-                    codewhispererterminal_launched_agent: launched_agent.map(Into::into),
+                    codewhispererterminal_launched_agent: Some(launched_agent.into()),
                 }
                 .into_metric_datum(),
             ),
@@ -502,7 +502,7 @@ pub struct AgentConfigInitArgs {
     pub agents_loaded_failed_count: i64,
     pub legacy_profile_migration_executed: bool,
     pub legacy_profile_migrated_count: i64,
-    pub launched_agent: Option<String>,
+    pub launched_agent: String,
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/crates/chat-cli/telemetry_definitions.json
+++ b/crates/chat-cli/telemetry_definitions.json
@@ -423,7 +423,7 @@
         { "type": "codewhispererterminal_agentsFailedToLoadCount" },
         { "type": "codewhispererterminal_legacyProfileMigrationExecuted", "required": false },
         { "type": "codewhispererterminal_legacyProfileMigratedCount", "required": false },
-        { "type": "codewhispererterminal_launchedAgent", "required": false }
+        { "type": "codewhispererterminal_launchedAgent" }
       ]
     },
     {


### PR DESCRIPTION
*Description of changes:*
- Currently the `codewhispererterminal_agentConfigInit` event only sets launchedAgent according to the passed `--agent` CLI argument. Instead, we want to always set this field according to whatever agent is being launched (which by default would be `q_cli_default`)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
