### PR TITLE
Use abs value of lines added/removed by q-cli

### DIFF
--- a/crates/chat-cli/src/cli/chat/line_tracker.rs
+++ b/crates/chat-cli/src/cli/chat/line_tracker.rs
@@ -34,6 +34,7 @@ impl FileLineTracker {
     }
 
     pub fn lines_by_agent(&self) -> isize {
-        (self.after_fswrite_lines as isize) - (self.before_fswrite_lines as isize)
+        let lines = (self.after_fswrite_lines as isize) - (self.before_fswrite_lines as isize);
+        lines.abs()
     }
 }


### PR DESCRIPTION
use the absolute value of the diff between lines of code before/after fs_write is invoked so that we correctly capture number of lines modified by q-cli.

Note that this still does not capture the case where - 
```
- line removed
+ line added
```

but fixes the immediate issue where we under-report the changes done by q-cli substantially when we remove more lines that we add.