### PR TITLE
chore: Skip sending profileArn when using custom endpoints

### DIFF
--- a/crates/chat-cli/src/api_client/mod.rs
+++ b/crates/chat-cli/src/api_client/mod.rs
@@ -609,7 +609,7 @@ impl ApiClient {
 
     // Add a helper method to check if using non-default endpoint
     fn is_custom_endpoint(database: &Database) -> bool {
-        database.settings.get(Setting::ApiCodeWhispererService).is_ok()
+        database.settings.get(Setting::ApiCodeWhispererService).is_some()
     }
 }
 

--- a/crates/chat-cli/src/api_client/mod.rs
+++ b/crates/chat-cli/src/api_client/mod.rs
@@ -94,7 +94,6 @@ pub struct ApiClient {
     streaming_client: Option<CodewhispererStreamingClient>,
     sigv4_streaming_client: Option<QDeveloperStreamingClient>,
     mock_client: Option<Arc<Mutex<std::vec::IntoIter<Vec<ChatResponseStream>>>>>,
-    #[allow(dead_code)]
     profile: Option<AuthProfile>,
     model_cache: ModelCache,
 }

--- a/crates/chat-cli/src/api_client/mod.rs
+++ b/crates/chat-cli/src/api_client/mod.rs
@@ -94,6 +94,7 @@ pub struct ApiClient {
     streaming_client: Option<CodewhispererStreamingClient>,
     sigv4_streaming_client: Option<QDeveloperStreamingClient>,
     mock_client: Option<Arc<Mutex<std::vec::IntoIter<Vec<ChatResponseStream>>>>>,
+    #[allow(dead_code)]
     profile: Option<AuthProfile>,
     model_cache: ModelCache,
 }
@@ -277,11 +278,8 @@ impl ApiClient {
 
         let mut models = Vec::new();
         let mut default_model = None;
-        let request = self
-            .client
-            .list_available_models()
-            .set_origin(Some(Cli));
-            // .set_profile_arn(self.profile.as_ref().map(|p| p.arn.clone()));
+        let request = self.client.list_available_models().set_origin(Some(Cli));
+        // .set_profile_arn(self.profile.as_ref().map(|p| p.arn.clone()));
         let mut paginator = request.into_paginator().send();
 
         while let Some(result) = paginator.next().await {
@@ -338,10 +336,8 @@ impl ApiClient {
     }
 
     pub async fn is_mcp_enabled(&self) -> Result<bool, ApiClientError> {
-        let request = self
-            .client
-            .get_profile();
-            // .set_profile_arn(self.profile.as_ref().map(|p| p.arn.clone()));
+        let request = self.client.get_profile();
+        // .set_profile_arn(self.profile.as_ref().map(|p| p.arn.clone()));
 
         let response = request.send().await?;
         let mcp_enabled = response

--- a/crates/chat-cli/src/api_client/mod.rs
+++ b/crates/chat-cli/src/api_client/mod.rs
@@ -230,7 +230,7 @@ impl ApiClient {
                 true => OptOutPreference::OptIn,
                 false => OptOutPreference::OptOut,
             })
-            .set_profile_arn(self.profile.as_ref().map(|p| p.arn.clone()))
+            // .set_profile_arn(self.profile.as_ref().map(|p| p.arn.clone()))
             .set_model_id(model)
             .send()
             .await?;
@@ -280,8 +280,8 @@ impl ApiClient {
         let request = self
             .client
             .list_available_models()
-            .set_origin(Some(Cli))
-            .set_profile_arn(self.profile.as_ref().map(|p| p.arn.clone()));
+            .set_origin(Some(Cli));
+            // .set_profile_arn(self.profile.as_ref().map(|p| p.arn.clone()));
         let mut paginator = request.into_paginator().send();
 
         while let Some(result) = paginator.next().await {
@@ -340,8 +340,8 @@ impl ApiClient {
     pub async fn is_mcp_enabled(&self) -> Result<bool, ApiClientError> {
         let request = self
             .client
-            .get_profile()
-            .set_profile_arn(self.profile.as_ref().map(|p| p.arn.clone()));
+            .get_profile();
+            // .set_profile_arn(self.profile.as_ref().map(|p| p.arn.clone()));
 
         let response = request.send().await?;
         let mcp_enabled = response
@@ -399,7 +399,7 @@ impl ApiClient {
             match client
                 .generate_assistant_response()
                 .conversation_state(conversation_state)
-                .set_profile_arn(self.profile.as_ref().map(|p| p.arn.clone()))
+                // .set_profile_arn(self.profile.as_ref().map(|p| p.arn.clone()))
                 .send()
                 .await
             {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change ensures we no longer send a `profileArn` when the CLI is pointed at a non-prod endpoint (e.g., alpha/gamma). Sending prod `profileArn` to preprod causes validation errors, so we now only attach it when the endpoint is the default prod one. It will default to IAD region if no profile is sending

This is mainly to unblock team testing on non-prod environments and make it easier for everyone to validate flows without hitting profile-related errors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
