### PR TITLE
feat: add tangent mode duration tracking telemetry

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/tangent.rs
+++ b/crates/chat-cli/src/cli/chat/cli/tangent.rs
@@ -18,7 +18,25 @@ pub struct TangentArgs;
 impl TangentArgs {
     pub async fn execute(self, os: &Os, session: &mut ChatSession) -> Result<ChatState, ChatError> {
         if session.conversation.is_in_tangent_mode() {
+            // Get duration before exiting tangent mode
+            let duration_seconds = session.conversation.get_tangent_duration_seconds().unwrap_or(0);
+
             session.conversation.exit_tangent_mode();
+
+            // Send telemetry for tangent mode session
+            if let Err(err) = os
+                .telemetry
+                .send_tangent_mode_session(
+                    &os.database,
+                    session.conversation.conversation_id().to_string(),
+                    crate::telemetry::TelemetryResult::Succeeded,
+                    crate::telemetry::core::TangentModeSessionArgs { duration_seconds },
+                )
+                .await
+            {
+                tracing::warn!(?err, "Failed to send tangent mode session telemetry");
+            }
+
             execute!(
                 session.stderr,
                 style::SetForegroundColor(Color::DarkGrey),
@@ -67,5 +85,45 @@ impl TangentArgs {
         Ok(ChatState::PromptUser {
             skip_printing_tools: false,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::cli::agent::Agents;
+    use crate::cli::chat::conversation::ConversationState;
+    use crate::cli::chat::tool_manager::ToolManager;
+    use crate::os::Os;
+
+    #[tokio::test]
+    async fn test_tangent_mode_duration_tracking() {
+        let mut os = Os::new().await.unwrap();
+        let agents = Agents::default();
+        let mut tool_manager = ToolManager::default();
+        let mut conversation = ConversationState::new(
+            "test_conv_id",
+            agents,
+            tool_manager.load_tools(&mut os, &mut vec![]).await.unwrap(),
+            tool_manager,
+            None,
+            &os,
+            false, // mcp_enabled
+        )
+        .await;
+
+        // Test entering tangent mode
+        assert!(!conversation.is_in_tangent_mode());
+        conversation.enter_tangent_mode();
+        assert!(conversation.is_in_tangent_mode());
+
+        // Should have a duration
+        let duration = conversation.get_tangent_duration_seconds();
+        assert!(duration.is_some());
+        assert!(duration.unwrap() >= 0);
+
+        // Test exiting tangent mode
+        conversation.exit_tangent_mode();
+        assert!(!conversation.is_in_tangent_mode());
+        assert!(conversation.get_tangent_duration_seconds().is_none());
     }
 }

--- a/crates/chat-cli/src/telemetry/core.rs
+++ b/crates/chat-cli/src/telemetry/core.rs
@@ -286,6 +286,25 @@ impl Event {
                 }
                 .into_metric_datum(),
             ),
+            EventType::TangentModeSession {
+                conversation_id,
+                result,
+                args: TangentModeSessionArgs { duration_seconds },
+            } => Some(
+                CodewhispererterminalChatSlashCommandExecuted {
+                    create_time: self.created_time,
+                    value: Some(duration_seconds as f64),
+                    credential_start_url: self.credential_start_url.map(Into::into),
+                    sso_region: self.sso_region.map(Into::into),
+                    amazonq_conversation_id: Some(conversation_id.into()),
+                    codewhispererterminal_chat_slash_command: Some("tangent".to_string().into()),
+                    codewhispererterminal_chat_slash_subcommand: Some("exit".to_string().into()),
+                    result: Some(result.to_string().into()),
+                    reason: None,
+                    codewhispererterminal_in_cloudshell: None,
+                }
+                .into_metric_datum(),
+            ),
             EventType::ToolUseSuggested {
                 conversation_id,
                 utterance_id,
@@ -528,6 +547,13 @@ pub struct ChatAddedMessageParams {
     pub message_meta_tags: Vec<MessageMetaTag>,
 }
 
+/// Optional fields for tangent mode session telemetry event.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Default)]
+pub struct TangentModeSessionArgs {
+    /// Duration of tangent mode session in seconds
+    pub duration_seconds: i64,
+}
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Default)]
 pub struct RecordUserTurnCompletionArgs {
     pub request_ids: Vec<Option<String>>,
@@ -591,6 +617,11 @@ pub enum EventType {
         conversation_id: String,
         result: TelemetryResult,
         args: RecordUserTurnCompletionArgs,
+    },
+    TangentModeSession {
+        conversation_id: String,
+        result: TelemetryResult,
+        args: TangentModeSessionArgs,
     },
     ToolUseSuggested {
         conversation_id: String,

--- a/crates/chat-cli/src/telemetry/mod.rs
+++ b/crates/chat-cli/src/telemetry/mod.rs
@@ -8,6 +8,7 @@ use core::{
     AgentConfigInitArgs,
     ChatAddedMessageParams,
     RecordUserTurnCompletionArgs,
+    TangentModeSessionArgs,
     ToolUseEventBuilder,
 };
 use std::str::FromStr;
@@ -314,6 +315,22 @@ impl TelemetryThread {
         args: RecordUserTurnCompletionArgs,
     ) -> Result<(), TelemetryError> {
         let mut telemetry_event = Event::new(EventType::RecordUserTurnCompletion {
+            conversation_id,
+            result,
+            args,
+        });
+        set_event_metadata(database, &mut telemetry_event).await;
+        Ok(self.tx.send(telemetry_event)?)
+    }
+
+    pub async fn send_tangent_mode_session(
+        &self,
+        database: &Database,
+        conversation_id: String,
+        result: TelemetryResult,
+        args: TangentModeSessionArgs,
+    ) -> Result<(), TelemetryError> {
+        let mut telemetry_event = Event::new(EventType::TangentModeSession {
             conversation_id,
             result,
             args,


### PR DESCRIPTION
- Track time spent in tangent mode sessions
- Send duration metric when exiting tangent mode via /tangent command
- Use codewhispererterminal_chatSlashCommandExecuted metric with:
  - command: 'tangent'
  - subcommand: 'exit'
  - value: duration in seconds
- Add comprehensive tests for duration calculation
- Enables analytics on tangent mode usage patterns

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
