### PR TITLE
Revert "fix(agent): tool permission override"

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -123,10 +123,7 @@ use util::{
 use winnow::Partial;
 use winnow::stream::Offset;
 
-use super::agent::{
-    DEFAULT_AGENT_NAME,
-    PermissionEvalResult,
-};
+use super::agent::PermissionEvalResult;
 use crate::api_client::model::ToolResultStatus;
 use crate::api_client::{
     self,
@@ -614,7 +611,7 @@ impl ChatSession {
                                 ": cannot resume conversation with {profile} because it no longer exists. Using default.\n"
                             ))
                         )?;
-                        let _ = agents.switch(DEFAULT_AGENT_NAME);
+                        let _ = agents.switch("default");
                     }
                 }
                 cs.agents = agents;
@@ -624,10 +621,6 @@ impl ChatSession {
             },
             false => ConversationState::new(conversation_id, agents, tool_config, tool_manager, model_id, os).await,
         };
-
-        if let Some(agent) = conversation.agents.get_active() {
-            agent.validate_tool_settings(&mut stderr)?;
-        }
 
         // Spawn a task for listening and broadcasting sigints.
         let (ctrlc_tx, ctrlc_rx) = tokio::sync::broadcast::channel(4);
@@ -1746,12 +1739,6 @@ impl ChatSession {
                             .clone()
                             .unwrap_or(tool_use.name.clone());
                         self.conversation.agents.trust_tools(vec![formatted_tool_name]);
-
-                        if let Some(agent) = self.conversation.agents.get_active() {
-                            agent
-                                .validate_tool_settings(&mut self.stderr)
-                                .map_err(|_e| ChatError::Custom("Failed to validate agent tool settings".into()))?;
-                        }
                     }
                     tool_use.accepted = true;
 

--- a/docs/agent-format.md
+++ b/docs/agent-format.md
@@ -160,7 +160,6 @@ Unlike the `tools` field, the `allowedTools` field does not support the `"*"` wi
 ## ToolsSettings Field
 
 The `toolsSettings` field provides configuration for specific tools. Each tool can have its own unique configuration options.
-Note that specifications that configure allowable patterns will be overridden if the tool is also included in `allowedTools`.
 
 ```json
 {


### PR DESCRIPTION
Reverts aws/amazon-q-developer-cli#2606

There are some issues with this commit: 
- execute isn't respecting allowed commands
- paths aren't being canonicalized prior to being turned into glob set (for fs_read and fs_write) 
- the anchors around denied commands / paths needs some more thoughts