### PR TITLE
feat: Add conditional compilation for Knowledge command using feature…

### DIFF
--- a/crates/chat-cli/Cargo.toml
+++ b/crates/chat-cli/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 [features]
 default = []
 wayland = ["arboard/wayland-data-control"]
+knowledge = []
 
 [[bin]]
 name = "test_mcp_server"

--- a/crates/chat-cli/src/cli/chat/cli/knowledge.rs
+++ b/crates/chat-cli/src/cli/chat/cli/knowledge.rs
@@ -19,6 +19,7 @@ use crate::cli::chat::{
     ChatSession,
     ChatState,
 };
+#[cfg(feature = "knowledge")]
 use crate::database::settings::Setting;
 use crate::os::Os;
 use crate::util::knowledge_store::KnowledgeStore;
@@ -69,10 +70,19 @@ impl KnowledgeSubcommand {
     }
 
     fn is_feature_enabled(os: &Os) -> bool {
-        os.database
-            .settings
-            .get_bool(Setting::EnabledKnowledge)
-            .unwrap_or(false)
+        // Feature is only available when compiled with the knowledge feature flag
+        #[cfg(feature = "knowledge")]
+        {
+            os.database
+                .settings
+                .get_bool(Setting::EnabledKnowledge)
+                .unwrap_or(false)
+        }
+        #[cfg(not(feature = "knowledge"))]
+        {
+            let _ = os; // Suppress unused variable warning
+            false
+        }
     }
 
     fn write_feature_disabled_message(session: &mut ChatSession) -> Result<(), std::io::Error> {

--- a/crates/chat-cli/src/cli/chat/cli/mod.rs
+++ b/crates/chat-cli/src/cli/chat/cli/mod.rs
@@ -3,6 +3,7 @@ pub mod compact;
 pub mod context;
 pub mod editor;
 pub mod hooks;
+#[cfg(feature = "knowledge")]
 pub mod knowledge;
 pub mod mcp;
 pub mod model;
@@ -19,6 +20,7 @@ use compact::CompactArgs;
 use context::ContextSubcommand;
 use editor::EditorArgs;
 use hooks::HooksArgs;
+#[cfg(feature = "knowledge")]
 use knowledge::KnowledgeSubcommand;
 use mcp::McpArgs;
 use model::ModelArgs;
@@ -56,9 +58,9 @@ pub enum SlashCommand {
     /// Manage context files for the chat session
     #[command(subcommand)]
     Context(ContextSubcommand),
-    /// (Beta) Manage knowledge base for persistent context storage. Requires "q settings
-    /// chat.enableKnowledge true"
-    #[command(subcommand, hide = true)]
+    /// (Beta) Manage knowledge base for persistent context storage
+    #[cfg(feature = "knowledge")]
+    #[command(subcommand)]
     Knowledge(KnowledgeSubcommand),
     /// Open $EDITOR (defaults to vi) to compose a prompt
     #[command(name = "editor")]
@@ -117,6 +119,7 @@ impl SlashCommand {
                 })
             },
             Self::Context(args) => args.execute(os, session).await,
+            #[cfg(feature = "knowledge")]
             Self::Knowledge(subcommand) => subcommand.execute(os, session).await,
             Self::PromptEditor(args) => args.execute(session).await,
             Self::Compact(args) => args.execute(os, session).await,
@@ -156,6 +159,7 @@ impl SlashCommand {
             Self::Agent(_) => "agent",
             Self::Profile => "profile",
             Self::Context(_) => "context",
+            #[cfg(feature = "knowledge")]
             Self::Knowledge(_) => "knowledge",
             Self::PromptEditor(_) => "editor",
             Self::Compact(_) => "compact",
@@ -178,6 +182,7 @@ impl SlashCommand {
         match self {
             SlashCommand::Agent(sub) => Some(sub.name()),
             SlashCommand::Context(sub) => Some(sub.name()),
+            #[cfg(feature = "knowledge")]
             SlashCommand::Knowledge(sub) => Some(sub.name()),
             SlashCommand::Tools(arg) => arg.subcommand_name(),
             SlashCommand::Prompts(arg) => arg.subcommand_name(),

--- a/crates/chat-cli/src/cli/chat/tools/knowledge.rs
+++ b/crates/chat-cli/src/cli/chat/tools/knowledge.rs
@@ -13,6 +13,7 @@ use super::{
     InvokeOutput,
     OutputKind,
 };
+#[cfg(feature = "knowledge")]
 use crate::database::settings::Setting;
 use crate::os::Os;
 use crate::util::knowledge_store::KnowledgeStore;
@@ -83,10 +84,19 @@ pub struct KnowledgeCancel {
 impl Knowledge {
     /// Checks if the knowledge feature is enabled in settings
     pub fn is_enabled(os: &Os) -> bool {
-        os.database
-            .settings
-            .get_bool(Setting::EnabledKnowledge)
-            .unwrap_or(false)
+        // Feature is only available when compiled with the knowledge feature flag
+        #[cfg(feature = "knowledge")]
+        {
+            os.database
+                .settings
+                .get_bool(Setting::EnabledKnowledge)
+                .unwrap_or(false)
+        }
+        #[cfg(not(feature = "knowledge"))]
+        {
+            let _ = os; // Suppress unused variable warning
+            false
+        }
     }
 
     pub async fn validate(&mut self, os: &Os) -> Result<()> {

--- a/crates/chat-cli/src/util/knowledge_store.rs
+++ b/crates/chat-cli/src/util/knowledge_store.rs
@@ -159,6 +159,7 @@ impl KnowledgeStore {
     }
 
     /// Clear all contexts immediately (synchronous operation)
+    #[allow(dead_code)]
     pub async fn clear_immediate(&mut self) -> Result<String, String> {
         match self.client.clear_all_immediate().await {
             Ok(count) => Ok(format!("✅ Successfully cleared {} knowledge base entries", count)),


### PR DESCRIPTION
… flag

- Add 'knowledge' feature flag to chat-cli Cargo.toml
- Make Knowledge command conditional with #[cfg(feature = "knowledge")]
- Restore original database setting logic when feature is enabled
- Hide Knowledge command from help when feature is disabled
- Fix unused import/variable warnings with conditional compilation
- Knowledge is disabled by default, enabled with --features knowledge

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
