### PR TITLE
feat: add timestamp for new user prompts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,6 +1224,7 @@ dependencies = [
  "bytes",
  "camino",
  "cfg-if",
+ "chrono",
  "clap",
  "clap_complete",
  "clap_complete_fig",

--- a/crates/chat-cli/Cargo.toml
+++ b/crates/chat-cli/Cargo.toml
@@ -45,6 +45,7 @@ bstr.workspace = true
 bytes.workspace = true
 camino.workspace = true
 cfg-if.workspace = true
+chrono.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
 clap_complete_fig.workspace = true

--- a/crates/chat-cli/src/cli/chat/conversation.rs
+++ b/crates/chat-cli/src/cli/chat/conversation.rs
@@ -67,8 +67,8 @@ use crate::cli::chat::ChatError;
 use crate::mcp_client::Prompt;
 use crate::os::Os;
 
-const CONTEXT_ENTRY_START_HEADER: &str = "--- CONTEXT ENTRY BEGIN ---\n";
-const CONTEXT_ENTRY_END_HEADER: &str = "--- CONTEXT ENTRY END ---\n\n";
+pub const CONTEXT_ENTRY_START_HEADER: &str = "--- CONTEXT ENTRY BEGIN ---\n";
+pub const CONTEXT_ENTRY_END_HEADER: &str = "--- CONTEXT ENTRY END ---\n\n";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HistoryEntry {


### PR DESCRIPTION
*Description of changes:*
- Previously the backend API would add a timestamp as part of the system prompt. Now, it is being removed in favor of letting the client implement this behavior.
- Only adding the timestamp for new user prompts, since tool use results don't have any content to be sent with the prompt.
- Reasoning behind having a timestamp: this enables temporal questions like "what did we do in the last hour" to be answered.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
