### PR TITLE
Add telemetry support for agent contribution tracking

### DIFF
--- a/crates/chat-cli/src/telemetry/mod.rs
+++ b/crates/chat-cli/src/telemetry/mod.rs
@@ -14,6 +14,8 @@ use std::str::FromStr;
 
 use amzn_codewhisperer_client::types::{
     ChatAddMessageEvent,
+    ChatInteractWithMessageEvent,
+    ChatMessageInteractionType,
     IdeCategory,
     OperatingSystem,
     TelemetryEvent,
@@ -557,55 +559,95 @@ impl TelemetryClient {
             return;
         };
 
-        if let EventType::ChatAddedMessage {
-            conversation_id,
-            data:
-                ChatAddedMessageParams {
-                    message_id,
-                    model,
-                    time_to_first_chunk_ms,
-                    time_between_chunks_ms,
-                    assistant_response_length,
-                    ..
-                },
-            ..
-        } = &event.ty
-        {
-            let user_context = self.user_context().unwrap();
-            // Short-Term fix for Validation errors -
-            // chatAddMessageEvent.timeBetweenChunks' : Member must have length less than or equal to 100
-            let time_between_chunks_truncated = time_between_chunks_ms
-                .as_ref()
-                .map(|chunks| chunks.iter().take(100).cloned().collect());
+        match &event.ty {
+            EventType::ChatAddedMessage {
+                conversation_id,
+                data:
+                    ChatAddedMessageParams {
+                        message_id,
+                        model,
+                        time_to_first_chunk_ms,
+                        time_between_chunks_ms,
+                        assistant_response_length,
+                        ..
+                    },
+                ..
+            } => {
+                let user_context = self.user_context().unwrap();
+                // Short-Term fix for Validation errors -
+                // chatAddMessageEvent.timeBetweenChunks' : Member must have length less than or equal to 100
+                let time_between_chunks_truncated = time_between_chunks_ms
+                    .as_ref()
+                    .map(|chunks| chunks.iter().take(100).cloned().collect());
 
-            let chat_add_message_event = match ChatAddMessageEvent::builder()
-                .conversation_id(conversation_id)
-                .message_id(message_id.clone().unwrap_or("not_set".to_string()))
-                .set_time_to_first_chunk_milliseconds(*time_to_first_chunk_ms)
-                .set_time_between_chunks(time_between_chunks_truncated)
-                .set_response_length(*assistant_response_length)
-                .build()
-            {
-                Ok(event) => event,
-                Err(err) => {
+                let chat_add_message_event = match ChatAddMessageEvent::builder()
+                    .conversation_id(conversation_id)
+                    .message_id(message_id.clone().unwrap_or("not_set".to_string()))
+                    .set_time_to_first_chunk_milliseconds(*time_to_first_chunk_ms)
+                    .set_time_between_chunks(time_between_chunks_truncated)
+                    .set_response_length(*assistant_response_length)
+                    .build()
+                {
+                    Ok(event) => event,
+                    Err(err) => {
+                        error!(err =% DisplayErrorContext(err), "Failed to send cw telemetry event");
+                        return;
+                    },
+                };
+
+                let event = TelemetryEvent::ChatAddMessageEvent(chat_add_message_event);
+                debug!(
+                    ?event,
+                    ?user_context,
+                    telemetry_enabled = self.telemetry_enabled,
+                    "Sending cw telemetry event"
+                );
+                if let Err(err) = codewhisperer_client
+                    .send_telemetry_event(event, user_context, self.telemetry_enabled, model.to_owned())
+                    .await
+                {
                     error!(err =% DisplayErrorContext(err), "Failed to send cw telemetry event");
-                    return;
-                },
-            };
+                }
+            },
+            EventType::AgentContribution {
+                conversation_id,
+                utterance_id,
+                lines_by_agent,
+                ..
+            } => {
+                let user_context = self.user_context().unwrap();
 
-            let event = TelemetryEvent::ChatAddMessageEvent(chat_add_message_event);
-            debug!(
-                ?event,
-                ?user_context,
-                telemetry_enabled = self.telemetry_enabled,
-                "Sending cw telemetry event"
-            );
-            if let Err(err) = codewhisperer_client
-                .send_telemetry_event(event, user_context, self.telemetry_enabled, model.to_owned())
-                .await
-            {
-                error!(err =% DisplayErrorContext(err), "Failed to send cw telemetry event");
-            }
+                let builder = ChatInteractWithMessageEvent::builder()
+                    .conversation_id(conversation_id)
+                    .message_id(utterance_id.clone().unwrap_or("not_set".to_string()))
+                    .accepted_line_count(lines_by_agent.map_or(0, |lines| lines as i32))
+                    .interaction_type(ChatMessageInteractionType::AgenticCodeAccepted);
+
+                let chat_interact_event = match builder.build() {
+                    Ok(event) => event,
+                    Err(err) => {
+                        error!(err =% DisplayErrorContext(err), "Failed to build ChatInteractWithMessageEvent");
+                        return;
+                    },
+                };
+
+                let event = TelemetryEvent::ChatInteractWithMessageEvent(chat_interact_event);
+                debug!(
+                    ?event,
+                    ?user_context,
+                    telemetry_enabled = self.telemetry_enabled,
+                    "Sending cw telemetry event"
+                );
+                if let Err(err) = codewhisperer_client
+                    .send_telemetry_event(event, user_context, self.telemetry_enabled, None)
+                    .await
+                {
+                    error!(err =% DisplayErrorContext(err), "Failed to send cw telemetry event");
+                }
+            },
+            _ => {
+                // No CW telemetry event for other event types
+            },
         }
     }
 


### PR DESCRIPTION
- Refactor send_cw_telemetry to handle multiple event types
- Add AgentContribution event handling that sends ChatInteractWithMessageEvent
- Track accepted line count from agent contributions as AgenticCodeAccepted interaction type
