### PR TITLE
feat(telemetry): add client application and additional info from tool

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -1885,6 +1885,18 @@ impl ChatSession {
                 ev.is_accepted = true;
             });
 
+            // Extract AWS service name and operation name if available
+            if let Some(additional_info) = tool.tool.get_additional_info() {
+                if let Some(aws_service_name) = additional_info.get("aws_service_name").and_then(|v| v.as_str()) {
+                    tool_telemetry =
+                        tool_telemetry.and_modify(|ev| ev.aws_service_name = Some(aws_service_name.to_string()));
+                }
+                if let Some(aws_operation_name) = additional_info.get("aws_operation_name").and_then(|v| v.as_str()) {
+                    tool_telemetry =
+                        tool_telemetry.and_modify(|ev| ev.aws_operation_name = Some(aws_operation_name.to_string()));
+                }
+            }
+
             let invoke_result = tool.tool.invoke(os, &mut self.stdout).await;
 
             if self.spinner.is_some() {
@@ -2557,7 +2569,7 @@ impl ChatSession {
             }
             .map(|v| v.to_string());
 
-            os.telemetry.send_tool_use_suggested(event).ok();
+            os.telemetry.send_tool_use_suggested(&os.database, event).await.ok();
         }
     }
 

--- a/crates/chat-cli/src/cli/chat/tools/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/mod.rs
@@ -147,6 +147,15 @@ impl Tool {
             Tool::Thinking(think) => think.validate(os).await,
         }
     }
+
+    /// Returns additional information about the tool if available
+    pub fn get_additional_info(&self) -> Option<serde_json::Value> {
+        match self {
+            Tool::UseAws(use_aws) => Some(use_aws.get_additional_info()),
+            // Add other tool types here as they implement get_additional_info()
+            _ => None,
+        }
+    }
 }
 
 /// A tool specification to be sent to the model as part of a conversation. Maps to

--- a/crates/chat-cli/src/cli/chat/tools/use_aws.rs
+++ b/crates/chat-cli/src/cli/chat/tools/use_aws.rs
@@ -178,6 +178,13 @@ impl UseAws {
         Ok(())
     }
 
+    pub fn get_additional_info(&self) -> serde_json::Value {
+        serde_json::json!({
+            "aws_service_name": self.service_name.clone(),
+            "aws_operation_name": self.operation_name.clone()
+        })
+    }
+
     /// Returns the CLI arguments properly formatted as kebab case if parameters is
     /// [Option::Some], otherwise None
     fn cli_parameters(&self) -> Option<Vec<(String, String)>> {

--- a/crates/chat-cli/src/cli/mod.rs
+++ b/crates/chat-cli/src/cli/mod.rs
@@ -141,7 +141,10 @@ impl RootSubcommand {
 
         // Send executed telemetry.
         if self.valid_for_telemetry() {
-            os.telemetry.send_cli_subcommand_executed(&self).ok();
+            os.telemetry
+                .send_cli_subcommand_executed(&os.database, &self)
+                .await
+                .ok();
         }
 
         match self {

--- a/crates/chat-cli/src/telemetry/core.rs
+++ b/crates/chat-cli/src/telemetry/core.rs
@@ -49,6 +49,7 @@ pub struct Event {
     pub created_time: Option<SystemTime>,
     pub credential_start_url: Option<String>,
     pub sso_region: Option<String>,
+    pub client_application: Option<String>,
     #[serde(flatten)]
     pub ty: EventType,
 }
@@ -60,6 +61,7 @@ impl Event {
             created_time: Some(SystemTime::now()),
             credential_start_url: None,
             sso_region: None,
+            client_application: None,
         }
     }
 
@@ -69,6 +71,10 @@ impl Event {
 
     pub fn set_sso_region(&mut self, sso_region: String) {
         self.sso_region = Some(sso_region);
+    }
+
+    pub fn set_client_application(&mut self, client_application: String) {
+        self.client_application = Some(client_application);
     }
 
     pub fn into_metric_datum(self) -> Option<MetricDatum> {
@@ -107,6 +113,7 @@ impl Event {
                     credential_start_url: self.credential_start_url.map(Into::into),
                     codewhispererterminal_subcommand: Some(subcommand.into()),
                     codewhispererterminal_in_cloudshell: None,
+                    codewhispererterminal_client_application: self.client_application.map(Into::into),
                 }
                 .into_metric_datum(),
             ),
@@ -209,6 +216,7 @@ impl Event {
                             .join(",")
                             .into(),
                     ),
+                    codewhispererterminal_client_application: self.client_application.map(Into::into),
                 }
                 .into_metric_datum(),
             ),
@@ -294,6 +302,8 @@ impl Event {
                 model,
                 execution_duration,
                 turn_duration,
+                aws_service_name,
+                aws_operation_name,
             } => Some(
                 CodewhispererterminalToolUseSuggested {
                     create_time: self.created_time,
@@ -323,6 +333,9 @@ impl Event {
                     codewhispererterminal_tool_turn_duration_ms: turn_duration
                         .map(|d| d.as_millis() as i64)
                         .map(Into::into),
+                    codewhispererterminal_client_application: self.client_application.map(Into::into),
+                    codewhispererterminal_aws_service_name: aws_service_name.map(Into::into),
+                    codewhispererterminal_aws_operation_name: aws_operation_name.map(Into::into),
                 }
                 .into_metric_datum(),
             ),
@@ -343,6 +356,7 @@ impl Event {
                     codewhispererterminal_tools_per_mcp_server: Some(CodewhispererterminalToolsPerMcpServer(
                         number_of_tools as i64,
                     )),
+                    codewhispererterminal_client_application: self.client_application.map(Into::into),
                 }
                 .into_metric_datum(),
             ),
@@ -431,6 +445,7 @@ impl Event {
                     status_code: status_code.map(|v| v as i64).map(Into::into),
                     request_id: request_id.map(Into::into),
                     codewhispererterminal_utterance_id: message_id.map(Into::into),
+                    codewhispererterminal_client_application: self.client_application.map(Into::into),
                 }
                 .into_metric_datum(),
             ),
@@ -562,6 +577,8 @@ pub enum EventType {
         model: Option<String>,
         execution_duration: Option<Duration>,
         turn_duration: Option<Duration>,
+        aws_service_name: Option<String>,
+        aws_operation_name: Option<String>,
     },
     McpServerInit {
         conversation_id: String,
@@ -617,6 +634,8 @@ pub struct ToolUseEventBuilder {
     pub model: Option<String>,
     pub execution_duration: Option<Duration>,
     pub turn_duration: Option<Duration>,
+    pub aws_service_name: Option<String>,
+    pub aws_operation_name: Option<String>,
 }
 
 impl ToolUseEventBuilder {
@@ -639,6 +658,8 @@ impl ToolUseEventBuilder {
             model,
             execution_duration: None,
             turn_duration: None,
+            aws_service_name: None,
+            aws_operation_name: None,
         }
     }
 

--- a/crates/chat-cli/src/telemetry/definitions.rs
+++ b/crates/chat-cli/src/telemetry/definitions.rs
@@ -43,6 +43,7 @@ mod tests {
             codewhispererterminal_tool_name: None,
             codewhispererterminal_assistant_response_length: Some(20.into()),
             codewhispererterminal_chat_message_meta_tags: Some([MessageMetaTag::Compact.to_string()].join(",").into()),
+            codewhispererterminal_client_application: None,
         });
 
         let s = serde_json::to_string_pretty(&metric_datum_init).unwrap();

--- a/crates/chat-cli/src/util/consts.rs
+++ b/crates/chat-cli/src/util/consts.rs
@@ -66,7 +66,10 @@ pub mod env_var {
         Q_USING_ZSH_AUTOSUGGESTIONS = "Q_USING_ZSH_AUTOSUGGESTIONS",
 
         /// Overrides the path to the bundle metadata released with certain desktop builds.
-        Q_BUNDLE_METADATA_PATH = "Q_BUNDLE_METADATA_PATH"
+        Q_BUNDLE_METADATA_PATH = "Q_BUNDLE_METADATA_PATH",
+
+        /// Identifier for the client application or service using the chat-cli
+        Q_CLI_CLIENT_APPLICATION = "Q_CLI_CLIENT_APPLICATION"
     }
 }
 

--- a/crates/chat-cli/telemetry_definitions.json
+++ b/crates/chat-cli/telemetry_definitions.json
@@ -96,6 +96,16 @@
       "description": "Comma-delimited tool name(s) of the tool uses requested by the model."
     },
     {
+      "name": "codewhispererterminal_AwsServiceName",
+      "type": "string",
+      "description": "AWS service called by the tool"
+    },
+    {
+      "name": "codewhispererterminal_AwsOperationName",
+      "type": "string",
+      "description": "Specific operation of the AWS service invoked by the tool"
+    },
+    {
       "name": "codewhispererterminal_isToolUseAccepted",
       "type": "boolean",
       "description": "Denotes if a tool use event has been fulfilled"
@@ -248,6 +258,11 @@
       "name": "codewhispererterminal_launchedAgent",
       "type": "string",
       "description": "The name of the agent launched by the user on startup"
+    },
+    {
+      "name": "codewhispererterminal_clientApplication",
+      "type": "string",
+      "description": "Identifier for the client application or service using the chat-cli"
     }
   ],
   "metrics": [
@@ -283,7 +298,8 @@
         { "type": "codewhispererterminal_toolUseId", "required": false },
         { "type": "codewhispererterminal_toolName", "required": false },
         { "type": "codewhispererterminal_assistantResponseLength", "required": false },
-        { "type": "codewhispererterminal_chatMessageMetaTags", "required": false }
+        { "type": "codewhispererterminal_chatMessageMetaTags", "required": false },
+        { "type": "codewhispererterminal_clientApplication" }
       ]
     },
     {
@@ -348,7 +364,8 @@
       "metadata": [
         { "type": "credentialStartUrl" },
         { "type": "codewhispererterminal_subcommand" },
-        { "type": "codewhispererterminal_inCloudshell" }
+        { "type": "codewhispererterminal_inCloudshell" },
+        { "type": "codewhispererterminal_clientApplication" }
       ]
     },
     {
@@ -394,7 +411,10 @@
         { "type": "codewhispererterminal_model" },
         { "type": "codewhispererterminal_toolExecutionDurationMs", "required": false },
         { "type": "codewhispererterminal_toolTurnDurationMs", "required": false },
-        { "type": "codewhispererterminal_isToolUseTrusted", "required": false }
+        { "type": "codewhispererterminal_isToolUseTrusted", "required": false },
+        { "type": "codewhispererterminal_clientApplication" },
+        { "type": "codewhispererterminal_AwsServiceName", "required": false },
+        { "type": "codewhispererterminal_AwsOperationName", "required": false }
       ]
     },
     {
@@ -409,7 +429,8 @@
           "type": "codewhispererterminal_mcpServerInitFailureReason",
           "required": false
         },
-        { "type": "codewhispererterminal_toolsPerMcpServer" }
+        { "type": "codewhispererterminal_toolsPerMcpServer" },
+        { "type": "codewhispererterminal_clientApplication" }
       ]
     },
     {
@@ -464,7 +485,8 @@
           { "type": "result" },
           { "type": "reason", "required": false },
           { "type": "reasonDesc", "required": false },
-          { "type": "statusCode", "required": false }
+          { "type": "statusCode", "required": false },
+          { "type": "codewhispererterminal_clientApplication" }
       ]
     }
   ]


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

1. New metric referring the client application using the Q CLI
a. Use Q_CLI_CLIENT_APPLICATION environment variable to set this field
b. Telemetry events supporting this new metric:
     1. ChatAddedMessage
     2. CliSubcommandExecuted
     3. ToolUseSuggested
     4. McpServerInit
      5. MessageResponseError

2. Additional information about the tool being used
a. Example for use_aws tool: aws_service_name and aws_operation_name
b. Any tool can leverage this metric in future if needed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
