### PR TITLE
fix:  Add client-side modelName mapping for backward compatibility 

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/model.rs
+++ b/crates/chat-cli/src/cli/chat/cli/model.rs
@@ -196,9 +196,26 @@ fn get_fallback_models() -> Vec<ModelInfo> {
             context_window_tokens: 200_000,
         },
         ModelInfo {
-            model_name: Some("claude-4-sonnet".to_string()),
-            model_id: "claude-4-sonnet".to_string(),
+            model_name: Some("claude-sonnet-4".to_string()),
+            model_id: "claude-sonnet-4".to_string(),
             context_window_tokens: 200_000,
         },
     ]
+}
+
+pub fn normalize_model_name(name: &str) -> &str {
+    match name {
+        "claude-4-sonnet" => "claude-sonnet-4",
+        // can add more mapping for backward compatibility
+        _ => name,
+    }
+}
+
+pub fn find_model<'a>(models: &'a [ModelInfo], name: &str) -> Option<&'a ModelInfo> {
+    let normalized = normalize_model_name(name);
+    models.iter().find(|m| {
+        [name, normalized].iter().any(|n| {
+            m.model_id.eq_ignore_ascii_case(n) || m.model_name.as_deref().is_some_and(|mn| mn.eq_ignore_ascii_case(n))
+        })
+    })
 }

--- a/crates/chat-cli/src/cli/chat/cli/model.rs
+++ b/crates/chat-cli/src/cli/chat/cli/model.rs
@@ -214,8 +214,9 @@ pub fn normalize_model_name(name: &str) -> &str {
 pub fn find_model<'a>(models: &'a [ModelInfo], name: &str) -> Option<&'a ModelInfo> {
     let normalized = normalize_model_name(name);
     models.iter().find(|m| {
-        [name, normalized].iter().any(|n| {
-            m.model_id.eq_ignore_ascii_case(n) || m.model_name.as_deref().is_some_and(|mn| mn.eq_ignore_ascii_case(n))
-        })
+        m.model_name
+            .as_deref()
+            .is_some_and(|n| n.eq_ignore_ascii_case(normalized))
+            || m.model_id.eq_ignore_ascii_case(normalized)
     })
 }

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -16,6 +16,7 @@ mod server_messenger;
 mod skim_integration;
 mod token_counter;
 pub mod tool_manager;
+use crate::cli::chat::cli::model::find_model;
 pub mod tools;
 pub mod util;
 use std::borrow::Cow;
@@ -315,13 +316,7 @@ impl ChatArgs {
         // Otherwise, CLI will use a default model when starting chat
         let (models, default_model_opt) = get_available_models(os).await?;
         let model_id: Option<String> = if let Some(requested) = self.model.as_ref() {
-            let requested_lower = requested.to_lowercase();
-            if let Some(m) = models.iter().find(|m| {
-                m.model_name
-                    .as_deref()
-                    .is_some_and(|n| n.eq_ignore_ascii_case(&requested_lower))
-                    || m.model_id.eq_ignore_ascii_case(&requested_lower)
-            }) {
+            if let Some(m) = find_model(&models, requested) {
                 Some(m.model_id.clone())
             } else {
                 let available = models
@@ -332,14 +327,9 @@ impl ChatArgs {
                 bail!("Model '{}' does not exist. Available models: {}", requested, available);
             }
         } else if let Some(saved) = os.database.settings.get_string(Setting::ChatDefaultModel) {
-            if let Some(m) = models.iter().find(|m| {
-                m.model_name.as_deref().is_some_and(|n| n.eq_ignore_ascii_case(&saved))
-                    || m.model_id.eq_ignore_ascii_case(&saved)
-            }) {
-                Some(m.model_id.clone())
-            } else {
-                Some(default_model_opt.model_id.clone())
-            }
+            find_model(&models, &saved)
+                .map(|m| m.model_id.clone())
+                .or(Some(default_model_opt.model_id.clone()))
         } else {
             Some(default_model_opt.model_id.clone())
         };

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -16,7 +16,6 @@ mod server_messenger;
 mod skim_integration;
 mod token_counter;
 pub mod tool_manager;
-use crate::cli::chat::cli::model::find_model;
 pub mod tools;
 pub mod util;
 use std::borrow::Cow;
@@ -134,6 +133,7 @@ use crate::auth::AuthError;
 use crate::auth::builder_id::is_idc_user;
 use crate::cli::agent::Agents;
 use crate::cli::chat::cli::SlashCommand;
+use crate::cli::chat::cli::model::find_model;
 use crate::cli::chat::cli::prompts::{
     GetPromptError,
     PromptsSubcommand,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The service side has changed the model name from` claude-4-sonnet` to `claude-sonnet-4`. Add a client-side mapping to ensure backward compatibility when invoking Q or updating q settings for chat.defaultModel with either model. This should also remain consistent with the plugin.

### Invoke chat with `claude-4-sonnet`:
<img width="781" height="430" alt="image" src="https://github.com/user-attachments/assets/abdc54be-1a35-4216-b263-a166d2b65177" />


### Invoke chat with `claude-sonnet-4`:
<img width="777" height="446" alt="Screenshot 2025-08-13 at 2 49 19 PM" src="https://github.com/user-attachments/assets/89989352-f3c7-4797-b918-8abda16054c0" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
