### PR TITLE
fix(agent): tool permission override

### DIFF
--- a/crates/chat-cli/src/cli/agent/mod.rs
+++ b/crates/chat-cli/src/cli/agent/mod.rs
@@ -254,37 +254,37 @@ impl Agent {
                 // currently we only have four native tools that offers tool settings
                 match allowed_tool.as_str() {
                     "fs_read" => {
-                        if let Some(overriden_settings) = FsRead::allowable_field_to_be_overriden(settings) {
+                        if let Some(overridden_settings) = FsRead::allowable_field_to_be_overridden(settings) {
                             queue_permission_override_warning(
                                 allowed_tool.as_str(),
-                                overriden_settings.as_str(),
+                                overridden_settings.as_str(),
                                 output,
                             )?;
                         }
                     },
                     "fs_write" => {
-                        if let Some(overriden_settings) = FsWrite::allowable_field_to_be_overriden(settings) {
+                        if let Some(overridden_settings) = FsWrite::allowable_field_to_be_overridden(settings) {
                             queue_permission_override_warning(
                                 allowed_tool.as_str(),
-                                overriden_settings.as_str(),
+                                overridden_settings.as_str(),
                                 output,
                             )?;
                         }
                     },
                     "use_aws" => {
-                        if let Some(overriden_settings) = UseAws::allowable_field_to_be_overriden(settings) {
+                        if let Some(overridden_settings) = UseAws::allowable_field_to_be_overridden(settings) {
                             queue_permission_override_warning(
                                 allowed_tool.as_str(),
-                                overriden_settings.as_str(),
+                                overridden_settings.as_str(),
                                 output,
                             )?;
                         }
                     },
                     name if name == execute_name => {
-                        if let Some(overriden_settings) = ExecuteCommand::allowable_field_to_be_overriden(settings) {
+                        if let Some(overridden_settings) = ExecuteCommand::allowable_field_to_be_overridden(settings) {
                             queue_permission_override_warning(
                                 allowed_tool.as_str(),
-                                overriden_settings.as_str(),
+                                overridden_settings.as_str(),
                                 output,
                             )?;
                         }

--- a/crates/chat-cli/src/cli/agent/mod.rs
+++ b/crates/chat-cli/src/cli/agent/mod.rs
@@ -54,6 +54,10 @@ pub use wrapper_types::{
     tool_settings_schema,
 };
 
+use super::chat::tools::execute::ExecuteCommand;
+use super::chat::tools::fs_read::FsRead;
+use super::chat::tools::fs_write::FsWrite;
+use super::chat::tools::use_aws::UseAws;
 use super::chat::tools::{
     DEFAULT_APPROVE,
     NATIVE_TOOLS,
@@ -213,8 +217,8 @@ impl Agent {
 
         self.path = Some(path.to_path_buf());
 
+        let mut stderr = std::io::stderr();
         if let (true, Some(legacy_mcp_config)) = (self.use_legacy_mcp_json, legacy_mcp_config) {
-            let mut stderr = std::io::stderr();
             for (name, legacy_server) in &legacy_mcp_config.mcp_servers {
                 if mcp_servers.mcp_servers.contains_key(name) {
                     let _ = queue!(
@@ -235,6 +239,58 @@ impl Agent {
                 let mut server_clone = legacy_server.clone();
                 server_clone.is_from_legacy_mcp_json = true;
                 mcp_servers.mcp_servers.insert(name.clone(), server_clone);
+            }
+        }
+
+        stderr.flush()?;
+
+        Ok(())
+    }
+
+    pub fn validate_tool_settings(&self, output: &mut impl Write) -> Result<(), AgentConfigError> {
+        let execute_name = if cfg!(windows) { "execute_cmd" } else { "execute_bash" };
+        for allowed_tool in &self.allowed_tools {
+            if let Some(settings) = self.tools_settings.get(allowed_tool.as_str()) {
+                // currently we only have four native tools that offers tool settings
+                match allowed_tool.as_str() {
+                    "fs_read" => {
+                        if let Some(overriden_settings) = FsRead::allowable_field_to_be_overriden(settings) {
+                            queue_permission_override_warning(
+                                allowed_tool.as_str(),
+                                overriden_settings.as_str(),
+                                output,
+                            )?;
+                        }
+                    },
+                    "fs_write" => {
+                        if let Some(overriden_settings) = FsWrite::allowable_field_to_be_overriden(settings) {
+                            queue_permission_override_warning(
+                                allowed_tool.as_str(),
+                                overriden_settings.as_str(),
+                                output,
+                            )?;
+                        }
+                    },
+                    "use_aws" => {
+                        if let Some(overriden_settings) = UseAws::allowable_field_to_be_overriden(settings) {
+                            queue_permission_override_warning(
+                                allowed_tool.as_str(),
+                                overriden_settings.as_str(),
+                                output,
+                            )?;
+                        }
+                    },
+                    name if name == execute_name => {
+                        if let Some(overriden_settings) = ExecuteCommand::allowable_field_to_be_overriden(settings) {
+                            queue_permission_override_warning(
+                                allowed_tool.as_str(),
+                                overriden_settings.as_str(),
+                                output,
+                            )?;
+                        }
+                    },
+                    _ => {},
+                }
             }
         }
 
@@ -801,6 +857,28 @@ async fn load_legacy_mcp_config(os: &Os) -> eyre::Result<Option<McpServerConfig>
         (Some(wc), None) => Some(wc),
         _ => None,
     })
+}
+
+pub fn queue_permission_override_warning(
+    tool_name: &str,
+    overridden_settings: &str,
+    output: &mut impl Write,
+) -> Result<(), std::io::Error> {
+    Ok(queue!(
+        output,
+        style::SetForegroundColor(Color::Yellow),
+        style::Print("WARN: "),
+        style::ResetColor,
+        style::Print("You have trusted "),
+        style::SetForegroundColor(Color::Green),
+        style::Print(tool_name),
+        style::ResetColor,
+        style::Print(" tool, which overrides the toolsSettings: "),
+        style::SetForegroundColor(Color::Cyan),
+        style::Print(overridden_settings),
+        style::ResetColor,
+        style::Print("\n"),
+    )?)
 }
 
 fn default_schema() -> String {

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -1756,6 +1756,12 @@ impl ChatSession {
                             .clone()
                             .unwrap_or(tool_use.name.clone());
                         self.conversation.agents.trust_tools(vec![formatted_tool_name]);
+
+                        if let Some(agent) = self.conversation.agents.get_active() {
+                            agent
+                                .validate_tool_settings(&mut self.stderr)
+                                .map_err(|_e| ChatError::Custom("Failed to validate agent tool settings".into()))?;
+                        }
                     }
                     tool_use.accepted = true;
 

--- a/crates/chat-cli/src/cli/chat/tools/execute/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/execute/mod.rs
@@ -202,7 +202,7 @@ impl ExecuteCommand {
         let tool_name = if cfg!(windows) { "execute_cmd" } else { "execute_bash" };
         let is_in_allowlist = agent.allowed_tools.contains(tool_name);
         match agent.tools_settings.get(tool_name) {
-            Some(settings) if is_in_allowlist => {
+            Some(settings) => {
                 let Settings {
                     allowed_commands,
                     denied_commands,
@@ -226,7 +226,7 @@ impl ExecuteCommand {
                     return PermissionEvalResult::Deny(denied_match_set);
                 }
 
-                if self.requires_acceptance(Some(&allowed_commands), allow_read_only) {
+                if !is_in_allowlist || self.requires_acceptance(Some(&allowed_commands), allow_read_only) {
                     PermissionEvalResult::Ask
                 } else {
                     PermissionEvalResult::Allow
@@ -263,10 +263,7 @@ pub fn format_output(output: &str, max_size: usize) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{
-        HashMap,
-        HashSet,
-    };
+    use std::collections::HashMap;
 
     use super::*;
     use crate::cli::agent::ToolSettingTarget;
@@ -408,13 +405,8 @@ mod tests {
     #[test]
     fn test_eval_perm() {
         let tool_name = if cfg!(windows) { "execute_cmd" } else { "execute_bash" };
-        let agent = Agent {
+        let mut agent = Agent {
             name: "test_agent".to_string(),
-            allowed_tools: {
-                let mut allowed_tools = HashSet::<String>::new();
-                allowed_tools.insert(tool_name.to_string());
-                allowed_tools
-            },
             tools_settings: {
                 let mut map = HashMap::<ToolSettingTarget, serde_json::Value>::new();
                 map.insert(
@@ -428,20 +420,32 @@ mod tests {
             ..Default::default()
         };
 
-        let tool = serde_json::from_value::<ExecuteCommand>(serde_json::json!({
+        let tool_one = serde_json::from_value::<ExecuteCommand>(serde_json::json!({
             "command": "git status",
         }))
         .unwrap();
 
-        let res = tool.eval_perm(&agent);
+        let res = tool_one.eval_perm(&agent);
         assert!(matches!(res, PermissionEvalResult::Deny(ref rules) if rules.contains(&"\\Agit .*\\z".to_string())));
 
-        let tool = serde_json::from_value::<ExecuteCommand>(serde_json::json!({
+        let tool_two = serde_json::from_value::<ExecuteCommand>(serde_json::json!({
             "command": "echo hello",
         }))
         .unwrap();
 
-        let res = tool.eval_perm(&agent);
+        let res = tool_two.eval_perm(&agent);
+        assert!(matches!(res, PermissionEvalResult::Ask));
+
+        agent.allowed_tools.insert(tool_name.to_string());
+
+        let res = tool_two.eval_perm(&agent);
+        assert!(matches!(res, PermissionEvalResult::Allow));
+
+        // Denied list should remain denied
+        let res = tool_one.eval_perm(&agent);
+        assert!(matches!(res, PermissionEvalResult::Deny(ref rules) if rules.contains(&"\\Agit .*\\z".to_string())));
+
+        let res = tool_two.eval_perm(&agent);
         assert!(matches!(res, PermissionEvalResult::Allow));
     }
 

--- a/crates/chat-cli/src/cli/chat/tools/execute/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/execute/mod.rs
@@ -176,7 +176,7 @@ impl ExecuteCommand {
         Ok(())
     }
 
-    pub fn allowable_field_to_be_overriden(settings: &serde_json::Value) -> Option<String> {
+    pub fn allowable_field_to_be_overridden(settings: &serde_json::Value) -> Option<String> {
         settings
             .get("allowedCommands")
             .map(|value| format!("allowedCommands: {}", value))

--- a/crates/chat-cli/src/cli/chat/tools/execute/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/execute/mod.rs
@@ -176,6 +176,12 @@ impl ExecuteCommand {
         Ok(())
     }
 
+    pub fn allowable_field_to_be_overriden(settings: &serde_json::Value) -> Option<String> {
+        settings
+            .get("allowedCommands")
+            .map(|value| format!("allowedCommands: {}", value))
+    }
+
     pub fn eval_perm(&self, agent: &Agent) -> PermissionEvalResult {
         #[derive(Debug, Deserialize)]
         #[serde(rename_all = "camelCase")]

--- a/crates/chat-cli/src/cli/chat/tools/fs_read.rs
+++ b/crates/chat-cli/src/cli/chat/tools/fs_read.rs
@@ -126,7 +126,7 @@ impl FsRead {
 
         let is_in_allowlist = agent.allowed_tools.contains("fs_read");
         match agent.tools_settings.get("fs_read") {
-            Some(settings) if is_in_allowlist => {
+            Some(settings) => {
                 let Settings {
                     allowed_paths,
                     denied_paths,
@@ -188,7 +188,7 @@ impl FsRead {
 
                                     // We only want to ask if we are not allowing read only
                                     // operation
-                                    if !allow_read_only && !allow_set.is_match(path) {
+                                    if !is_in_allowlist && !allow_read_only && !allow_set.is_match(path) {
                                         ask = true;
                                     }
                                 },
@@ -209,7 +209,10 @@ impl FsRead {
 
                                     // We only want to ask if we are not allowing read only
                                     // operation
-                                    if !allow_read_only && !paths.iter().any(|path| allow_set.is_match(path)) {
+                                    if !is_in_allowlist
+                                        && !allow_read_only
+                                        && !paths.iter().any(|path| allow_set.is_match(path))
+                                    {
                                         ask = true;
                                     }
                                 },
@@ -844,10 +847,7 @@ fn format_mode(mode: u32) -> [char; 9] {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{
-        HashMap,
-        HashSet,
-    };
+    use std::collections::HashMap;
 
     use super::*;
     use crate::cli::agent::ToolSettingTarget;
@@ -1387,13 +1387,8 @@ mod tests {
         const DENIED_PATH_ONE: &str = "/some/denied/path";
         const DENIED_PATH_GLOB: &str = "/denied/glob/**/path";
 
-        let agent = Agent {
+        let mut agent = Agent {
             name: "test_agent".to_string(),
-            allowed_tools: {
-                let mut allowed_tools = HashSet::<String>::new();
-                allowed_tools.insert("fs_read".to_string());
-                allowed_tools
-            },
             tools_settings: {
                 let mut map = HashMap::<ToolSettingTarget, serde_json::Value>::new();
                 map.insert(
@@ -1407,7 +1402,7 @@ mod tests {
             ..Default::default()
         };
 
-        let tool = serde_json::from_value::<FsRead>(serde_json::json!({
+        let tool_one = serde_json::from_value::<FsRead>(serde_json::json!({
             "operations": [
                 { "path": DENIED_PATH_ONE, "mode": "Line", "start_line": 1, "end_line": 2 },
                 { "path": "/denied/glob", "mode": "Directory" },
@@ -1418,7 +1413,17 @@ mod tests {
         }))
         .unwrap();
 
-        let res = tool.eval_perm(&agent);
+        let res = tool_one.eval_perm(&agent);
+        assert!(matches!(
+            res,
+            PermissionEvalResult::Deny(ref deny_list)
+                if deny_list.iter().filter(|p| *p == DENIED_PATH_GLOB).collect::<Vec<_>>().len() == 2
+                && deny_list.iter().filter(|p| *p == DENIED_PATH_ONE).collect::<Vec<_>>().len() == 1
+        ));
+
+        agent.allowed_tools.insert("fs_read".to_string());
+
+        let res = tool_one.eval_perm(&agent);
         assert!(matches!(
             res,
             PermissionEvalResult::Deny(ref deny_list)

--- a/crates/chat-cli/src/cli/chat/tools/fs_read.rs
+++ b/crates/chat-cli/src/cli/chat/tools/fs_read.rs
@@ -102,6 +102,12 @@ impl FsRead {
         }
     }
 
+    pub fn allowable_field_to_be_overriden(settings: &serde_json::Value) -> Option<String> {
+        settings
+            .get("allowedPaths")
+            .map(|value| format!("allowedPaths: {}", value))
+    }
+
     pub fn eval_perm(&self, agent: &Agent) -> PermissionEvalResult {
         #[derive(Debug, Deserialize)]
         #[serde(rename_all = "camelCase")]

--- a/crates/chat-cli/src/cli/chat/tools/fs_read.rs
+++ b/crates/chat-cli/src/cli/chat/tools/fs_read.rs
@@ -102,7 +102,7 @@ impl FsRead {
         }
     }
 
-    pub fn allowable_field_to_be_overriden(settings: &serde_json::Value) -> Option<String> {
+    pub fn allowable_field_to_be_overridden(settings: &serde_json::Value) -> Option<String> {
         settings
             .get("allowedPaths")
             .map(|value| format!("allowedPaths: {}", value))

--- a/crates/chat-cli/src/cli/chat/tools/fs_write.rs
+++ b/crates/chat-cli/src/cli/chat/tools/fs_write.rs
@@ -415,6 +415,12 @@ impl FsWrite {
         }
     }
 
+    pub fn allowable_field_to_be_overriden(settings: &serde_json::Value) -> Option<String> {
+        settings
+            .get("allowedPaths")
+            .map(|value| format!("allowedPaths: {}", value))
+    }
+
     pub fn eval_perm(&self, agent: &Agent) -> PermissionEvalResult {
         #[derive(Debug, Deserialize)]
         #[serde(rename_all = "camelCase")]

--- a/crates/chat-cli/src/cli/chat/tools/fs_write.rs
+++ b/crates/chat-cli/src/cli/chat/tools/fs_write.rs
@@ -415,7 +415,7 @@ impl FsWrite {
         }
     }
 
-    pub fn allowable_field_to_be_overriden(settings: &serde_json::Value) -> Option<String> {
+    pub fn allowable_field_to_be_overridden(settings: &serde_json::Value) -> Option<String> {
         settings
             .get("allowedPaths")
             .map(|value| format!("allowedPaths: {}", value))

--- a/crates/chat-cli/src/cli/chat/tools/fs_write.rs
+++ b/crates/chat-cli/src/cli/chat/tools/fs_write.rs
@@ -433,7 +433,7 @@ impl FsWrite {
 
         let is_in_allowlist = agent.allowed_tools.contains("fs_write");
         match agent.tools_settings.get("fs_write") {
-            Some(settings) if is_in_allowlist => {
+            Some(settings) => {
                 let Settings {
                     allowed_paths,
                     denied_paths,
@@ -486,7 +486,7 @@ impl FsWrite {
                                             .collect::<Vec<_>>()
                                     });
                                 }
-                                if allow_set.is_match(path) {
+                                if is_in_allowlist || allow_set.is_match(path) {
                                     return PermissionEvalResult::Allow;
                                 }
                             },
@@ -808,10 +808,7 @@ fn syntect_to_crossterm_color(syntect: syntect::highlighting::Color) -> style::C
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{
-        HashMap,
-        HashSet,
-    };
+    use std::collections::HashMap;
 
     use super::*;
     use crate::cli::agent::ToolSettingTarget;
@@ -1270,13 +1267,8 @@ mod tests {
         const DENIED_PATH_ONE: &str = "/some/denied/path/**";
         const DENIED_PATH_GLOB: &str = "/denied/glob/**/path/**";
 
-        let agent = Agent {
+        let mut agent = Agent {
             name: "test_agent".to_string(),
-            allowed_tools: {
-                let mut allowed_tools = HashSet::<String>::new();
-                allowed_tools.insert("fs_write".to_string());
-                allowed_tools
-            },
             tools_settings: {
                 let mut map = HashMap::<ToolSettingTarget, serde_json::Value>::new();
                 map.insert(
@@ -1290,51 +1282,62 @@ mod tests {
             ..Default::default()
         };
 
-        let tool = serde_json::from_value::<FsWrite>(serde_json::json!({
+        let tool_one = serde_json::from_value::<FsWrite>(serde_json::json!({
             "path": "/not/a/denied/path/file.txt",
             "command": "create",
             "file_text": "content in nested path"
         }))
         .unwrap();
 
-        let res = tool.eval_perm(&agent);
+        let res = tool_one.eval_perm(&agent);
         assert!(matches!(res, PermissionEvalResult::Ask));
 
-        let tool = serde_json::from_value::<FsWrite>(serde_json::json!({
+        let tool_two = serde_json::from_value::<FsWrite>(serde_json::json!({
             "path": format!("{DENIED_PATH_ONE}/file.txt"),
             "command": "create",
             "file_text": "content in nested path"
         }))
         .unwrap();
 
-        let res = tool.eval_perm(&agent);
+        let res = tool_two.eval_perm(&agent);
         assert!(
             matches!(res, PermissionEvalResult::Deny(ref deny_list) if deny_list.contains(&DENIED_PATH_ONE.to_string()))
         );
 
-        let tool = serde_json::from_value::<FsWrite>(serde_json::json!({
+        let tool_three = serde_json::from_value::<FsWrite>(serde_json::json!({
             "path": format!("/denied/glob/child_one/path/file.txt"),
             "command": "create",
             "file_text": "content in nested path"
         }))
         .unwrap();
 
-        let res = tool.eval_perm(&agent);
+        let res = tool_three.eval_perm(&agent);
         assert!(
             matches!(res, PermissionEvalResult::Deny(ref deny_list) if deny_list.contains(&DENIED_PATH_GLOB.to_string()))
         );
 
-        let tool = serde_json::from_value::<FsWrite>(serde_json::json!({
+        let tool_four = serde_json::from_value::<FsWrite>(serde_json::json!({
             "path": format!("/denied/glob/child_one/grand_child_one/path/file.txt"),
             "command": "create",
             "file_text": "content in nested path"
         }))
         .unwrap();
 
-        let res = tool.eval_perm(&agent);
+        let res = tool_four.eval_perm(&agent);
         assert!(
             matches!(res, PermissionEvalResult::Deny(ref deny_list) if deny_list.contains(&DENIED_PATH_GLOB.to_string()))
         );
+
+        agent.allowed_tools.insert("fs_write".to_string());
+
+        // Denied list should remained denied
+        let res = tool_four.eval_perm(&agent);
+        assert!(
+            matches!(res, PermissionEvalResult::Deny(ref deny_list) if deny_list.contains(&DENIED_PATH_GLOB.to_string()))
+        );
+
+        let res = tool_one.eval_perm(&agent);
+        assert!(matches!(res, PermissionEvalResult::Allow));
     }
 
     #[tokio::test]

--- a/crates/chat-cli/src/cli/chat/tools/use_aws.rs
+++ b/crates/chat-cli/src/cli/chat/tools/use_aws.rs
@@ -194,7 +194,7 @@ impl UseAws {
         let Self { service_name, .. } = self;
         let is_in_allowlist = agent.allowed_tools.contains("use_aws");
         match agent.tools_settings.get("use_aws") {
-            Some(settings) if is_in_allowlist => {
+            Some(settings) => {
                 let settings = match serde_json::from_value::<Settings>(settings.clone()) {
                     Ok(settings) => settings,
                     Err(e) => {
@@ -205,7 +205,7 @@ impl UseAws {
                 if settings.denied_services.contains(service_name) {
                     return PermissionEvalResult::Deny(vec![service_name.clone()]);
                 }
-                if settings.allowed_services.contains(service_name) {
+                if is_in_allowlist || settings.allowed_services.contains(service_name) {
                     return PermissionEvalResult::Allow;
                 }
                 PermissionEvalResult::Ask
@@ -224,8 +224,6 @@ impl UseAws {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
-
     use super::*;
     use crate::cli::agent::ToolSettingTarget;
 
@@ -351,7 +349,7 @@ mod tests {
 
     #[test]
     fn test_eval_perm() {
-        let cmd = use_aws! {{
+        let cmd_one = use_aws! {{
             "service_name": "s3",
             "operation_name": "put-object",
             "region": "us-west-2",
@@ -359,13 +357,8 @@ mod tests {
             "label": ""
         }};
 
-        let agent = Agent {
+        let mut agent = Agent {
             name: "test_agent".to_string(),
-            allowed_tools: {
-                let mut allowed_tools = HashSet::<String>::new();
-                allowed_tools.insert("use_aws".to_string());
-                allowed_tools
-            },
             tools_settings: {
                 let mut map = HashMap::<ToolSettingTarget, serde_json::Value>::new();
                 map.insert(
@@ -379,10 +372,10 @@ mod tests {
             ..Default::default()
         };
 
-        let res = cmd.eval_perm(&agent);
+        let res = cmd_one.eval_perm(&agent);
         assert!(matches!(res, PermissionEvalResult::Deny(ref services) if services.contains(&"s3".to_string())));
 
-        let cmd = use_aws! {{
+        let cmd_two = use_aws! {{
             "service_name": "api_gateway",
             "operation_name": "request",
             "region": "us-west-2",
@@ -390,7 +383,16 @@ mod tests {
             "label": ""
         }};
 
-        let res = cmd.eval_perm(&agent);
+        let res = cmd_two.eval_perm(&agent);
         assert!(matches!(res, PermissionEvalResult::Ask));
+
+        agent.allowed_tools.insert("use_aws".to_string());
+
+        let res = cmd_two.eval_perm(&agent);
+        assert!(matches!(res, PermissionEvalResult::Allow));
+
+        // Denied services should still be denied after trusting tool
+        let res = cmd_one.eval_perm(&agent);
+        assert!(matches!(res, PermissionEvalResult::Deny(ref services) if services.contains(&"s3".to_string())));
     }
 }

--- a/crates/chat-cli/src/cli/chat/tools/use_aws.rs
+++ b/crates/chat-cli/src/cli/chat/tools/use_aws.rs
@@ -175,6 +175,12 @@ impl UseAws {
         }
     }
 
+    pub fn allowable_field_to_be_overriden(settings: &serde_json::Value) -> Option<String> {
+        settings
+            .get("allowedServices")
+            .map(|value| format!("allowedServices: {}", value))
+    }
+
     pub fn eval_perm(&self, agent: &Agent) -> PermissionEvalResult {
         #[derive(Debug, Deserialize)]
         #[serde(rename_all = "camelCase")]

--- a/crates/chat-cli/src/cli/chat/tools/use_aws.rs
+++ b/crates/chat-cli/src/cli/chat/tools/use_aws.rs
@@ -175,7 +175,7 @@ impl UseAws {
         }
     }
 
-    pub fn allowable_field_to_be_overriden(settings: &serde_json::Value) -> Option<String> {
+    pub fn allowable_field_to_be_overridden(settings: &serde_json::Value) -> Option<String> {
         settings
             .get("allowedServices")
             .map(|value| format!("allowedServices: {}", value))

--- a/docs/agent-format.md
+++ b/docs/agent-format.md
@@ -160,6 +160,7 @@ Unlike the `tools` field, the `allowedTools` field does not support the `"*"` wi
 ## ToolsSettings Field
 
 The `toolsSettings` field provides configuration for specific tools. Each tool can have its own unique configuration options.
+Note that specifications that configure allowable patterns will be overridden if the tool is also included in `allowedTools`.
 
 ```json
 {


### PR DESCRIPTION
*Issue #, if available:*
Premise

Currently in the agent config we require a tool to be included in “allowedTools” in order for its corresponding entry in “toolsSettings” to take effect. 


Feedback 1

If the toolsSettings is permission related, this would result in a stricter permission for the tool than if it were to have no toolsSettings at all. From users feedback, the consensus is that this is unintuitive. 

For example, config A is looser than config B:
```json
// Config A
{
  "allowedTools": [
    "fs_read",
    "execute_bash",
    "fs_write"
  ],
  "toolsSettings": {}
}
```
```json
// Config B
{
  "allowedTools": [
    "fs_read",
    "execute_bash",
    "fs_write"
  ],
  "toolsSettings": {
    "execute_bash": {
      "allowedCommands": ["git status"] // now only git status is permitted
    }
  }
}
```


Feedback 2

Having an entry for a given tool in toolsSettings without also including them in allowedTools would potentially break “trust tool” command. This is because trust tool effectively includes the tool in allowedTools, which in this scenario practically “activates” the entry in toolsSettings.

For example, consider the following:

1. User erroneously include a permission related toolsSettings entry for execute_bash without having included it in allowedTools. 
2. User goes to invoke said tool. When prompted, user replies with “t” to trust the tool for the rest of the session with the expecation that they should not be prompted again for execute_bash invocation.
3. The previously “dormant” toolsSettings now gets activated with the newly added entry of execute_bash in allowedTools. As mentioned above, this actually narrows the list of allowed commands.
4. User is once again prompted for execute_bash the next time it runs should the command not match what is stated in allowedCommands in the toolsSettings entry for execute_bash.


*Description of changes:*
Iff a tool appears in both allowedTools & toolSettings show this warning on launch

* You have trusted the “execute_bash” tool, which will override the toolSettings that have been defined: <dump toolSettings JSON>


Tool permission evaluation:

1. If tool invocation is rejected by a toolSetting, deny it
2. If tool is in allowedTools list, invoke it
3. If tool is [t]rusted at runtime, invoke it
4. If tool invocation conforms to toolSetting, invoke

<img width="1313" height="1258" alt="image" src="https://github.com/user-attachments/assets/822726d9-d7c1-4db0-ac68-1596ba2dd2df" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
