### PR TITLE
Fix: bug: q login always prompts for start url and region even if the…

### DIFF
--- a/crates/chat-cli/src/cli/user.rs
+++ b/crates/chat-cli/src/cli/user.rs
@@ -108,22 +108,21 @@ impl LoginArgs {
                 let (start_url, region) = match login_method {
                     AuthMethod::BuilderId => (None, None),
                     AuthMethod::IdentityCenter => {
-                        let default_start_url = match self.identity_provider {
-                            Some(start_url) => Some(start_url),
-                            None => os.database.get_start_url()?,
+                        let start_url = match self.identity_provider {
+                            Some(url) => url,  // CLI arg provided - use directly
+                            None => {
+                                // No CLI arg - prompt with database default
+                                let default = os.database.get_start_url()?;
+                                input("Enter Start URL", default.as_deref())?
+                            }
                         };
-                        let default_region = match self.region {
-                            Some(region) => Some(region),
-                            None => os.database.get_idc_region()?,
-                        };
-
-                        let start_url = match default_start_url {
-                            Some(url) => url,
-                            None => input("Enter Start URL", None)?,
-                        };
-                        let region = match default_region {
-                            Some(r) => r,
-                            None => input("Enter Region", None)?,
+                        let region = match self.region {
+                            Some(r) => r,  // CLI arg provided - use directly
+                            None => {
+                                // No CLI arg - prompt with database default
+                                let default = os.database.get_idc_region()?;
+                                input("Enter Region", default.as_deref())?
+                            }
                         };
 
                         let _ = os.database.set_start_url(start_url.clone());


### PR DESCRIPTION
…y are provided via --identity-provider and --region #2659

*Issue #, if available:* 2659

*Description of changes:* Small change to crates/chat-cli/src/cli/user.rs around line 117 to not call input() for values we already have supplied via command line arguments


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
