### PR TITLE
fix: cannot resolve directory 'chat_cli'

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ cargo install typos-cli
 
 ## Project Layout
 
-- [`chat_cli`](crates/chat_cli/) - the `q` CLI, allows users to interface with Amazon Q Developer from
+- [`chat_cli`](crates/chat-cli/) - the `q` CLI, allows users to interface with Amazon Q Developer from
   the command line
 - [`scripts/`](scripts/) - Contains ops and build related scripts
 - [`crates/`](crates/) - Contains all rust crates


### PR DESCRIPTION
*Issue #, if available:*  
#2631  

*Description of changes:*  
- Fixed incorrect folder reference in documentation (`chat_cli` → `chat-cli`)  
- Updated links so IDEs (VS Code, IntelliJ) and GitHub UI can correctly resolve the directory  

*How tested:*  
- Verified that updated links correctly resolve in GitHub web UI  
- Confirmed navigation works in VS Code and IntelliJ after the fix  
