### PR TITLE
docs: fix local agent directory path in documentation

### DIFF
--- a/docs/agent-file-locations.md
+++ b/docs/agent-file-locations.md
@@ -47,7 +47,7 @@ These agents are available from any directory when using Q CLI.
 
 When Q CLI looks for an agent, it follows this precedence order:
 
-1. **Local first**: Checks `.aws/amazonq/cli-agents/` in the current working directory
+1. **Local first**: Checks `.amazonq/cli-agents/` in the current working directory
 2. **Global fallback**: If not found locally, checks `~/.aws/amazonq/cli-agents/` in the home directory
 
 ## Naming Conflicts

--- a/docs/default-agent-behavior.md
+++ b/docs/default-agent-behavior.md
@@ -96,7 +96,7 @@ q chat --agent specialized-agent
 
 ### Create a Custom Default
 You can create your own "default" agent by placing an agent file with the name `q_cli_default` in either:
-- `.aws/amazonq/cli-agents/` (local)
+- `.amazonq/cli-agents/` (local)
 - `~/.aws/amazonq/cli-agents/` (global)
 
 This will override the built-in default agent configuration.


### PR DESCRIPTION
## Summary
Fixed incorrect local agent directory paths in documentation to match the actual implementation.

*Issue #, if available:*

*Description of changes:*

## Changes
- Fixed local agent path from `.aws/amazonq/cli-agents/` to `.amazonq/cli-agents/` in:
  - `docs/agent-file-locations.md` (line 50)
  - `docs/default-agent-behavior.md` (line 99)
- Global paths (`~/.aws/amazonq/cli-agents/`) remain unchanged as they are correct

## Verification
Confirmed correct paths by checking source code in `crates/chat-cli/src/util/directories.rs`:
- `WORKSPACE_AGENT_DIR_RELATIVE: ".amazonq/cli-agents"` (line 45)
- `GLOBAL_AGENT_DIR_RELATIVE_TO_HOME: ".aws/amazonq/cli-agents"` (line 46)

## Type of Change
- [x] Documentation fix
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing
- [x] Documentation changes reviewed
- [x] Paths verified against source code

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
