### PR TITLE
feat: implement hierarchical agent config discovery

### DIFF
--- a/crates/chat-cli/src/util/directories.rs
+++ b/crates/chat-cli/src/util/directories.rs
@@ -165,6 +165,11 @@ pub fn chat_local_agent_dir(os: &Os) -> Result<PathBuf> {
     Ok(cwd.join(WORKSPACE_AGENT_DIR_RELATIVE))
 }
 
+/// Directory for agent config relative to given path
+pub fn chat_relative_agent_dir(dir: PathBuf) -> Result<PathBuf> {
+    Ok(dir.join(WORKSPACE_AGENT_DIR_RELATIVE))
+}
+
 /// Derives the absolute path to an agent config directory given a "workspace directory".
 /// A workspace directory is a directory where q chat is to be launched
 ///


### PR DESCRIPTION
# Implement hierarchical agent config discovery

## Overview

This pull request modifies local agent discovery to look for `.amazonq/cli-agents/` not just in the current directory but in
all directories above. 

## Problem Statement

The AWS documentation for Q CLI states, under [Managing custom agents](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-custom-agents-management.html) that "Project-level custom agents" are "Available only within the specific project directory and its subdirectories."

However this is not _quite_ correct. Project-level custom agents are available _only_ in the specific project directory, and not in its subdirectories.

This change fixes the behavior to match the documentation.

## Key Changes Made

1. **`crates/chat-cli/src/cli/agent/mod.rs`** - Agent Management
   - modified `Agents::load` to search for local agents starting with the current working directory and then iterating upwards

2. **`crates/chat-cli/src/util/directories.rs`** - Directory Utils
   - Add chat_relative_agent_dir helper function for relative path resolution

## Testing & Verification

### Build Verification ✅
- ✅ **Successful compilation**: `cargo build --release` completes without errors
- ✅ **Clean warnings**: Only expected warnings about unused helper functions
- ✅ **No breaking changes**: All existing functionality preserved

### Manual Testing Performed
- Created ./amazonq/cli-agents/MyAgent.json
- Verified that `chat_cli chat --agent=MyAgent` worked in directory with .amazonq/... and subdirectories.
- Verified that named agent not found in parent of that directory.

## Backward Compatibility
- ✅ All existing functionality preserved
- ✅ No API changes
- ✅ No configuration changes required
- ✅ No breaking changes to existing workflows


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
