### PR TITLE
Proposal: Add a `/reply` command

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/mod.rs
+++ b/crates/chat-cli/src/cli/chat/cli/mod.rs
@@ -11,6 +11,7 @@ pub mod model;
 pub mod persist;
 pub mod profile;
 pub mod prompts;
+pub mod reply;
 pub mod subscribe;
 pub mod tangent;
 pub mod todos;
@@ -31,6 +32,7 @@ use model::ModelArgs;
 use persist::PersistSubcommand;
 use profile::AgentSubcommand;
 use prompts::PromptsArgs;
+use reply::ReplyArgs;
 use tangent::TangentArgs;
 use todos::TodoSubcommand;
 use tools::ToolsArgs;
@@ -71,6 +73,8 @@ pub enum SlashCommand {
     /// Open $EDITOR (defaults to vi) to compose a prompt
     #[command(name = "editor")]
     PromptEditor(EditorArgs),
+    /// Open $EDITOR with the most recent assistant message quoted for reply
+    Reply(ReplyArgs),
     /// Summarize the conversation to free up context space
     Compact(CompactArgs),
     /// View tools and permissions
@@ -139,6 +143,7 @@ impl SlashCommand {
             Self::Context(args) => args.execute(os, session).await,
             Self::Knowledge(subcommand) => subcommand.execute(os, session).await,
             Self::PromptEditor(args) => args.execute(session).await,
+            Self::Reply(args) => args.execute(session).await,
             Self::Compact(args) => args.execute(os, session).await,
             Self::Tools(args) => args.execute(session).await,
             Self::Issue(args) => {
@@ -182,6 +187,7 @@ impl SlashCommand {
             Self::Context(_) => "context",
             Self::Knowledge(_) => "knowledge",
             Self::PromptEditor(_) => "editor",
+            Self::Reply(_) => "reply",
             Self::Compact(_) => "compact",
             Self::Tools(_) => "tools",
             Self::Issue(_) => "issue",

--- a/crates/chat-cli/src/cli/chat/cli/reply.rs
+++ b/crates/chat-cli/src/cli/chat/cli/reply.rs
@@ -1,17 +1,11 @@
 use clap::Args;
 use crossterm::execute;
-use crossterm::style::{
-    self,
-    Color,
-};
+use crossterm::style::{self, Color};
 
-use crate::cli::chat::{
-    ChatError,
-    ChatSession,
-    ChatState,
-};
 use super::editor::open_editor;
+use crate::cli::chat::{ChatError, ChatSession, ChatState};
 
+/// Arguments to the `/reply` command.
 #[deny(missing_docs)]
 #[derive(Debug, PartialEq, Args)]
 pub struct ReplyArgs {}
@@ -19,7 +13,8 @@ pub struct ReplyArgs {}
 impl ReplyArgs {
     pub async fn execute(self, session: &mut ChatSession) -> Result<ChatState, ChatError> {
         // Get the most recent assistant message from transcript
-        let last_assistant_message = session.conversation
+        let last_assistant_message = session
+            .conversation
             .transcript
             .iter()
             .rev()
@@ -45,7 +40,7 @@ impl ReplyArgs {
                 return Ok(ChatState::PromptUser {
                     skip_printing_tools: true,
                 });
-            }
+            },
         };
 
         let content = match open_editor(Some(initial_text.clone())) {
@@ -64,41 +59,43 @@ impl ReplyArgs {
             },
         };
 
-        Ok(match content.trim().is_empty() || content.trim() == initial_text.trim() {
-            true => {
-                execute!(
-                    session.stderr,
-                    style::SetForegroundColor(Color::Yellow),
-                    style::Print("\nNo changes made in editor, not submitting.\n\n"),
-                    style::SetForegroundColor(Color::Reset)
-                )?;
+        Ok(
+            match content.trim().is_empty() || content.trim() == initial_text.trim() {
+                true => {
+                    execute!(
+                        session.stderr,
+                        style::SetForegroundColor(Color::Yellow),
+                        style::Print("\nNo changes made in editor, not submitting.\n\n"),
+                        style::SetForegroundColor(Color::Reset)
+                    )?;
 
-                ChatState::PromptUser {
-                    skip_printing_tools: true,
-                }
+                    ChatState::PromptUser {
+                        skip_printing_tools: true,
+                    }
+                },
+                false => {
+                    execute!(
+                        session.stderr,
+                        style::SetForegroundColor(Color::Green),
+                        style::Print("\nContent loaded from editor. Submitting prompt...\n\n"),
+                        style::SetForegroundColor(Color::Reset)
+                    )?;
+
+                    // Display the content as if the user typed it
+                    execute!(
+                        session.stderr,
+                        style::SetAttribute(style::Attribute::Reset),
+                        style::SetForegroundColor(Color::Magenta),
+                        style::Print("> "),
+                        style::SetAttribute(style::Attribute::Reset),
+                        style::Print(&content),
+                        style::Print("\n")
+                    )?;
+
+                    // Process the content as user input
+                    ChatState::HandleInput { input: content }
+                },
             },
-            false => {
-                execute!(
-                    session.stderr,
-                    style::SetForegroundColor(Color::Green),
-                    style::Print("\nContent loaded from editor. Submitting prompt...\n\n"),
-                    style::SetForegroundColor(Color::Reset)
-                )?;
-
-                // Display the content as if the user typed it
-                execute!(
-                    session.stderr,
-                    style::SetAttribute(style::Attribute::Reset),
-                    style::SetForegroundColor(Color::Magenta),
-                    style::Print("> "),
-                    style::SetAttribute(style::Attribute::Reset),
-                    style::Print(&content),
-                    style::Print("\n")
-                )?;
-
-                // Process the content as user input
-                ChatState::HandleInput { input: content }
-            },
-        })
+        )
     }
 }

--- a/crates/chat-cli/src/cli/chat/cli/reply.rs
+++ b/crates/chat-cli/src/cli/chat/cli/reply.rs
@@ -1,0 +1,104 @@
+use clap::Args;
+use crossterm::execute;
+use crossterm::style::{
+    self,
+    Color,
+};
+
+use crate::cli::chat::{
+    ChatError,
+    ChatSession,
+    ChatState,
+};
+use super::editor::open_editor;
+
+#[deny(missing_docs)]
+#[derive(Debug, PartialEq, Args)]
+pub struct ReplyArgs {}
+
+impl ReplyArgs {
+    pub async fn execute(self, session: &mut ChatSession) -> Result<ChatState, ChatError> {
+        // Get the most recent assistant message from transcript
+        let last_assistant_message = session.conversation
+            .transcript
+            .iter()
+            .rev()
+            .find(|msg| !msg.starts_with("> "))
+            .cloned();
+
+        let initial_text = match last_assistant_message {
+            Some(msg) => {
+                // Format with > prefix for each line
+                msg.lines()
+                    .map(|line| format!("> {}", line))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            },
+            None => {
+                execute!(
+                    session.stderr,
+                    style::SetForegroundColor(Color::Yellow),
+                    style::Print("\nNo assistant message found to reply to.\n\n"),
+                    style::SetForegroundColor(Color::Reset)
+                )?;
+
+                return Ok(ChatState::PromptUser {
+                    skip_printing_tools: true,
+                });
+            }
+        };
+
+        let content = match open_editor(Some(initial_text)) {
+            Ok(content) => content,
+            Err(err) => {
+                execute!(
+                    session.stderr,
+                    style::SetForegroundColor(Color::Red),
+                    style::Print(format!("\nError opening editor: {}\n\n", err)),
+                    style::SetForegroundColor(Color::Reset)
+                )?;
+
+                return Ok(ChatState::PromptUser {
+                    skip_printing_tools: true,
+                });
+            },
+        };
+
+        Ok(match content.trim().is_empty() {
+            true => {
+                execute!(
+                    session.stderr,
+                    style::SetForegroundColor(Color::Yellow),
+                    style::Print("\nEmpty content from editor, not submitting.\n\n"),
+                    style::SetForegroundColor(Color::Reset)
+                )?;
+
+                ChatState::PromptUser {
+                    skip_printing_tools: true,
+                }
+            },
+            false => {
+                execute!(
+                    session.stderr,
+                    style::SetForegroundColor(Color::Green),
+                    style::Print("\nContent loaded from editor. Submitting prompt...\n\n"),
+                    style::SetForegroundColor(Color::Reset)
+                )?;
+
+                // Display the content as if the user typed it
+                execute!(
+                    session.stderr,
+                    style::SetAttribute(style::Attribute::Reset),
+                    style::SetForegroundColor(Color::Magenta),
+                    style::Print("> "),
+                    style::SetAttribute(style::Attribute::Reset),
+                    style::Print(&content),
+                    style::Print("\n")
+                )?;
+
+                // Process the content as user input
+                ChatState::HandleInput { input: content }
+            },
+        })
+    }
+}

--- a/crates/chat-cli/src/cli/chat/cli/reply.rs
+++ b/crates/chat-cli/src/cli/chat/cli/reply.rs
@@ -48,7 +48,7 @@ impl ReplyArgs {
             }
         };
 
-        let content = match open_editor(Some(initial_text)) {
+        let content = match open_editor(Some(initial_text.clone())) {
             Ok(content) => content,
             Err(err) => {
                 execute!(
@@ -64,12 +64,12 @@ impl ReplyArgs {
             },
         };
 
-        Ok(match content.trim().is_empty() {
+        Ok(match content.trim().is_empty() || content.trim() == initial_text.trim() {
             true => {
                 execute!(
                     session.stderr,
                     style::SetForegroundColor(Color::Yellow),
-                    style::Print("\nEmpty content from editor, not submitting.\n\n"),
+                    style::Print("\nNo changes made in editor, not submitting.\n\n"),
                     style::SetForegroundColor(Color::Reset)
                 )?;
 

--- a/crates/chat-cli/src/cli/chat/prompt.rs
+++ b/crates/chat-cli/src/cli/chat/prompt.rs
@@ -54,6 +54,7 @@ pub const COMMANDS: &[&str] = &[
     "/clear",
     "/help",
     "/editor",
+    "/reply",
     "/issue",
     "/quit",
     "/tools",


### PR DESCRIPTION
*Description of changes:*

I'm not sure if there is better process for this, but this is a small feature I've been wanting! In addition to `/editor`, you can now do `/reply`. It begins the editor with the assistant's last comments, quoted with `>`. I find this very useful particularly when Claude has given me a list of clarifications and I want to answer all of them.

*Concerns:*

I couldn't find any existing infra to unit-test this with. I was thinking that it'd be nice to have a way to "mock out" the editor, but that doesn't seem to be a thing. Maybe I missed it?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
