### PR TITLE
feat: auto-prompt to resume existing chat conversations

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -406,6 +406,11 @@ impl ChatArgs {
             return Ok(());
         }
 
+        // Skip if the feature is disabled
+        if !os.database.settings.get_bool(crate::database::settings::Setting::ChatPromptToResume).unwrap_or(false) {
+            return Ok(());
+        }
+
         // Check for existing conversation in current directory
         let previous_conversation = std::env::current_dir()
             .ok()

--- a/crates/chat-cli/src/database/settings.rs
+++ b/crates/chat-cli/src/database/settings.rs
@@ -77,6 +77,8 @@ pub enum Setting {
     ChatEnableHistoryHints,
     #[strum(message = "Enable the todo list feature (boolean)")]
     EnabledTodoList,
+    #[strum(message = "Enable the prompt to resume chat feature (boolean)")]
+    ChatPromptToResume,
 }
 
 impl AsRef<str> for Setting {
@@ -112,6 +114,7 @@ impl AsRef<str> for Setting {
             Self::ChatDisableAutoCompaction => "chat.disableAutoCompaction",
             Self::ChatEnableHistoryHints => "chat.enableHistoryHints",
             Self::EnabledTodoList => "chat.enableTodoList",
+            Self::ChatPromptToResume => "chat.promptToResume",
         }
     }
 }


### PR DESCRIPTION
I felt frustrated to loose previous conversation after entering a message in an already used directory. So this PR propose to warn the user and offer him the --resume option if q chat detects is a conversation in the current directory. 

```
❯ /Users/omsr/Documents/myWorkspace/amazon-q-developer-cli/target/release/chat_cli
🤖 You are chatting with claude-sonnet-4

> hello

> Hello! I'm Amazon Q, your AI assistant for AWS and development tasks. I can help you with:

• AWS resource management and CLI operations
• File system operations and code editing
• Bash command execution
• Infrastructure configurations
• Troubleshooting and optimization
• Software development tasks

What can I help you with today?

> i am Olivier

> Hi Olivier! Nice to meet you. How can I assist you today?

>

(To exit the CLI, press Ctrl+C or Ctrl+D again or type /quit)

>
❯ /Users/omsr/Documents/myWorkspace/amazon-q-developer-cli/target/release/chat_cli
Found existing Q chat conversation in this directory. Resume? [Y/n]: Y
🤖 You are chatting with claude-sonnet-4


> We exchanged greetings - you introduced yourself as Olivier, and I introduced myself as Amazon Q and offered to help with AWS and development tasks.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
