### PR TITLE
fix(tools): show all native tools in /tools command

### DIFF
--- a/crates/chat-cli/src/cli/chat/tool_manager.rs
+++ b/crates/chat-cli/src/cli/chat/tool_manager.rs
@@ -897,11 +897,13 @@ impl ToolManager {
                 serde_json::from_str::<HashMap<String, ToolSpec>>(include_str!("tools/tool_index.json"))?
                     .into_iter()
                     .filter(|(name, _)| {
+                        use crate::cli::chat::tools::NATIVE_TOOLS;
                         name == DUMMY_TOOL_NAME
                             || is_allow_all
                             || is_allow_native
                             || tool_list.contains(name)
                             || tool_list.contains(&format!("@builtin/{name}"))
+                            || NATIVE_TOOLS.contains(&name.as_str())
                     })
                     .collect::<HashMap<_, _>>();
             if !crate::cli::chat::tools::thinking::Thinking::is_enabled(os) {


### PR DESCRIPTION
Always load native tools regardless of agent configuration so users can see complete tool list with permission status. Fixes empty /tools output when tools have settings but aren't in allowedTools.



<img width="924" height="613" alt="SCR-20250812-movk" src="https://github.com/user-attachments/assets/e40b8bdf-9c08-41b9-a0ad-01244a77ca3d" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
