### PR TITLE
Make /quit command alias /exit visible

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/mod.rs
+++ b/crates/chat-cli/src/cli/chat/cli/mod.rs
@@ -32,6 +32,7 @@ use prompts::PromptsArgs;
 use tangent::TangentArgs;
 use todos::TodoSubcommand;
 use tools::ToolsArgs;
+use color_print::cstr;
 
 use crate::cli::chat::cli::subscribe::SubscribeArgs;
 use crate::cli::chat::cli::usage::UsageArgs;
@@ -49,8 +50,8 @@ use crate::os::Os;
 #[derive(Debug, PartialEq, Parser)]
 #[command(color = clap::ColorChoice::Always, term_width = 0, after_long_help = EXTRA_HELP)]
 pub enum SlashCommand {
-    /// Quit the application
-    #[command(aliases = ["q", "exit"])]
+    /// Quit the application (alias /exit)
+    #[command(visible_aliases = ["q", "exit"], override_usage = cstr!("<bold>/quit</bold> or <bold>/exit</bold>"))]
     Quit,
     /// Clear the conversation history
     Clear(ClearArgs),

--- a/crates/chat-cli/src/cli/chat/prompt.rs
+++ b/crates/chat-cli/src/cli/chat/prompt.rs
@@ -51,6 +51,7 @@ pub const COMMANDS: &[&str] = &[
     "/editor",
     "/issue",
     "/quit",
+    "/exit",
     "/tools",
     "/tools trust",
     "/tools untrust",
@@ -495,21 +496,23 @@ mod tests {
         let (prompt_request_sender, _) = tokio::sync::broadcast::channel::<PromptQuery>(5);
         let (_, prompt_response_receiver) = tokio::sync::broadcast::channel::<PromptQueryResult>(5);
         let completer = ChatCompleter::new(prompt_request_sender, prompt_response_receiver);
-        let line = "/h";
-        let pos = 2; // Position at the end of "/h"
 
-        // Create a mock context with empty history
-        let empty_history = DefaultHistory::new();
-        let os = Context::new(&empty_history);
+        let test_cases = [
+            ("/h", "/help"),
+            ("/q", "/quit"),
+            ("/e", "/exit"),
+        ];
 
-        // Get completions
-        let (start, completions) = completer.complete(line, pos, &os).unwrap();
+        for (input, expected) in test_cases {
+            let pos = input.len();
+            let empty_history = DefaultHistory::new();
+            let os = Context::new(&empty_history);
 
-        // Verify start position
-        assert_eq!(start, 0);
+            let (start, completions) = completer.complete(input, pos, &os).unwrap();
 
-        // Verify completions contain expected commands
-        assert!(completions.contains(&"/help".to_string()));
+            assert_eq!(start, 0);
+            assert!(completions.contains(&expected.to_string()));
+        }
     }
 
     #[test]


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

When using Amazon Q I've found myself trying to exit the chat via the command `/exit` and then seeing no autocompletion so I search for help and see that the command is actually `/quit`. 

I wanted to add new functionality to create `/exit` as an alias for `/quit` but it turns out the alias already existed but was not visible to the user. I've made it visible both in the help and autocompletion so it's easily discoverable by users. 

NOTE: I didn't add any changes for the other alias `q` as autocompletion of the letter `q` will automatically show `quit` it didn't need necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
