### PR TITLE
feat: add shell_read_only_ls_directory tool

### DIFF
--- a/crates/chat-cli/src/cli/chat/tool_manager.rs
+++ b/crates/chat-cli/src/cli/chat/tool_manager.rs
@@ -78,6 +78,7 @@ use crate::cli::chat::tools::fs_read::FsRead;
 use crate::cli::chat::tools::fs_write::FsWrite;
 use crate::cli::chat::tools::gh_issue::GhIssue;
 use crate::cli::chat::tools::knowledge::Knowledge;
+use crate::cli::chat::tools::shell_wrappers::LsDirectory;
 use crate::cli::chat::tools::thinking::Thinking;
 use crate::cli::chat::tools::use_aws::UseAws;
 use crate::cli::chat::tools::{
@@ -1066,6 +1067,9 @@ impl ToolManager {
             "report_issue" => Tool::GhIssue(serde_json::from_value::<GhIssue>(value.args).map_err(map_err)?),
             "thinking" => Tool::Thinking(serde_json::from_value::<Thinking>(value.args).map_err(map_err)?),
             "knowledge" => Tool::Knowledge(serde_json::from_value::<Knowledge>(value.args).map_err(map_err)?),
+            "shell_read_only_ls_directory" => {
+                Tool::LsDirectory(serde_json::from_value::<LsDirectory>(value.args).map_err(map_err)?)
+            },
             // Note that this name is namespaced with server_name{DELIMITER}tool_name
             name => {
                 // Note: tn_map also has tools that underwent no transformation. In otherwords, if

--- a/crates/chat-cli/src/cli/chat/tools/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/mod.rs
@@ -4,6 +4,7 @@ pub mod fs_read;
 pub mod fs_write;
 pub mod gh_issue;
 pub mod knowledge;
+pub mod shell_wrappers;
 pub mod thinking;
 pub mod use_aws;
 
@@ -34,6 +35,7 @@ use serde::{
     Deserialize,
     Serialize,
 };
+use shell_wrappers::LsDirectory;
 use thinking::Thinking;
 use tracing::error;
 use use_aws::UseAws;
@@ -79,6 +81,7 @@ pub enum Tool {
     GhIssue(GhIssue),
     Knowledge(Knowledge),
     Thinking(Thinking),
+    LsDirectory(LsDirectory),
 }
 
 impl Tool {
@@ -96,6 +99,7 @@ impl Tool {
             Tool::GhIssue(_) => "gh_issue",
             Tool::Knowledge(_) => "knowledge",
             Tool::Thinking(_) => "thinking (prerelease)",
+            Tool::LsDirectory(_) => "shell_read_only_ls_directory",
         }
         .to_owned()
     }
@@ -111,6 +115,7 @@ impl Tool {
             Tool::GhIssue(_) => PermissionEvalResult::Allow,
             Tool::Thinking(_) => PermissionEvalResult::Allow,
             Tool::Knowledge(knowledge) => knowledge.eval_perm(agent),
+            Tool::LsDirectory(ls_directory) => ls_directory.eval_perm(agent),
         }
     }
 
@@ -130,6 +135,7 @@ impl Tool {
             Tool::GhIssue(gh_issue) => gh_issue.invoke(os, stdout).await,
             Tool::Knowledge(knowledge) => knowledge.invoke(os, stdout).await,
             Tool::Thinking(think) => think.invoke(stdout).await,
+            Tool::LsDirectory(ls_directory) => ls_directory.invoke(os, stdout).await,
         }
     }
 
@@ -144,6 +150,7 @@ impl Tool {
             Tool::GhIssue(gh_issue) => gh_issue.queue_description(output),
             Tool::Knowledge(knowledge) => knowledge.queue_description(os, output).await,
             Tool::Thinking(thinking) => thinking.queue_description(output),
+            Tool::LsDirectory(ls_directory) => ls_directory.queue_description(output),
         }
     }
 
@@ -158,6 +165,7 @@ impl Tool {
             Tool::GhIssue(gh_issue) => gh_issue.validate(os).await,
             Tool::Knowledge(knowledge) => knowledge.validate(os).await,
             Tool::Thinking(think) => think.validate(os).await,
+            Tool::LsDirectory(ls_directory) => ls_directory.validate(os).await,
         }
     }
 

--- a/crates/chat-cli/src/cli/chat/tools/shell_wrappers/ls_directory.rs
+++ b/crates/chat-cli/src/cli/chat/tools/shell_wrappers/ls_directory.rs
@@ -1,0 +1,123 @@
+use std::io::Write;
+
+use crossterm::queue;
+use crossterm::style::{
+    self,
+    Color,
+};
+use eyre::{
+    Result,
+    bail,
+};
+use serde::Deserialize;
+
+use super::super::{
+    InvokeOutput,
+    MAX_TOOL_RESPONSE_SIZE,
+    OutputKind,
+    sanitize_path_tool_arg,
+};
+use crate::cli::agent::{
+    Agent,
+    PermissionEvalResult,
+};
+use crate::cli::chat::sanitize_unicode_tags;
+use crate::cli::chat::tools::execute::run_command;
+use crate::os::Os;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct LsDirectory {
+    pub path: String,
+    pub show_hidden: Option<bool>,
+    pub long_format: Option<bool>,
+    pub recursive: Option<bool>,
+    pub sort_by: Option<SortBy>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub enum SortBy {
+    #[serde(rename = "name")]
+    Name,
+    #[serde(rename = "size")]
+    Size,
+    #[serde(rename = "time")]
+    Time,
+}
+
+impl LsDirectory {
+    pub fn queue_description(&self, output: &mut impl Write) -> Result<()> {
+        queue!(output, style::Print("I will list directory contents: "),)?;
+
+        queue!(
+            output,
+            style::SetForegroundColor(Color::Green),
+            style::Print(&self.path),
+            style::Print("\n"),
+            style::ResetColor
+        )?;
+
+        Ok(())
+    }
+
+    pub async fn validate(&mut self, os: &Os) -> Result<()> {
+        let sanitized_path = sanitize_path_tool_arg(os, &self.path);
+
+        if !sanitized_path.exists() {
+            bail!("Path does not exist: {}", self.path);
+        }
+
+        if !sanitized_path.is_dir() {
+            bail!("Path is not a directory: {}", self.path);
+        }
+
+        self.path = sanitized_path.to_string_lossy().to_string();
+        Ok(())
+    }
+
+    pub fn eval_perm(&self, agent: &Agent) -> PermissionEvalResult {
+        _ = self;
+        if agent.allowed_tools.contains("shell_read_only_ls_directory") {
+            PermissionEvalResult::Allow
+        } else {
+            PermissionEvalResult::Ask
+        }
+    }
+
+    pub async fn invoke(&self, os: &Os, output: &mut impl Write) -> Result<InvokeOutput> {
+        let mut command = "ls".to_string();
+
+        if self.long_format.unwrap_or(false) {
+            command.push_str(" -l");
+        }
+
+        if self.show_hidden.unwrap_or(false) {
+            command.push_str(" -a");
+        }
+
+        if self.recursive.unwrap_or(false) {
+            command.push_str(" -R");
+        }
+
+        match &self.sort_by {
+            Some(SortBy::Size) => command.push_str(" -S"),
+            Some(SortBy::Time) => command.push_str(" -t"),
+            _ => {},
+        }
+
+        command.push_str(&format!(" '{}'", self.path));
+
+        let result = run_command(os, &command, MAX_TOOL_RESPONSE_SIZE / 3, Some(output)).await?;
+        let clean_stdout = sanitize_unicode_tags(&result.stdout);
+        let clean_stderr = sanitize_unicode_tags(&result.stderr);
+
+        let json_result = serde_json::json!({
+            "exit_status": result.exit_status.unwrap_or(0).to_string(),
+            "stdout": clean_stdout,
+            "stderr": clean_stderr,
+        });
+
+        Ok(InvokeOutput {
+            output: OutputKind::Json(json_result),
+        })
+    }
+}

--- a/crates/chat-cli/src/cli/chat/tools/shell_wrappers/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/shell_wrappers/mod.rs
@@ -1,0 +1,3 @@
+pub mod ls_directory;
+
+pub use ls_directory::LsDirectory;

--- a/crates/chat-cli/src/cli/chat/tools/tool_index.json
+++ b/crates/chat-cli/src/cli/chat/tools/tool_index.json
@@ -281,5 +281,38 @@
         "command"
       ]
     }
+  },
+  "shell_read_only_ls_directory": {
+    "name": "shell_read_only_ls_directory",
+    "description": "List directory contents with sanitized parameters",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Directory path to list"
+        },
+        "show_hidden": {
+          "type": "boolean",
+          "description": "Show hidden files (files starting with .)"
+        },
+        "long_format": {
+          "type": "boolean", 
+          "description": "Use long listing format with detailed information"
+        },
+        "recursive": {
+          "type": "boolean",
+          "description": "List subdirectories recursively"
+        },
+        "sort_by": {
+          "type": "string",
+          "enum": ["name", "size", "time"],
+          "description": "Sort files by name, size, or modification time"
+        }
+      },
+      "required": [
+        "path"
+      ]
+    }
   }
 }


### PR DESCRIPTION
- Add LsDirectory tool for safe directory listing with sanitized parameters
- Support options for hidden files, long format, recursive listing, and sorting
- Integrate tool into ToolManager with proper validation and permissions
- Add tool definition to tool_index.json with complete schema
