### PR TITLE
fix(ci): resolve CI pipeline failures

### DIFF
--- a/crates/chat-cli/src/cli/chat/conversation.rs
+++ b/crates/chat-cli/src/cli/chat/conversation.rs
@@ -135,7 +135,6 @@ impl ConversationState {
         current_model_id: Option<String>,
         os: &Os,
     ) -> Self {
-
         let model = if let Some(model_id) = current_model_id {
             match get_model_info(&model_id, os).await {
                 Ok(info) => Some(info),
@@ -1279,5 +1278,4 @@ mod tests {
             conversation.set_next_user_message(i.to_string()).await;
         }
     }
-
 }

--- a/crates/chat-cli/src/cli/chat/tools/custom_tool.rs
+++ b/crates/chat-cli/src/cli/chat/tools/custom_tool.rs
@@ -35,8 +35,8 @@ use crate::mcp_client::{
     ToolCallResult,
 };
 use crate::os::Os;
-use crate::util::pattern_matching::matches_any_pattern;
 use crate::util::MCP_SERVER_TOOL_DELIMITER;
+use crate::util::pattern_matching::matches_any_pattern;
 
 // TODO: support http transport type
 #[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq, JsonSchema)]

--- a/crates/chat-cli/src/cli/chat/tools/knowledge.rs
+++ b/crates/chat-cli/src/cli/chat/tools/knowledge.rs
@@ -19,8 +19,8 @@ use crate::cli::agent::{
 };
 use crate::database::settings::Setting;
 use crate::os::Os;
-use crate::util::pattern_matching::matches_any_pattern;
 use crate::util::knowledge_store::KnowledgeStore;
+use crate::util::pattern_matching::matches_any_pattern;
 
 /// The Knowledge tool allows storing and retrieving information across chat sessions.
 /// It provides semantic search capabilities for files, directories, and text content.

--- a/crates/chat-cli/src/util/pattern_matching.rs
+++ b/crates/chat-cli/src/util/pattern_matching.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+
 use globset::Glob;
 
 /// Check if a string matches any pattern in a set of patterns
@@ -8,28 +9,29 @@ pub fn matches_any_pattern(patterns: &HashSet<String>, text: &str) -> bool {
         if pattern == text {
             return true;
         }
-        
+
         // Glob pattern match if contains wildcards
         if pattern.contains('*') || pattern.contains('?') {
             if let Ok(glob) = Glob::new(pattern) {
                 return glob.compile_matcher().is_match(text);
             }
         }
-        
+
         false
     })
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::collections::HashSet;
+
+    use super::*;
 
     #[test]
     fn test_exact_match() {
         let mut patterns = HashSet::new();
         patterns.insert("fs_read".to_string());
-        
+
         assert!(matches_any_pattern(&patterns, "fs_read"));
         assert!(!matches_any_pattern(&patterns, "fs_write"));
     }
@@ -38,7 +40,7 @@ mod tests {
     fn test_wildcard_patterns() {
         let mut patterns = HashSet::new();
         patterns.insert("fs_*".to_string());
-        
+
         assert!(matches_any_pattern(&patterns, "fs_read"));
         assert!(matches_any_pattern(&patterns, "fs_write"));
         assert!(!matches_any_pattern(&patterns, "execute_bash"));
@@ -48,7 +50,7 @@ mod tests {
     fn test_mcp_patterns() {
         let mut patterns = HashSet::new();
         patterns.insert("@mcp-server/*".to_string());
-        
+
         assert!(matches_any_pattern(&patterns, "@mcp-server/tool1"));
         assert!(matches_any_pattern(&patterns, "@mcp-server/tool2"));
         assert!(!matches_any_pattern(&patterns, "@other-server/tool"));
@@ -58,7 +60,7 @@ mod tests {
     fn test_question_mark_wildcard() {
         let mut patterns = HashSet::new();
         patterns.insert("fs_?ead".to_string());
-        
+
         assert!(matches_any_pattern(&patterns, "fs_read"));
         assert!(!matches_any_pattern(&patterns, "fs_write"));
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
fixed the ci failure introduced by https://github.com/aws/amazon-q-developer-cli/pull/2612
run `cargo +nightly fmt ` to fix the ci

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
