### PR TITLE
Fix calculation for num-lines contributed by q-cli

### DIFF
--- a/crates/chat-cli/src/cli/chat/line_tracker.rs
+++ b/crates/chat-cli/src/cli/chat/line_tracker.rs
@@ -13,6 +13,10 @@ pub struct FileLineTracker {
     pub before_fswrite_lines: usize,
     /// Line count after `fs_write` executes
     pub after_fswrite_lines: usize,
+    /// Lines added by agent in the current operation
+    pub lines_added_by_agent: usize,
+    /// Lines removed by agent in the current operation
+    pub lines_removed_by_agent: usize,
     /// Whether or not this is the first `fs_write` invocation
     pub is_first_write: bool,
 }
@@ -23,6 +27,8 @@ impl Default for FileLineTracker {
             prev_fswrite_lines: 0,
             before_fswrite_lines: 0,
             after_fswrite_lines: 0,
+            lines_added_by_agent: 0,
+            lines_removed_by_agent: 0,
             is_first_write: true,
         }
     }
@@ -34,7 +40,6 @@ impl FileLineTracker {
     }
 
     pub fn lines_by_agent(&self) -> isize {
-        let lines = (self.after_fswrite_lines as isize) - (self.before_fswrite_lines as isize);
-        lines.abs()
+        (self.lines_added_by_agent + self.lines_removed_by_agent) as isize
     }
 }


### PR DESCRIPTION

## Fix calculation for num-lines contributed by Q CLI

### Summary
Improves the accuracy of line contribution tracking by implementing proper diff-based calculation instead of using simple before/after line counts.

### Changes
• **Enhanced FileLineTracker struct**: Added lines_added_by_agent and lines_removed_by_agent fields to track actual line changes
• **Improved lines_by_agent() method**: Now returns the sum of added and removed lines instead of absolute difference between before/after counts
• **Added calculate_diff_lines() method**: Analyzes different file operations (create, str_replace, insert, append) to accurately count line changes

### Technical Details
The previous implementation used (after_lines - before_lines).abs() which could be inaccurate for operations that both add and remove lines. The new approach:

1. Create operations: Counts all lines in the new file as added
2. String replace operations: Calculates net difference between old and new content
3. Insert/Append operations: Counts all new lines as added

### Impact
This fix ensures more accurate reporting of Q CLI's code contribution metrics, providing better visibility into the actual lines of code generated by the 
assistant.