### PR TITLE
chore: add /tangent to /experiment

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/experiment.rs
+++ b/crates/chat-cli/src/cli/chat/cli/experiment.rs
@@ -39,6 +39,11 @@ static AVAILABLE_EXPERIMENTS: &[Experiment] = &[
         description: "Enables complex reasoning with step-by-step thought processes",
         setting_key: Setting::EnabledThinking,
     },
+    Experiment {
+        name: "Tangent Mode",
+        description: "Enables entering into a temporary mode for sending isolated conversations (/tangent)",
+        setting_key: Setting::EnabledTangentMode,
+    },
 ];
 
 #[derive(Debug, PartialEq, Args)]

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -36,6 +36,28 @@ Amazon Q CLI includes experimental features that can be toggled on/off using the
 
 **When enabled:** The AI will show its thinking process when working through complex problems or multi-step reasoning.
 
+### Tangent Mode
+**Command:** `/tangent`  
+**Description:** Enables conversation checkpointing for exploring tangential topics
+
+**Features:**
+- Create conversation checkpoints to explore side topics
+- Return to the main conversation thread at any time
+- Preserve conversation context while branching off
+- Keyboard shortcut support (default: Ctrl+T)
+
+**Usage:**
+```
+/tangent                    # Toggle tangent mode on/off
+```
+
+**Settings:**
+- `chat.enableTangentMode` - Enable/disable tangent mode feature (boolean)
+- `chat.tangentModeKey` - Keyboard shortcut key (single character, default: 't')
+- `introspect.tangentMode` - Auto-enter tangent mode for introspect questions (boolean)
+
+**When enabled:** Use `/tangent` or the keyboard shortcut to create a checkpoint and explore tangential topics. Use the same command to return to your main conversation.
+
 ## Managing Experiments
 
 Use the `/experiment` command to toggle experimental features:


### PR DESCRIPTION
*Description of changes:*
- Adding tangent mode to `/experiment` since it follows the same experimental paradigm as knowledge and thinking

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
