### PR TITLE
feat: add github action for release notification

### DIFF
--- a/.github/workflows/release-notification.yaml
+++ b/.github/workflows/release-notification.yaml
@@ -19,7 +19,8 @@ jobs:
               "release_url": "${{ github.event.release.html_url }}",
               "author_name": "${{ github.event.release.author.login }}",
               "repository_name": "${{ github.event.repository.name }}",
-              "repository_url": "${{ github.event.repository.html_url }}"
+              "repository_url": "${{ github.event.repository.html_url }}",
+              "release_description": "${{ github.event.release.body }}"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # Use the secret for the webhook URL

--- a/.github/workflows/release-notification.yaml
+++ b/.github/workflows/release-notification.yaml
@@ -1,0 +1,25 @@
+
+name: Release Notification
+
+on:
+  release:
+    types: [published] # Trigger on new releases being published
+
+jobs:
+  slack_notification:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Release Details to Slack
+        uses: slackapi/slack-github-action@v1.23.0 # Or the latest version of this action
+        with:
+          payload: |
+            {
+              "release_name": "${{ github.event.release.name }}",
+              "tag_name": "${{ github.event.release.tag_name }}",
+              "release_url": "${{ github.event.release.html_url }}",
+              "author_name": "${{ github.event.release.author.login }}",
+              "repository_name": "${{ github.event.repository.name }}",
+              "repository_url": "${{ github.event.repository.html_url }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # Use the secret for the webhook URL

--- a/.github/workflows/release-notification.yaml
+++ b/.github/workflows/release-notification.yaml
@@ -20,7 +20,7 @@ jobs:
               "author_name": "${{ github.event.release.author.login }}",
               "repository_name": "${{ github.event.repository.name }}",
               "repository_url": "${{ github.event.repository.html_url }}",
-              "release_description": "${{ github.event.release.body }}"
+              "release_description": ${{ toJSON(github.event.release.body) }}
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # Use the secret for the webhook URL


### PR DESCRIPTION
*Issue #, if available:*
We need a Github Action to post notifications to slack. 

*Description of changes:*
Added the required Github Actions file to achieve this. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
