### PR TITLE
fix: use_aws printing default profile when its not used, minor updates to agent docs

### DIFF
--- a/crates/chat-cli/src/cli/chat/tools/use_aws.rs
+++ b/crates/chat-cli/src/cli/chat/tools/use_aws.rs
@@ -136,8 +136,6 @@ impl UseAws {
 
         if let Some(ref profile_name) = self.profile_name {
             queue!(output, style::Print(format!("Profile name: {}\n", profile_name)))?;
-        } else {
-            queue!(output, style::Print("Profile name: default\n".to_string()))?;
         }
 
         queue!(output, style::Print(format!("Region: {}", self.region)))?;

--- a/docs/agent-format.md
+++ b/docs/agent-format.md
@@ -234,7 +234,7 @@ The `useLegacyMcpJson` field determines whether to include MCP servers defined i
 }
 ```
 
-When set to `true`, the agent will have access to all MCP servers defined in the global configuration in addition to those defined in the agent's `mcpServers` field.
+When set to `true`, the agent will have access to all MCP servers defined in the global and local configurations in addition to those defined in the agent's `mcpServers` field.
 
 ## Complete Example
 

--- a/docs/built-in-tools.md
+++ b/docs/built-in-tools.md
@@ -159,7 +159,7 @@ Tools can be explicitly allowed in the `allowedTools` section of the agent confi
 }
 ```
 
-If a tool is not in the `allowedTools` list, the user will be prompted for permission when the tool is used.
+If a tool is not in the `allowedTools` list, the user will be prompted for permission when the tool is used unless an allowed `toolSettings` configuration is set.
 
 Some tools have default permission behaviors:
 - `fs_read` and `report_issue` are trusted by default


### PR DESCRIPTION
*Description of changes:*
- The `use_aws` tool will print that the default profile is being used when missing, when in reality we do not fall back to using the default profile.
- Minor docs update
- Minor test update to add an assertion

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
