### PR TITLE
feat: add /experiment slash command for toggling experimental features

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/experiment.rs
+++ b/crates/chat-cli/src/cli/chat/cli/experiment.rs
@@ -61,9 +61,9 @@ async fn select_experiment(os: &mut Os, session: &mut ChatSession) -> Result<Opt
 
         current_states.push(is_enabled);
         // Create clean single-line format: "Knowledge    [ON]   - Description"
-        let status_indicator = if is_enabled { 
+        let status_indicator = if is_enabled {
             style::Stylize::green("[ON] ")
-        } else { 
+        } else {
             style::Stylize::grey("[OFF]")
         };
         let label = format!(

--- a/crates/chat-cli/src/cli/chat/cli/experiment.rs
+++ b/crates/chat-cli/src/cli/chat/cli/experiment.rs
@@ -60,8 +60,12 @@ async fn select_experiment(os: &mut Os, session: &mut ChatSession) -> Result<Opt
         let is_enabled = os.database.settings.get_bool(experiment.setting_key).unwrap_or(false);
 
         current_states.push(is_enabled);
-        // Create clean single-line format: "Knowledge    [✅ ON]   - Description"
-        let status_indicator = if is_enabled { "[✅ ON] " } else { "[❌ OFF]" };
+        // Create clean single-line format: "Knowledge    [ON]   - Description"
+        let status_indicator = if is_enabled { 
+            style::Stylize::green("[ON] ")
+        } else { 
+            style::Stylize::grey("[OFF]")
+        };
         let label = format!(
             "{:<18} {} - {}",
             experiment.name,
@@ -73,8 +77,8 @@ async fn select_experiment(os: &mut Os, session: &mut ChatSession) -> Result<Opt
 
     experiment_labels.push(String::new());
     experiment_labels.push(format!(
-        "⚠️  {}",
-        style::Stylize::dark_grey("Experimental features may be changed or removed at any time")
+        "{}",
+        style::Stylize::white("⚠ Experimental features may be changed or removed at any time")
     ));
 
     let selection: Option<_> = match Select::with_theme(&crate::util::dialoguer_theme())

--- a/crates/chat-cli/src/cli/chat/cli/experiment.rs
+++ b/crates/chat-cli/src/cli/chat/cli/experiment.rs
@@ -1,0 +1,151 @@
+// ABOUTME: Implements the /experiment slash command for toggling experimental features
+// ABOUTME: Provides interactive selection interface similar to /model command
+
+use clap::Args;
+use crossterm::style::{
+    self,
+    Color,
+};
+use crossterm::{
+    execute,
+    queue,
+};
+use dialoguer::Select;
+
+use crate::cli::chat::{
+    ChatError,
+    ChatSession,
+    ChatState,
+};
+use crate::database::settings::Setting;
+use crate::os::Os;
+
+/// Represents an experimental feature that can be toggled
+#[derive(Debug, Clone)]
+struct Experiment {
+    name: &'static str,
+    description: &'static str,
+    setting_key: Setting,
+}
+
+static AVAILABLE_EXPERIMENTS: &[Experiment] = &[
+    Experiment {
+        name: "Knowledge",
+        description: "Enables persistent context storage and retrieval across chat sessions (/knowledge)",
+        setting_key: Setting::EnabledKnowledge,
+    },
+    Experiment {
+        name: "Thinking",
+        description: "Enables complex reasoning with step-by-step thought processes",
+        setting_key: Setting::EnabledThinking,
+    },
+];
+
+#[derive(Debug, PartialEq, Args)]
+pub struct ExperimentArgs;
+impl ExperimentArgs {
+    pub async fn execute(self, os: &mut Os, session: &mut ChatSession) -> Result<ChatState, ChatError> {
+        Ok(select_experiment(os, session).await?.unwrap_or(ChatState::PromptUser {
+            skip_printing_tools: false,
+        }))
+    }
+}
+
+async fn select_experiment(os: &mut Os, session: &mut ChatSession) -> Result<Option<ChatState>, ChatError> {
+    // Get current experiment status
+    let mut experiment_labels = Vec::new();
+    let mut current_states = Vec::new();
+
+    for experiment in AVAILABLE_EXPERIMENTS {
+        let is_enabled = os.database.settings.get_bool(experiment.setting_key).unwrap_or(false);
+
+        current_states.push(is_enabled);
+        // Create clean single-line format: "Knowledge    [✅ ON]   - Description"
+        let status_indicator = if is_enabled { "[✅ ON] " } else { "[❌ OFF]" };
+        let label = format!(
+            "{:<18} {} - {}",
+            experiment.name,
+            status_indicator,
+            style::Stylize::dark_grey(experiment.description)
+        );
+        experiment_labels.push(label);
+    }
+
+    experiment_labels.push(String::new());
+    experiment_labels.push(format!(
+        "⚠️  {}",
+        style::Stylize::dark_grey("Experimental features may be changed or removed at any time")
+    ));
+
+    let selection: Option<_> = match Select::with_theme(&crate::util::dialoguer_theme())
+        .with_prompt("Select an experiment to toggle")
+        .items(&experiment_labels)
+        .default(0)
+        .interact_on_opt(&dialoguer::console::Term::stdout())
+    {
+        Ok(sel) => {
+            let _ = crossterm::execute!(
+                std::io::stdout(),
+                crossterm::style::SetForegroundColor(crossterm::style::Color::Magenta)
+            );
+            sel
+        },
+        // Ctrl‑C -> Err(Interrupted)
+        Err(dialoguer::Error::IO(ref e)) if e.kind() == std::io::ErrorKind::Interrupted => return Ok(None),
+        Err(e) => return Err(ChatError::Custom(format!("Failed to choose experiment: {e}").into())),
+    };
+
+    queue!(session.stderr, style::ResetColor)?;
+
+    if let Some(index) = selection {
+        // Clear the dialoguer selection line to avoid showing old status
+        queue!(
+            session.stderr,
+            crossterm::cursor::MoveUp(1),
+            crossterm::terminal::Clear(crossterm::terminal::ClearType::CurrentLine),
+        )?;
+
+        // Skip if user selected disclaimer or empty line
+        if index >= AVAILABLE_EXPERIMENTS.len() {
+            return Ok(Some(ChatState::PromptUser {
+                skip_printing_tools: false,
+            }));
+        }
+
+        let experiment = &AVAILABLE_EXPERIMENTS[index];
+        let current_state = current_states[index];
+        let new_state = !current_state;
+
+        // Update the setting
+        os.database
+            .settings
+            .set(experiment.setting_key, new_state)
+            .await
+            .map_err(|e| ChatError::Custom(format!("Failed to update experiment setting: {e}").into()))?;
+
+        // Reload tools to reflect the experiment change
+        let _ = session
+            .conversation
+            .tool_manager
+            .load_tools(os, &mut session.stderr)
+            .await;
+
+        let status_text = if new_state { "enabled" } else { "disabled" };
+
+        queue!(
+            session.stderr,
+            style::Print("\n"),
+            style::SetForegroundColor(Color::Green),
+            style::Print(format!(" {} experiment {}\n\n", experiment.name, status_text)),
+            style::ResetColor,
+            style::SetForegroundColor(Color::Reset),
+            style::SetBackgroundColor(Color::Reset),
+        )?;
+    }
+
+    execute!(session.stderr, style::ResetColor)?;
+
+    Ok(Some(ChatState::PromptUser {
+        skip_printing_tools: false,
+    }))
+}

--- a/crates/chat-cli/src/cli/chat/cli/mod.rs
+++ b/crates/chat-cli/src/cli/chat/cli/mod.rs
@@ -2,6 +2,7 @@ pub mod clear;
 pub mod compact;
 pub mod context;
 pub mod editor;
+pub mod experiment;
 pub mod hooks;
 pub mod knowledge;
 pub mod mcp;
@@ -19,6 +20,7 @@ use clear::ClearArgs;
 use compact::CompactArgs;
 use context::ContextSubcommand;
 use editor::EditorArgs;
+use experiment::ExperimentArgs;
 use hooks::HooksArgs;
 use knowledge::KnowledgeSubcommand;
 use mcp::McpArgs;
@@ -81,6 +83,8 @@ pub enum SlashCommand {
     Mcp(McpArgs),
     /// Select a model for the current conversation session
     Model(ModelArgs),
+    /// Toggle experimental features
+    Experiment(ExperimentArgs),
     /// Upgrade to a Q Developer Pro subscription for increased query limits
     Subscribe(SubscribeArgs),
     /// Toggle tangent mode for isolated conversations
@@ -139,6 +143,7 @@ impl SlashCommand {
             Self::Usage(args) => args.execute(os, session).await,
             Self::Mcp(args) => args.execute(session).await,
             Self::Model(args) => args.execute(os, session).await,
+            Self::Experiment(args) => args.execute(os, session).await,
             Self::Subscribe(args) => args.execute(os, session).await,
             Self::Tangent(args) => args.execute(os, session).await,
             Self::Persist(subcommand) => subcommand.execute(os, session).await,
@@ -171,6 +176,7 @@ impl SlashCommand {
             Self::Usage(_) => "usage",
             Self::Mcp(_) => "mcp",
             Self::Model(_) => "model",
+            Self::Experiment(_) => "experiment",
             Self::Subscribe(_) => "subscribe",
             Self::Tangent(_) => "tangent",
             Self::Persist(sub) => match sub {

--- a/crates/chat-cli/src/cli/chat/prompt.rs
+++ b/crates/chat-cli/src/cli/chat/prompt.rs
@@ -58,6 +58,7 @@ pub const COMMANDS: &[&str] = &[
     "/tools reset",
     "/mcp",
     "/model",
+    "/experiment",
     "/agent",
     "/agent help",
     "/agent list",

--- a/crates/chat-cli/src/cli/chat/tools/introspect.rs
+++ b/crates/chat-cli/src/cli/chat/tools/introspect.rs
@@ -56,6 +56,9 @@ impl Introspect {
         documentation.push_str("\n\n--- docs/built-in-tools.md ---\n");
         documentation.push_str(include_str!("../../../../../../docs/built-in-tools.md"));
 
+        documentation.push_str("\n\n--- docs/experiments.md ---\n");
+        documentation.push_str(include_str!("../../../../../../docs/experiments.md"));
+
         documentation.push_str("\n\n--- docs/agent-file-locations.md ---\n");
         documentation.push_str(include_str!("../../../../../../docs/agent-file-locations.md"));
 
@@ -84,6 +87,8 @@ impl Introspect {
         documentation.push_str(
             "• Built-in Tools: https://github.com/aws/amazon-q-developer-cli/blob/main/docs/built-in-tools.md\n",
         );
+        documentation
+            .push_str("• Experiments: https://github.com/aws/amazon-q-developer-cli/blob/main/docs/experiments.md\n");
         documentation.push_str("• Agent File Locations: https://github.com/aws/amazon-q-developer-cli/blob/main/docs/agent-file-locations.md\n");
         documentation
             .push_str("• Contributing: https://github.com/aws/amazon-q-developer-cli/blob/main/CONTRIBUTING.md\n");
@@ -129,12 +134,11 @@ impl Introspect {
         })
     }
 
-    pub fn queue_description(&self, output: &mut impl Write) -> Result<()> {
+    pub fn queue_description(output: &mut impl Write) -> Result<()> {
         use crossterm::{
             queue,
             style,
         };
-        _ = self;
         queue!(output, style::Print("Introspecting to get you the right information"))?;
         Ok(())
     }

--- a/crates/chat-cli/src/cli/chat/tools/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/mod.rs
@@ -149,7 +149,7 @@ impl Tool {
             Tool::UseAws(use_aws) => use_aws.queue_description(output),
             Tool::Custom(custom_tool) => custom_tool.queue_description(output),
             Tool::GhIssue(gh_issue) => gh_issue.queue_description(output),
-            Tool::Introspect(introspect) => introspect.queue_description(output),
+            Tool::Introspect(_) => Introspect::queue_description(output),
             Tool::Knowledge(knowledge) => knowledge.queue_description(os, output).await,
             Tool::Thinking(thinking) => thinking.queue_description(output),
         }

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -1,0 +1,72 @@
+# Experimental Features
+
+Amazon Q CLI includes experimental features that can be toggled on/off using the `/experiment` command. These features are in active development and may change or be removed at any time.
+
+## Available Experiments
+
+### Knowledge
+**Command:** `/knowledge`  
+**Description:** Enables persistent context storage and retrieval across chat sessions
+
+**Features:**
+- Store and search through files, directories, and text content
+- Semantic search capabilities for better context retrieval  
+- Persistent knowledge base across chat sessions
+- Add/remove/search knowledge contexts
+
+**Usage:**
+```
+/knowledge add <path>        # Add files or directories to knowledge base
+/knowledge show             # Display knowledge base contents
+/knowledge remove <path>    # Remove knowledge base entry by path
+/knowledge update <path>    # Update a file or directory in knowledge base
+/knowledge clear            # Remove all knowledge base entries
+/knowledge status           # Show background operation status
+/knowledge cancel           # Cancel background operation
+```
+
+### Thinking
+**Description:** Enables complex reasoning with step-by-step thought processes
+
+**Features:**
+- Shows AI reasoning process for complex problems
+- Helps understand how conclusions are reached
+- Useful for debugging and learning
+- Transparent decision-making process
+
+**When enabled:** The AI will show its thinking process when working through complex problems or multi-step reasoning.
+
+## Managing Experiments
+
+Use the `/experiment` command to toggle experimental features:
+
+```
+/experiment
+```
+
+This will show an interactive menu where you can:
+- See current status of each experiment (ON/OFF)
+- Toggle experiments by selecting them
+- View descriptions of what each experiment does
+
+## Important Notes
+
+⚠️ **Experimental features may be changed or removed at any time**  
+⚠️ **Experience might not be perfect**  
+⚠️ **Use at your own discretion in production workflows**
+
+These features are provided to gather feedback and test new capabilities. Please report any issues or feedback through the `/issue` command.
+
+## Fuzzy Search Support
+
+All experimental commands are available in the fuzzy search (Ctrl+S):
+- `/experiment` - Manage experimental features
+- `/knowledge` - Knowledge base commands (when enabled)
+
+## Settings Integration
+
+Experiments are stored as settings and persist across sessions:
+- `EnabledKnowledge` - Knowledge experiment state
+- `EnabledThinking` - Thinking experiment state
+
+You can also manage these through the settings system if needed.


### PR DESCRIPTION
- Add new /experiment command
- Toggle selection interface with colored On/Off status indicators
- Include experiment descriptions and disclaimer about experimental features

<img width="855" height="157" alt="image" src="https://github.com/user-attachments/assets/d9912f0a-5557-4f7c-a60b-9e59b3bda603" />

*Description of changes:*

<img width="1199" height="620" alt="image" src="https://github.com/user-attachments/assets/7029d240-2ca3-49f8-b41a-ee9b56dc3ac7" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
