### PR TITLE
fix: add more safety checks for execute_bash readonly checks

### DIFF
--- a/crates/chat-cli/src/cli/chat/tools/execute/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/execute/mod.rs
@@ -49,7 +49,7 @@ pub struct ExecuteCommand {
 impl ExecuteCommand {
     pub fn requires_acceptance(&self, allowed_commands: Option<&Vec<String>>, allow_read_only: bool) -> bool {
         // Always require acceptance for multi-line commands.
-        if self.command.contains("\n") {
+        if self.command.contains("\n") || self.command.contains("\r") {
             return true;
         }
 


### PR DESCRIPTION
*Description of changes:*
- Currently the read-only checks for `execute_bash` allow certain modifiable operations to be allowed. This PR is adding additional checks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
