### PR TITLE
Build for running in windows natively

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/chat-cli"]
 
 [workspace.package]
 authors = ["Amazon Q CLI Team (q-cli@amazon.com)", "Chay Nabors (nabochay@amazon.com)", "Brandon Kiser (bskiser@amazon.com)", "Felix Ding (dingfeli@amazon.com)"]
-edition = "2024"
+edition = "2021"
 homepage = "https://aws.amazon.com/q/"
 publish = false
 version = "1.19.0"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 - **macOS**:
   - **DMG**: [Download now](https://desktop-release.q.us-east-1.amazonaws.com/latest/Amazon%20Q.dmg)
   - **HomeBrew**: ```brew install --cask amazon-q ```
+- **Windows**:
+  - **ZIP**: [Download now](https://desktop-release.q.us-east-1.amazonaws.com/latest/qchat-windows.zip)
+  - **Executable**: [Download now](https://desktop-release.q.us-east-1.amazonaws.com/latest/qchat.exe)
 - **Linux**:
   - [Ubuntu/Debian](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-installing.html#command-line-installing-ubuntu)
   - [AppImage](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-installing.html#command-line-installing-appimage)
@@ -18,9 +21,16 @@ Before getting started, see our [contributing docs](CONTRIBUTING.md#security-iss
 
 ### Prerequisites
 
-- MacOS
+- **macOS**
   - Xcode 13 or later
   - Brew
+- **Windows**
+  - Visual Studio 2019 or later (with C++ build tools)
+  - PowerShell 5.1 or later
+  - Git for Windows
+- **Linux**
+  - GCC or Clang
+  - Git
 
 #### 1. Clone repo
 
@@ -30,8 +40,22 @@ git clone https://github.com/aws/amazon-q-developer-cli.git
 
 #### 2. Install the Rust toolchain using [Rustup](https://rustup.rs):
 
+**macOS/Linux:**
+
 ```shell
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+rustup default stable
+rustup toolchain install nightly
+cargo install typos-cli
+```
+
+**Windows:**
+
+```powershell
+# Download and run rustup-init.exe from https://rustup.rs/
+# Or use the following PowerShell command:
+Invoke-WebRequest -Uri "https://win.rustup.rs/x86_64" -OutFile "rustup-init.exe"
+.\rustup-init.exe
 rustup default stable
 rustup toolchain install nightly
 cargo install typos-cli

--- a/crates/chat-cli/Cargo.toml
+++ b/crates/chat-cli/Cargo.toml
@@ -65,7 +65,6 @@ indicatif.workspace = true
 indoc.workspace = true
 insta.workspace = true
 libc.workspace = true
-mimalloc.workspace = true
 nix.workspace = true
 owo-colors.workspace = true
 parking_lot.workspace = true

--- a/scripts/util.py
+++ b/scripts/util.py
@@ -33,6 +33,11 @@ def isLinux() -> bool:
 
 
 @cache
+def isWindows() -> bool:
+    return platform.system() == "Windows"
+
+
+@cache
 def isMusl() -> bool:
     return os.environ.get("AMAZON_Q_BUILD_MUSL") is not None
 


### PR DESCRIPTION
in reference of #153 , #2063, 

*Description of changes:*
- Support native run in windows (no WSL required)
- Support default agent mcps in native windows (custom agents are already supported)

_notes_

- in order to execute need there's a pre-requirement of 3 DLLs (libwinpthread-1.dll, libstdc++-6.dll, libgcc_s_seh-1.dll) all taken from latest installation of [msys2](https://www.msys2.org/) in `c:\msys64\mingw64\bin\`
- also need to define `"tools": ["*"]` when mcp is configured in custom agent