### PR TITLE
feat: add tangent mode for isolated conversations

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/mod.rs
+++ b/crates/chat-cli/src/cli/chat/cli/mod.rs
@@ -10,6 +10,7 @@ pub mod persist;
 pub mod profile;
 pub mod prompts;
 pub mod subscribe;
+pub mod tangent;
 pub mod tools;
 pub mod usage;
 
@@ -25,17 +26,13 @@ use model::ModelArgs;
 use persist::PersistSubcommand;
 use profile::AgentSubcommand;
 use prompts::PromptsArgs;
+use tangent::TangentArgs;
 use tools::ToolsArgs;
 
 use crate::cli::chat::cli::subscribe::SubscribeArgs;
 use crate::cli::chat::cli::usage::UsageArgs;
 use crate::cli::chat::consts::AGENT_MIGRATION_DOC_URL;
-use crate::cli::chat::{
-    ChatError,
-    ChatSession,
-    ChatState,
-    EXTRA_HELP,
-};
+use crate::cli::chat::{ChatError, ChatSession, ChatState, EXTRA_HELP};
 use crate::cli::issue;
 use crate::os::Os;
 
@@ -81,6 +78,8 @@ pub enum SlashCommand {
     Model(ModelArgs),
     /// Upgrade to a Q Developer Pro subscription for increased query limits
     Subscribe(SubscribeArgs),
+    /// Toggle tangent mode for isolated conversations
+    Tangent(TangentArgs),
     #[command(flatten)]
     Persist(PersistSubcommand),
     // #[command(flatten)]
@@ -94,10 +93,7 @@ impl SlashCommand {
             Self::Clear(args) => args.execute(session).await,
             Self::Agent(subcommand) => subcommand.execute(os, session).await,
             Self::Profile => {
-                use crossterm::{
-                    execute,
-                    style,
-                };
+                use crossterm::{execute, style};
                 execute!(
                     session.stderr,
                     style::SetForegroundColor(style::Color::Yellow),
@@ -136,6 +132,7 @@ impl SlashCommand {
             Self::Mcp(args) => args.execute(session).await,
             Self::Model(args) => args.execute(os, session).await,
             Self::Subscribe(args) => args.execute(os, session).await,
+            Self::Tangent(args) => args.execute(os, session).await,
             Self::Persist(subcommand) => subcommand.execute(os, session).await,
             // Self::Root(subcommand) => {
             //     if let Err(err) = subcommand.execute(os, database, telemetry).await {
@@ -167,6 +164,7 @@ impl SlashCommand {
             Self::Mcp(_) => "mcp",
             Self::Model(_) => "model",
             Self::Subscribe(_) => "subscribe",
+            Self::Tangent(_) => "tangent",
             Self::Persist(sub) => match sub {
                 PersistSubcommand::Save { .. } => "save",
                 PersistSubcommand::Load { .. } => "load",

--- a/crates/chat-cli/src/cli/chat/cli/tangent.rs
+++ b/crates/chat-cli/src/cli/chat/cli/tangent.rs
@@ -1,0 +1,66 @@
+use clap::Args;
+use crossterm::execute;
+use crossterm::style::{self, Color};
+
+use crate::cli::chat::{ChatError, ChatSession, ChatState};
+use crate::os::Os;
+
+#[derive(Debug, PartialEq, Args)]
+pub struct TangentArgs;
+
+impl TangentArgs {
+    pub async fn execute(self, os: &Os, session: &mut ChatSession) -> Result<ChatState, ChatError> {
+        if session.conversation.is_in_tangent_mode() {
+            session.conversation.exit_tangent_mode();
+            execute!(
+                session.stderr,
+                style::SetForegroundColor(Color::DarkGrey),
+                style::Print("Restored conversation from checkpoint ("),
+                style::SetForegroundColor(Color::Yellow),
+                style::Print("↯"),
+                style::SetForegroundColor(Color::DarkGrey),
+                style::Print("). - Returned to main conversation.\n"),
+                style::SetForegroundColor(Color::Reset)
+            )?;
+        } else {
+            session.conversation.enter_tangent_mode();
+
+            // Get the configured tangent mode key for display
+            let tangent_key_char = match os
+                .database
+                .settings
+                .get_string(crate::database::settings::Setting::TangentModeKey)
+            {
+                Some(key) if key.len() == 1 => key.chars().next().unwrap_or('t'),
+                _ => 't', // Default to 't' if setting is missing or invalid
+            };
+            let tangent_key_display = format!("ctrl + {}", tangent_key_char.to_lowercase());
+
+            execute!(
+                session.stderr,
+                style::SetForegroundColor(Color::DarkGrey),
+                style::Print("Created a conversation checkpoint ("),
+                style::SetForegroundColor(Color::Yellow),
+                style::Print("↯"),
+                style::SetForegroundColor(Color::DarkGrey),
+                style::Print("). Use "),
+                style::SetForegroundColor(Color::Green),
+                style::Print(&tangent_key_display),
+                style::SetForegroundColor(Color::DarkGrey),
+                style::Print(" or "),
+                style::SetForegroundColor(Color::Green),
+                style::Print("/tangent"),
+                style::SetForegroundColor(Color::DarkGrey),
+                style::Print(" to restore the conversation later.\n"),
+                style::Print(
+                    "Note: this functionality is experimental and may change or be removed in the future.\n"
+                ),
+                style::SetForegroundColor(Color::Reset)
+            )?;
+        }
+
+        Ok(ChatState::PromptUser {
+            skip_printing_tools: false,
+        })
+    }
+}

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -19,144 +19,61 @@ pub mod tool_manager;
 pub mod tools;
 pub mod util;
 use std::borrow::Cow;
-use std::collections::{
-    HashMap,
-    VecDeque,
-};
-use std::io::{
-    IsTerminal,
-    Read,
-    Write,
-};
+use std::collections::{HashMap, VecDeque};
+use std::io::{IsTerminal, Read, Write};
 use std::process::ExitCode;
 use std::sync::Arc;
-use std::time::{
-    Duration,
-    Instant,
-};
+use std::time::{Duration, Instant};
 
 use amzn_codewhisperer_client::types::SubscriptionStatus;
-use clap::{
-    Args,
-    CommandFactory,
-    Parser,
-};
+use clap::{Args, CommandFactory, Parser};
 use cli::compact::CompactStrategy;
-use cli::model::{
-    get_available_models,
-    select_model,
-};
+use cli::model::{get_available_models, select_model};
 pub use conversation::ConversationState;
 use conversation::TokenWarningLevel;
-use crossterm::style::{
-    Attribute,
-    Color,
-    Stylize,
-};
-use crossterm::{
-    cursor,
-    execute,
-    queue,
-    style,
-    terminal,
-};
-use eyre::{
-    Report,
-    Result,
-    bail,
-    eyre,
-};
+use crossterm::style::{Attribute, Color, Stylize};
+use crossterm::{cursor, execute, queue, style, terminal};
+use tool_manager::{PromptQuery, PromptQueryResult};
+use eyre::{Report, Result, bail, eyre};
 use input_source::InputSource;
-use message::{
-    AssistantMessage,
-    AssistantToolUse,
-    ToolUseResult,
-    ToolUseResultBlock,
-};
-use parse::{
-    ParseState,
-    interpret_markdown,
-};
-use parser::{
-    RecvErrorKind,
-    RequestMetadata,
-    SendMessageStream,
-};
+use message::{AssistantMessage, AssistantToolUse, ToolUseResult, ToolUseResultBlock};
+use parse::{ParseState, interpret_markdown};
+use parser::{RecvErrorKind, RequestMetadata, SendMessageStream};
 use regex::Regex;
-use spinners::{
-    Spinner,
-    Spinners,
-};
+use spinners::{Spinner, Spinners};
 use thiserror::Error;
 use time::OffsetDateTime;
 use token_counter::TokenCounter;
 use tokio::signal::ctrl_c;
-use tokio::sync::{
-    Mutex,
-    broadcast,
-};
-use tool_manager::{
-    PromptQuery,
-    PromptQueryResult,
-    ToolManager,
-    ToolManagerBuilder,
-};
+use tokio::sync::{Mutex, broadcast};
+use tool_manager::{ToolManager, ToolManagerBuilder};
 use tools::gh_issue::GhIssueContext;
-use tools::{
-    NATIVE_TOOLS,
-    OutputKind,
-    QueuedTool,
-    Tool,
-    ToolSpec,
-};
-use tracing::{
-    debug,
-    error,
-    info,
-    trace,
-    warn,
-};
+use tools::{NATIVE_TOOLS, OutputKind, QueuedTool, Tool, ToolSpec};
+use tracing::{debug, error, info, trace, warn};
 use util::images::RichImageBlock;
 use util::ui::draw_box;
-use util::{
-    animate_output,
-    play_notification_bell,
-};
+use util::{animate_output, play_notification_bell};
 use winnow::Partial;
 use winnow::stream::Offset;
 
 use super::agent::PermissionEvalResult;
 use crate::api_client::model::ToolResultStatus;
-use crate::api_client::{
-    self,
-    ApiClientError,
-};
+use crate::api_client::{self, ApiClientError};
 use crate::auth::AuthError;
 use crate::auth::builder_id::is_idc_user;
 use crate::cli::agent::Agents;
 use crate::cli::chat::cli::SlashCommand;
 use crate::cli::chat::cli::model::find_model;
-use crate::cli::chat::cli::prompts::{
-    GetPromptError,
-    PromptsSubcommand,
-};
+use crate::cli::chat::cli::prompts::{GetPromptError, PromptsSubcommand};
 use crate::cli::chat::util::sanitize_unicode_tags;
 use crate::database::settings::Setting;
 use crate::mcp_client::Prompt;
 use crate::os::Os;
 use crate::telemetry::core::{
-    AgentConfigInitArgs,
-    ChatAddedMessageParams,
-    ChatConversationType,
-    MessageMetaTag,
-    RecordUserTurnCompletionArgs,
+    AgentConfigInitArgs, ChatAddedMessageParams, ChatConversationType, MessageMetaTag, RecordUserTurnCompletionArgs,
     ToolUseEventBuilder,
 };
-use crate::telemetry::{
-    ReasonCode,
-    TelemetryResult,
-    get_error_reason,
-};
+use crate::telemetry::{ReasonCode, TelemetryResult, get_error_reason};
 use crate::util::MCP_SERVER_TOOL_DELIMITER;
 
 const LIMIT_REACHED_TEXT: &str = color_print::cstr! { "You've used all your free requests for this month. You have two options:
@@ -174,6 +91,8 @@ pub const EXTRA_HELP: &str = color_print::cstr! {"
 <em>Ctrl(^) + s</em>         <black!>Fuzzy search commands and context files</black!>
                     <black!>Use Tab to select multiple items</black!>
                     <black!>Change the keybind using: q settings chat.skimCommandKey x</black!>
+<em>Ctrl(^) + t</em>         <black!>Toggle tangent mode for isolated conversations</black!>
+                    <black!>Change the keybind using: q settings chat.tangentModeKey x</black!>
 <em>chat.editMode</em>       <black!>The prompt editing mode (vim or emacs)</black!>
                     <black!>Change using: q settings chat.skimCommandKey x</black!>
 "};
@@ -267,13 +186,17 @@ impl ChatArgs {
             agents.trust_all_tools = self.trust_all_tools;
 
             os.telemetry
-                .send_agent_config_init(&os.database, conversation_id.clone(), AgentConfigInitArgs {
-                    agents_loaded_count: md.load_count as i64,
-                    agents_loaded_failed_count: md.load_failed_count as i64,
-                    legacy_profile_migration_executed: md.migration_performed,
-                    legacy_profile_migrated_count: md.migrated_count as i64,
-                    launched_agent: md.launched_agent,
-                })
+                .send_agent_config_init(
+                    &os.database,
+                    conversation_id.clone(),
+                    AgentConfigInitArgs {
+                        agents_loaded_count: md.load_count as i64,
+                        agents_loaded_failed_count: md.load_failed_count as i64,
+                        legacy_profile_migration_executed: md.migration_performed,
+                        legacy_profile_migrated_count: md.migrated_count as i64,
+                        launched_agent: md.launched_agent,
+                    },
+                )
                 .await
                 .map_err(|err| error!(?err, "failed to send agent config init telemetry"))
                 .ok();
@@ -398,7 +321,7 @@ const SMALL_SCREEN_WELCOME_TEXT: &str = color_print::cstr! {"<em>Welcome to <cya
 const RESUME_TEXT: &str = color_print::cstr! {"<em>Picking up where we left off...</em>"};
 
 // Only show the model-related tip for now to make users aware of this feature.
-const ROTATING_TIPS: [&str; 16] = [
+const ROTATING_TIPS: [&str; 17] = [
     color_print::cstr! {"You can resume the last conversation from your current directory by launching with
     <green!>q chat --resume</green!>"},
     color_print::cstr! {"Get notified whenever Q CLI finishes responding.
@@ -430,6 +353,7 @@ const ROTATING_TIPS: [&str; 16] = [
     color_print::cstr! {"Use <green!>/model</green!> to select the model to use for this conversation"},
     color_print::cstr! {"Set a default model by running <green!>q settings chat.defaultModel MODEL</green!>. Run <green!>/model</green!> to learn more."},
     color_print::cstr! {"Run <green!>/prompts</green!> to learn how to build & run repeatable workflows"},
+    color_print::cstr! {"Use <green!>/tangent</green!> or <green!>ctrl + t</green!> (customizable) to start isolated conversations ( ↯ ) that don't affect your main chat history"},
 ];
 
 const GREETING_BREAK_POINT: usize = 80;
@@ -2626,7 +2550,8 @@ impl ChatSession {
     fn generate_tool_trust_prompt(&mut self) -> String {
         let profile = self.conversation.current_profile().map(|s| s.to_string());
         let all_trusted = self.all_tools_trusted();
-        prompt::generate_prompt(profile.as_deref(), all_trusted)
+        let tangent_mode = self.conversation.is_in_tangent_mode();
+        prompt::generate_prompt(profile.as_deref(), all_trusted, tangent_mode)
     }
 
     async fn send_tool_use_telemetry(&mut self, os: &Os) {
@@ -2728,7 +2653,13 @@ impl ChatSession {
             tool_use_id: self.conversation.latest_tool_use_ids(),
             tool_name: self.conversation.latest_tool_use_names(),
             assistant_response_length: md.map(|md| md.response_size as i32),
-            message_meta_tags: md.map(|md| md.message_meta_tags.clone()).unwrap_or_default(),
+            message_meta_tags: {
+                let mut tags = md.map(|md| md.message_meta_tags.clone()).unwrap_or_default();
+                if self.conversation.is_in_tangent_mode() {
+                    tags.push(crate::telemetry::core::MessageMetaTag::TangentMode);
+                }
+                tags
+            },
         };
         os.telemetry
             .send_chat_added_message(&os.database, conversation_id.clone(), result, data)
@@ -2748,26 +2679,31 @@ impl ChatSession {
             };
 
             os.telemetry
-                .send_record_user_turn_completion(&os.database, conversation_id, result, RecordUserTurnCompletionArgs {
-                    message_ids: mds.iter().map(|md| md.message_id.clone()).collect::<_>(),
-                    request_ids: mds.iter().map(|md| md.request_id.clone()).collect::<_>(),
-                    reason,
-                    reason_desc,
-                    status_code,
-                    time_to_first_chunks_ms: mds
-                        .iter()
-                        .map(|md| md.time_to_first_chunk.map(|d| d.as_secs_f64() * 1000.0))
-                        .collect::<_>(),
-                    chat_conversation_type: md.and_then(|md| md.chat_conversation_type),
-                    assistant_response_length: mds.iter().map(|md| md.response_size as i64).sum(),
-                    message_meta_tags: mds.last().map(|md| md.message_meta_tags.clone()).unwrap_or_default(),
-                    user_prompt_length: mds.first().map(|md| md.user_prompt_length).unwrap_or_default() as i64,
-                    user_turn_duration_seconds,
-                    follow_up_count: mds
-                        .iter()
-                        .filter(|md| matches!(md.chat_conversation_type, Some(ChatConversationType::ToolUse)))
-                        .count() as i64,
-                })
+                .send_record_user_turn_completion(
+                    &os.database,
+                    conversation_id,
+                    result,
+                    RecordUserTurnCompletionArgs {
+                        message_ids: mds.iter().map(|md| md.message_id.clone()).collect::<_>(),
+                        request_ids: mds.iter().map(|md| md.request_id.clone()).collect::<_>(),
+                        reason,
+                        reason_desc,
+                        status_code,
+                        time_to_first_chunks_ms: mds
+                            .iter()
+                            .map(|md| md.time_to_first_chunk.map(|d| d.as_secs_f64() * 1000.0))
+                            .collect::<_>(),
+                        chat_conversation_type: md.and_then(|md| md.chat_conversation_type),
+                        assistant_response_length: mds.iter().map(|md| md.response_size as i64).sum(),
+                        message_meta_tags: mds.last().map(|md| md.message_meta_tags.clone()).unwrap_or_default(),
+                        user_prompt_length: mds.first().map(|md| md.user_prompt_length).unwrap_or_default() as i64,
+                        user_turn_duration_seconds,
+                        follow_up_count: mds
+                            .iter()
+                            .filter(|md| matches!(md.chat_conversation_type, Some(ChatConversationType::ToolUse)))
+                            .count() as i64,
+                    },
+                )
                 .await
                 .ok();
         }

--- a/crates/chat-cli/src/cli/chat/prompt.rs
+++ b/crates/chat-cli/src/cli/chat/prompt.rs
@@ -2,36 +2,14 @@ use std::borrow::Cow;
 use std::cell::RefCell;
 
 use eyre::Result;
-use rustyline::completion::{
-    Completer,
-    FilenameCompleter,
-    extract_word,
-};
+use rustyline::completion::{Completer, FilenameCompleter, extract_word};
 use rustyline::error::ReadlineError;
-use rustyline::highlight::{
-    CmdKind,
-    Highlighter,
-};
+use rustyline::highlight::{CmdKind, Highlighter};
 use rustyline::hint::Hinter as RustylineHinter;
 use rustyline::history::DefaultHistory;
-use rustyline::validate::{
-    ValidationContext,
-    ValidationResult,
-    Validator,
-};
+use rustyline::validate::{ValidationContext, ValidationResult, Validator};
 use rustyline::{
-    Cmd,
-    Completer,
-    CompletionType,
-    Config,
-    Context,
-    EditMode,
-    Editor,
-    EventHandler,
-    Helper,
-    Hinter,
-    KeyCode,
-    KeyEvent,
+    Cmd, Completer, CompletionType, Config, Context, EditMode, Editor, EventHandler, Helper, Hinter, KeyCode, KeyEvent,
     Modifiers,
 };
 use winnow::stream::AsChar;
@@ -389,17 +367,22 @@ impl Highlighter for ChatHelper {
         if let Some(components) = parse_prompt_components(prompt) {
             let mut result = String::new();
 
-            // Add profile part if present
+            // Add profile part if present (cyan)
             if let Some(profile) = components.profile {
                 result.push_str(&format!("[{}] ", profile).cyan().to_string());
             }
 
-            // Add warning symbol if present
+            // Add tangent indicator if present (yellow)
+            if components.tangent_mode {
+                result.push_str(&"↯ ".yellow().to_string());
+            }
+
+            // Add warning symbol if present (red)
             if components.warning {
                 result.push_str(&"!".red().to_string());
             }
 
-            // Add the prompt symbol
+            // Add the prompt symbol (magenta)
             result.push_str(&"> ".magenta().to_string());
 
             Cow::Owned(result)
@@ -456,6 +439,16 @@ pub fn rl(
     rl.bind_sequence(
         KeyEvent(KeyCode::Char('f'), Modifiers::CTRL),
         EventHandler::Simple(Cmd::CompleteHint),
+    );
+
+    // Add custom keybinding for Ctrl+T to toggle tangent mode (configurable)
+    let tangent_key_char = match os.database.settings.get_string(Setting::TangentModeKey) {
+        Some(key) if key.len() == 1 => key.chars().next().unwrap_or('t'),
+        _ => 't', // Default to 't' if setting is missing or invalid
+    };
+    rl.bind_sequence(
+        KeyEvent(KeyCode::Char(tangent_key_char), Modifiers::CTRL),
+        EventHandler::Simple(Cmd::Insert(1, "/tangent".to_string())),
     );
 
     Ok(rl)
@@ -590,6 +583,54 @@ mod tests {
         let invalid_prompt = "invalid prompt format";
         let highlighted = helper.highlight_prompt(invalid_prompt, true);
         assert_eq!(highlighted, invalid_prompt);
+    }
+
+    #[test]
+    fn test_highlight_prompt_tangent_mode() {
+        let (prompt_request_sender, _) = tokio::sync::broadcast::channel::<PromptQuery>(1);
+        let (_, prompt_response_receiver) = tokio::sync::broadcast::channel::<PromptQueryResult>(1);
+        let helper = ChatHelper {
+            completer: ChatCompleter::new(prompt_request_sender, prompt_response_receiver),
+            hinter: ChatHinter::new(true),
+            validator: MultiLineValidator,
+        };
+
+        // Test tangent mode prompt highlighting - ↯ yellow, > magenta
+        let highlighted = helper.highlight_prompt("↯ > ", true);
+        assert_eq!(highlighted, format!("{}{}", "↯ ".yellow(), "> ".magenta()));
+    }
+
+    #[test]
+    fn test_highlight_prompt_tangent_mode_with_warning() {
+        let (prompt_request_sender, _) = tokio::sync::broadcast::channel::<PromptQuery>(1);
+        let (_, prompt_response_receiver) = tokio::sync::broadcast::channel::<PromptQueryResult>(1);
+        let helper = ChatHelper {
+            completer: ChatCompleter::new(prompt_request_sender, prompt_response_receiver),
+            hinter: ChatHinter::new(true),
+            validator: MultiLineValidator,
+        };
+
+        // Test tangent mode with warning - ↯ yellow, ! red, > magenta
+        let highlighted = helper.highlight_prompt("↯ !> ", true);
+        assert_eq!(highlighted, format!("{}{}{}", "↯ ".yellow(), "!".red(), "> ".magenta()));
+    }
+
+    #[test]
+    fn test_highlight_prompt_profile_with_tangent_mode() {
+        let (prompt_request_sender, _) = tokio::sync::broadcast::channel::<PromptQuery>(1);
+        let (_, prompt_response_receiver) = tokio::sync::broadcast::channel::<PromptQueryResult>(1);
+        let helper = ChatHelper {
+            completer: ChatCompleter::new(prompt_request_sender, prompt_response_receiver),
+            hinter: ChatHinter::new(true),
+            validator: MultiLineValidator,
+        };
+
+        // Test profile with tangent mode - [dev] cyan, ↯ yellow, > magenta
+        let highlighted = helper.highlight_prompt("[dev] ↯ > ", true);
+        assert_eq!(
+            highlighted,
+            format!("{}{}{}", "[dev] ".cyan(), "↯ ".yellow(), "> ".magenta())
+        );
     }
 
     #[test]

--- a/crates/chat-cli/src/cli/chat/prompt_parser.rs
+++ b/crates/chat-cli/src/cli/chat/prompt_parser.rs
@@ -5,40 +5,53 @@ use crate::cli::agent::DEFAULT_AGENT_NAME;
 pub struct PromptComponents {
     pub profile: Option<String>,
     pub warning: bool,
+    pub tangent_mode: bool,
 }
 
 /// Parse prompt components from a plain text prompt
 pub fn parse_prompt_components(prompt: &str) -> Option<PromptComponents> {
-    // Expected format: "[profile] !> " or "> " or "!> " etc.
+    // Expected format: "[agent] !> " or "> " or "!> " or "[agent] ↯ > " or "↯ > " or "[agent] ↯ !> " etc.
     let mut profile = None;
     let mut warning = false;
+    let mut tangent_mode = false;
     let mut remaining = prompt.trim();
 
-    // Check for profile pattern [profile]
+    // Check for agent pattern [agent] first
     if let Some(start) = remaining.find('[') {
         if let Some(end) = remaining.find(']') {
             if start < end {
-                profile = Some(remaining[start + 1..end].to_string());
+                let content = &remaining[start + 1..end];
+                profile = Some(content.to_string());
                 remaining = remaining[end + 1..].trim_start();
             }
         }
     }
 
-    // Check for warning symbol !
+    // Check for tangent mode ↯ first
+    if let Some(after_tangent) = remaining.strip_prefix('↯') {
+        tangent_mode = true;
+        remaining = after_tangent.trim_start();
+    }
+
+    // Check for warning symbol ! (comes after tangent mode)
     if remaining.starts_with('!') {
         warning = true;
         remaining = remaining[1..].trim_start();
     }
 
-    // Should end with "> "
+    // Should end with "> " for both normal and tangent mode
     if remaining.trim_end() == ">" {
-        Some(PromptComponents { profile, warning })
+        Some(PromptComponents {
+            profile,
+            warning,
+            tangent_mode,
+        })
     } else {
         None
     }
 }
 
-pub fn generate_prompt(current_profile: Option<&str>, warning: bool) -> String {
+pub fn generate_prompt(current_profile: Option<&str>, warning: bool, tangent_mode: bool) -> String {
     // Generate plain text prompt that will be colored by highlight_prompt
     let warning_symbol = if warning { "!" } else { "" };
     let profile_part = current_profile
@@ -46,7 +59,11 @@ pub fn generate_prompt(current_profile: Option<&str>, warning: bool) -> String {
         .map(|p| format!("[{p}] "))
         .unwrap_or_default();
 
-    format!("{profile_part}{warning_symbol}> ")
+    if tangent_mode {
+        format!("{profile_part}↯ {warning_symbol}> ")
+    } else {
+        format!("{profile_part}{warning_symbol}> ")
+    }
 }
 
 #[cfg(test)]
@@ -56,15 +73,26 @@ mod tests {
     #[test]
     fn test_generate_prompt() {
         // Test default prompt (no profile)
-        assert_eq!(generate_prompt(None, false), "> ");
+        assert_eq!(generate_prompt(None, false, false), "> ");
         // Test default prompt with warning
-        assert_eq!(generate_prompt(None, true), "!> ");
+        assert_eq!(generate_prompt(None, true, false), "!> ");
+        // Test tangent mode
+        assert_eq!(generate_prompt(None, false, true), "↯ > ");
+        // Test tangent mode with warning
+        assert_eq!(generate_prompt(None, true, true), "↯ !> ");
         // Test default profile (should be same as no profile)
-        assert_eq!(generate_prompt(Some(DEFAULT_AGENT_NAME), false), "> ");
+        assert_eq!(generate_prompt(Some(DEFAULT_AGENT_NAME), false, false), "> ");
         // Test custom profile
-        assert_eq!(generate_prompt(Some("test-profile"), false), "[test-profile] > ");
+        assert_eq!(generate_prompt(Some("test-profile"), false, false), "[test-profile] > ");
+        // Test custom profile with tangent mode
+        assert_eq!(
+            generate_prompt(Some("test-profile"), false, true),
+            "[test-profile] ↯ > "
+        );
         // Test another custom profile with warning
-        assert_eq!(generate_prompt(Some("dev"), true), "[dev] !> ");
+        assert_eq!(generate_prompt(Some("dev"), true, false), "[dev] !> ");
+        // Test custom profile with warning and tangent mode
+        assert_eq!(generate_prompt(Some("dev"), true, true), "[dev] ↯ !> ");
     }
 
     #[test]
@@ -73,21 +101,49 @@ mod tests {
         let components = parse_prompt_components("> ").unwrap();
         assert!(components.profile.is_none());
         assert!(!components.warning);
+        assert!(!components.tangent_mode);
 
         // Test warning prompt
         let components = parse_prompt_components("!> ").unwrap();
         assert!(components.profile.is_none());
         assert!(components.warning);
+        assert!(!components.tangent_mode);
+
+        // Test tangent mode
+        let components = parse_prompt_components("↯ > ").unwrap();
+        assert!(components.profile.is_none());
+        assert!(!components.warning);
+        assert!(components.tangent_mode);
+
+        // Test tangent mode with warning
+        let components = parse_prompt_components("↯ !> ").unwrap();
+        assert!(components.profile.is_none());
+        assert!(components.warning);
+        assert!(components.tangent_mode);
 
         // Test profile prompt
         let components = parse_prompt_components("[test] > ").unwrap();
         assert_eq!(components.profile.as_deref(), Some("test"));
         assert!(!components.warning);
+        assert!(!components.tangent_mode);
 
         // Test profile with warning
         let components = parse_prompt_components("[dev] !> ").unwrap();
         assert_eq!(components.profile.as_deref(), Some("dev"));
         assert!(components.warning);
+        assert!(!components.tangent_mode);
+
+        // Test profile with tangent mode
+        let components = parse_prompt_components("[dev] ↯ > ").unwrap();
+        assert_eq!(components.profile.as_deref(), Some("dev"));
+        assert!(!components.warning);
+        assert!(components.tangent_mode);
+
+        // Test profile with warning and tangent mode
+        let components = parse_prompt_components("[dev] ↯ !> ").unwrap();
+        assert_eq!(components.profile.as_deref(), Some("dev"));
+        assert!(components.warning);
+        assert!(components.tangent_mode);
 
         // Test invalid prompt
         assert!(parse_prompt_components("invalid").is_none());

--- a/crates/chat-cli/src/database/settings.rs
+++ b/crates/chat-cli/src/database/settings.rs
@@ -2,16 +2,9 @@ use std::fmt::Display;
 use std::io::SeekFrom;
 
 use fd_lock::RwLock;
-use serde_json::{
-    Map,
-    Value,
-};
+use serde_json::{Map, Value};
 use tokio::fs::File;
-use tokio::io::{
-    AsyncReadExt,
-    AsyncSeekExt,
-    AsyncWriteExt,
-};
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 
 use super::DatabaseError;
 
@@ -29,6 +22,7 @@ pub enum Setting {
     KnowledgeChunkOverlap,
     KnowledgeIndexType,
     SkimCommandKey,
+    TangentModeKey,
     ChatGreetingEnabled,
     ApiTimeout,
     ChatEditMode,
@@ -60,6 +54,7 @@ impl AsRef<str> for Setting {
             Self::KnowledgeChunkOverlap => "knowledge.chunkOverlap",
             Self::KnowledgeIndexType => "knowledge.indexType",
             Self::SkimCommandKey => "chat.skimCommandKey",
+            Self::TangentModeKey => "chat.tangentModeKey",
             Self::ChatGreetingEnabled => "chat.greeting.enabled",
             Self::ApiTimeout => "api.timeout",
             Self::ChatEditMode => "chat.editMode",
@@ -101,6 +96,7 @@ impl TryFrom<&str> for Setting {
             "knowledge.chunkOverlap" => Ok(Self::KnowledgeChunkOverlap),
             "knowledge.indexType" => Ok(Self::KnowledgeIndexType),
             "chat.skimCommandKey" => Ok(Self::SkimCommandKey),
+            "chat.tangentModeKey" => Ok(Self::TangentModeKey),
             "chat.greeting.enabled" => Ok(Self::ChatGreetingEnabled),
             "api.timeout" => Ok(Self::ApiTimeout),
             "chat.editMode" => Ok(Self::ChatEditMode),

--- a/crates/chat-cli/src/telemetry/core.rs
+++ b/crates/chat-cli/src/telemetry/core.rs
@@ -496,6 +496,8 @@ impl From<ChatConversationType> for CodewhispererterminalChatConversationType {
 pub enum MessageMetaTag {
     /// A /compact request
     Compact,
+    /// A /tangent request
+    TangentMode,
 }
 
 /// Optional fields to add for a chatAddedMessage telemetry event.


### PR DESCRIPTION
*Issue #, if available:*
add tangent mode for isolated conversations
<img width="1434" height="821" alt="image" src="https://github.com/user-attachments/assets/c3f0b393-3136-48ed-ac17-5b4cb15372a4" />


*Description of changes:*
- Add /tangent command to toggle between normal and tangent modes
- Preserve conversation history during tangent for context
- Restore main conversation when exiting tangent mode
- Add Ctrl+T keyboard shortcut for quick access
- Visual indicator: green [T] prompt in tangent mode
- Comprehensive tests for state management and UI components

Allows users to explore side topics without polluting main conversation context.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
