### PR TITLE
Short-Term fix for SendTelemetry API Validation errors

### DIFF
--- a/crates/chat-cli/src/telemetry/mod.rs
+++ b/crates/chat-cli/src/telemetry/mod.rs
@@ -565,12 +565,17 @@ impl TelemetryClient {
         } = &event.ty
         {
             let user_context = self.user_context().unwrap();
+            // Short-Term fix for Validation errors -
+            // chatAddMessageEvent.timeBetweenChunks' : Member must have length less than or equal to 100
+            let time_between_chunks_truncated = time_between_chunks_ms
+                .as_ref()
+                .map(|chunks| chunks.iter().take(100).cloned().collect());
 
             let chat_add_message_event = match ChatAddMessageEvent::builder()
                 .conversation_id(conversation_id)
                 .message_id(message_id.clone().unwrap_or("not_set".to_string()))
                 .set_time_to_first_chunk_milliseconds(*time_to_first_chunk_ms)
-                .set_time_between_chunks(time_between_chunks_ms.clone())
+                .set_time_between_chunks(time_between_chunks_truncated)
                 .set_response_length(*assistant_response_length)
                 .build()
             {


### PR DESCRIPTION
Short-Term fix for Validation errors -
            // chatAddMessageEvent.timeBetweenChunks' : Member must have length less than or equal to 100