### PR TITLE
feat: adding glob pattern support for agent configuration

### DIFF
--- a/crates/chat-cli/src/cli/chat/conversation.rs
+++ b/crates/chat-cli/src/cli/chat/conversation.rs
@@ -135,6 +135,7 @@ impl ConversationState {
         current_model_id: Option<String>,
         os: &Os,
     ) -> Self {
+
         let model = if let Some(model_id) = current_model_id {
             match get_model_info(&model_id, os).await {
                 Ok(info) => Some(info),
@@ -1253,4 +1254,5 @@ mod tests {
             conversation.set_next_user_message(i.to_string()).await;
         }
     }
+
 }

--- a/crates/chat-cli/src/cli/chat/tools/custom_tool.rs
+++ b/crates/chat-cli/src/cli/chat/tools/custom_tool.rs
@@ -37,6 +37,8 @@ use crate::mcp_client::{
     ToolCallResult,
 };
 use crate::os::Os;
+use crate::util::pattern_matching::matches_any_pattern;
+use crate::util::MCP_SERVER_TOOL_DELIMITER;
 
 // TODO: support http transport type
 #[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq, JsonSchema)]
@@ -288,7 +290,6 @@ impl CustomTool {
     }
 
     pub fn eval_perm(&self, agent: &Agent) -> PermissionEvalResult {
-        use crate::util::MCP_SERVER_TOOL_DELIMITER;
         let Self {
             name: tool_name,
             client,
@@ -296,15 +297,17 @@ impl CustomTool {
         } = self;
         let server_name = client.get_server_name();
 
-        if agent.allowed_tools.contains(&format!("@{server_name}"))
-            || agent
-                .allowed_tools
-                .contains(&format!("@{server_name}{MCP_SERVER_TOOL_DELIMITER}{tool_name}"))
-        {
-            PermissionEvalResult::Allow
-        } else {
-            PermissionEvalResult::Ask
+        let server_pattern = format!("@{server_name}");
+        if agent.allowed_tools.contains(&server_pattern) {
+            return PermissionEvalResult::Allow;
         }
+
+        let tool_pattern = format!("@{server_name}{MCP_SERVER_TOOL_DELIMITER}{tool_name}");
+        if matches_any_pattern(&agent.allowed_tools, &tool_pattern) {
+            return PermissionEvalResult::Allow;
+        }
+
+        PermissionEvalResult::Ask
     }
 }
 

--- a/crates/chat-cli/src/cli/chat/tools/execute/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/execute/mod.rs
@@ -23,6 +23,7 @@ use crate::cli::chat::tools::{
 };
 use crate::cli::chat::util::truncate_safe;
 use crate::os::Os;
+use crate::util::pattern_matching::matches_any_pattern;
 
 // Platform-specific modules
 #[cfg(windows)]
@@ -194,7 +195,7 @@ impl ExecuteCommand {
 
         let Self { command, .. } = self;
         let tool_name = if cfg!(windows) { "execute_cmd" } else { "execute_bash" };
-        let is_in_allowlist = agent.allowed_tools.contains(tool_name);
+        let is_in_allowlist = matches_any_pattern(&agent.allowed_tools, tool_name);
         match agent.tools_settings.get(tool_name) {
             Some(settings) if is_in_allowlist => {
                 let Settings {

--- a/crates/chat-cli/src/cli/chat/tools/fs_read.rs
+++ b/crates/chat-cli/src/cli/chat/tools/fs_read.rs
@@ -48,6 +48,7 @@ use crate::cli::chat::{
     sanitize_unicode_tags,
 };
 use crate::os::Os;
+use crate::util::pattern_matching::matches_any_pattern;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct FsRead {
@@ -118,7 +119,7 @@ impl FsRead {
             true
         }
 
-        let is_in_allowlist = agent.allowed_tools.contains("fs_read");
+        let is_in_allowlist = matches_any_pattern(&agent.allowed_tools, "fs_read");
         match agent.tools_settings.get("fs_read") {
             Some(settings) if is_in_allowlist => {
                 let Settings {

--- a/crates/chat-cli/src/cli/chat/tools/fs_write.rs
+++ b/crates/chat-cli/src/cli/chat/tools/fs_write.rs
@@ -47,6 +47,7 @@ use crate::cli::agent::{
 };
 use crate::cli::chat::line_tracker::FileLineTracker;
 use crate::os::Os;
+use crate::util::pattern_matching::matches_any_pattern;
 
 static SYNTAX_SET: LazyLock<SyntaxSet> = LazyLock::new(SyntaxSet::load_defaults_newlines);
 static THEME_SET: LazyLock<ThemeSet> = LazyLock::new(ThemeSet::load_defaults);
@@ -425,7 +426,7 @@ impl FsWrite {
             denied_paths: Vec<String>,
         }
 
-        let is_in_allowlist = agent.allowed_tools.contains("fs_write");
+        let is_in_allowlist = matches_any_pattern(&agent.allowed_tools, "fs_write");
         match agent.tools_settings.get("fs_write") {
             Some(settings) if is_in_allowlist => {
                 let Settings {

--- a/crates/chat-cli/src/cli/chat/tools/knowledge.rs
+++ b/crates/chat-cli/src/cli/chat/tools/knowledge.rs
@@ -19,6 +19,7 @@ use crate::cli::agent::{
 };
 use crate::database::settings::Setting;
 use crate::os::Os;
+use crate::util::pattern_matching::matches_any_pattern;
 use crate::util::knowledge_store::KnowledgeStore;
 
 /// The Knowledge tool allows storing and retrieving information across chat sessions.
@@ -490,7 +491,7 @@ impl Knowledge {
 
     pub fn eval_perm(&self, agent: &Agent) -> PermissionEvalResult {
         _ = self;
-        if agent.allowed_tools.contains("knowledge") {
+        if matches_any_pattern(&agent.allowed_tools, "knowledge") {
             PermissionEvalResult::Allow
         } else {
             PermissionEvalResult::Ask

--- a/crates/chat-cli/src/cli/chat/tools/use_aws.rs
+++ b/crates/chat-cli/src/cli/chat/tools/use_aws.rs
@@ -29,6 +29,7 @@ use crate::cli::agent::{
     PermissionEvalResult,
 };
 use crate::os::Os;
+use crate::util::pattern_matching::matches_any_pattern;
 
 const READONLY_OPS: [&str; 6] = ["get", "describe", "list", "ls", "search", "batch_get"];
 
@@ -186,7 +187,7 @@ impl UseAws {
         }
 
         let Self { service_name, .. } = self;
-        let is_in_allowlist = agent.allowed_tools.contains("use_aws");
+        let is_in_allowlist = matches_any_pattern(&agent.allowed_tools, "use_aws");
         match agent.tools_settings.get("use_aws") {
             Some(settings) if is_in_allowlist => {
                 let settings = match serde_json::from_value::<Settings>(settings.clone()) {

--- a/crates/chat-cli/src/util/mod.rs
+++ b/crates/chat-cli/src/util/mod.rs
@@ -2,6 +2,7 @@ pub mod consts;
 pub mod directories;
 pub mod knowledge_store;
 pub mod open;
+pub mod pattern_matching;
 pub mod process;
 pub mod spinner;
 pub mod system_info;

--- a/crates/chat-cli/src/util/pattern_matching.rs
+++ b/crates/chat-cli/src/util/pattern_matching.rs
@@ -1,0 +1,65 @@
+use std::collections::HashSet;
+use globset::Glob;
+
+/// Check if a string matches any pattern in a set of patterns
+pub fn matches_any_pattern(patterns: &HashSet<String>, text: &str) -> bool {
+    patterns.iter().any(|pattern| {
+        // Exact match first
+        if pattern == text {
+            return true;
+        }
+        
+        // Glob pattern match if contains wildcards
+        if pattern.contains('*') || pattern.contains('?') {
+            if let Ok(glob) = Glob::new(pattern) {
+                return glob.compile_matcher().is_match(text);
+            }
+        }
+        
+        false
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn test_exact_match() {
+        let mut patterns = HashSet::new();
+        patterns.insert("fs_read".to_string());
+        
+        assert!(matches_any_pattern(&patterns, "fs_read"));
+        assert!(!matches_any_pattern(&patterns, "fs_write"));
+    }
+
+    #[test]
+    fn test_wildcard_patterns() {
+        let mut patterns = HashSet::new();
+        patterns.insert("fs_*".to_string());
+        
+        assert!(matches_any_pattern(&patterns, "fs_read"));
+        assert!(matches_any_pattern(&patterns, "fs_write"));
+        assert!(!matches_any_pattern(&patterns, "execute_bash"));
+    }
+
+    #[test]
+    fn test_mcp_patterns() {
+        let mut patterns = HashSet::new();
+        patterns.insert("@mcp-server/*".to_string());
+        
+        assert!(matches_any_pattern(&patterns, "@mcp-server/tool1"));
+        assert!(matches_any_pattern(&patterns, "@mcp-server/tool2"));
+        assert!(!matches_any_pattern(&patterns, "@other-server/tool"));
+    }
+
+    #[test]
+    fn test_question_mark_wildcard() {
+        let mut patterns = HashSet::new();
+        patterns.insert("fs_?ead".to_string());
+        
+        assert!(matches_any_pattern(&patterns, "fs_read"));
+        assert!(!matches_any_pattern(&patterns, "fs_write"));
+    }
+}

--- a/docs/agent-format.md
+++ b/docs/agent-format.md
@@ -144,18 +144,72 @@ The `allowedTools` field specifies which tools can be used without prompting the
 {
   "allowedTools": [
     "fs_read",
+    "fs_*",
     "@git/git_status",
+    "@server/read_*",
     "@fetch"
   ]
 }
 ```
 
-You can allow:
-- Specific built-in tools by name (e.g., `"fs_read"`)
-- Specific MCP tools using `@server_name/tool_name` (e.g., `"@git/git_status"`)
-- All tools from an MCP server using `@server_name` (e.g., `"@fetch"`)
+You can allow tools using several patterns:
 
-Unlike the `tools` field, the `allowedTools` field does not support the `"*"` wildcard for allowing all tools. To allow specific tools, you must list them individually or use server-level wildcards with the `@server_name` syntax.
+### Exact Matches
+- **Built-in tools**: `"fs_read"`, `"execute_bash"`, `"knowledge"`
+- **Specific MCP tools**: `"@server_name/tool_name"` (e.g., `"@git/git_status"`)
+- **All tools from MCP server**: `"@server_name"` (e.g., `"@fetch"`)
+
+### Wildcard Patterns
+The `allowedTools` field supports glob-style wildcard patterns using `*` and `?`:
+
+#### Native Tool Patterns
+- **Prefix wildcard**: `"fs_*"` → matches `fs_read`, `fs_write`, `fs_anything`
+- **Suffix wildcard**: `"*_bash"` → matches `execute_bash`, `run_bash`
+- **Middle wildcard**: `"fs_*_tool"` → matches `fs_read_tool`, `fs_write_tool`
+- **Single character**: `"fs_?ead"` → matches `fs_read`, `fs_head` (but not `fs_write`)
+
+#### MCP Tool Patterns
+- **Tool prefix**: `"@server/read_*"` → matches `@server/read_file`, `@server/read_config`
+- **Tool suffix**: `"@server/*_get"` → matches `@server/issue_get`, `@server/data_get`
+- **Server pattern**: `"@*-mcp/read_*"` → matches `@git-mcp/read_file`, `@db-mcp/read_data`
+- **Any tool from pattern servers**: `"@git-*/*"` → matches any tool from servers matching `git-*`
+
+### Examples
+
+```json
+{
+  "allowedTools": [
+    // Exact matches
+    "fs_read",
+    "knowledge",
+    "@server/specific_tool",
+    
+    // Native tool wildcards
+    "fs_*",                    // All filesystem tools
+    "execute_*",               // All execute tools
+    "*_test",                  // Any tool ending in _test
+    
+    // MCP tool wildcards
+    "@server/api_*",           // All API tools from server
+    "@server/read_*",          // All read tools from server
+    "@git-server/get_*_info",  // Tools like get_user_info, get_repo_info
+    "@*/status",               // Status tool from any server
+    
+    // Server-level permissions
+    "@fetch",                  // All tools from fetch server
+    "@git-*"                   // All tools from any git-* server
+  ]
+}
+```
+
+### Pattern Matching Rules
+- **`*`** matches any sequence of characters (including none)
+- **`?`** matches exactly one character
+- **Exact matches** take precedence over patterns
+- **Server-level permissions** (`@server_name`) allow all tools from that server
+- **Case-sensitive** matching
+
+Unlike the `tools` field, the `allowedTools` field does not support the `"*"` wildcard for allowing all tools. To allow tools, you must use specific patterns or server-level permissions.
 
 ## ToolsSettings Field
 


### PR DESCRIPTION
feat: Implement wildcard pattern matching for agent allowedTools
    
    - Add globset-based pattern matching to support wildcards (* and ?) in allowedTools
    - Create util/pattern_matching.rs module with matches_any_pattern function
    - Update all native tools (fs_read, fs_write, execute_bash, use_aws, knowledge) to use pattern matching
    - Update MCP custom tools to support wildcard patterns while preserving exact server-level matching
    - Standardize imports across tool files for consistency
    - Maintain backward compatibility with existing exact-match behavior
    
    Enables agent configs like:
    - "fs_*" matches fs_read, fs_write
    - "@mcp-server/tool_*" matches tool_read, tool_write
    - "execute_*" matches execute_bash, execute_cmd


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
