### PR TITLE
Invalid pointer to trace log location

### DIFF
--- a/crates/chat-cli/src/cli/chat/tool_manager.rs
+++ b/crates/chat-cli/src/cli/chat/tool_manager.rs
@@ -1875,7 +1875,7 @@ fn queue_failure_message(
         style::Print(fail_load_msg),
         style::Print("\n"),
         style::Print(format!(
-            " - run with Q_LOG_LEVEL=trace and see $TMPDIR/{CHAT_BINARY_NAME} for detail\n"
+            " - run with Q_LOG_LEVEL=trace and see $TMPDIR/qlog/{CHAT_BINARY_NAME}.log for detail\n"
         )),
         style::ResetColor,
     )?)


### PR DESCRIPTION
I ran into an issue with an MCP server:

```
❯ q chat
✗ mcp-obsidian has failed to load after 0.13 s
 - No such file or directory (os error 2)
 - run with Q_LOG_LEVEL=trace and see $TMPDIR/qchat for detail
```

But the log file does not exist at that location. Did a bit of digging and the correct location is $TMPDIR/qlog/qchat.log


*Description of changes:*
Fixed the error message to show the correct location.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
