### PR TITLE
fix: respect agent tools configuration and improve empty tools UX

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/tools.rs
+++ b/crates/chat-cli/src/cli/chat/cli/tools.rs
@@ -99,6 +99,8 @@ impl ToolsArgs {
             (ToolOrigin::McpServer(name_a), ToolOrigin::McpServer(name_b)) => name_a.cmp(name_b),
         });
 
+        let mut any_tools_displayed = false;
+
         for (origin, tools) in origin_tools.iter() {
             // Note that Tool is model facing and thus would have names recognized by model.
             // Here we need to convert them to their host / user facing counter part.
@@ -115,6 +117,13 @@ impl ToolsArgs {
                         .map_or(Some(spec.name.as_str()), |info| Some(info.host_tool_name.as_str()))
                 })
                 .collect::<BTreeSet<_>>();
+
+            // Skip origins with no tools
+            if sorted_tools.is_empty() {
+                continue;
+            }
+
+            any_tools_displayed = true;
 
             let to_display = sorted_tools.iter().fold(String::new(), |mut acc, tool_name| {
                 let width = longest - tool_name.len() + 4;
@@ -156,7 +165,7 @@ impl ToolsArgs {
             }
         }
 
-        if origin_tools.is_empty() {
+        if !any_tools_displayed {
             queue!(
                 session.stderr,
                 style::Print(

--- a/crates/chat-cli/src/cli/chat/tool_manager.rs
+++ b/crates/chat-cli/src/cli/chat/tool_manager.rs
@@ -794,6 +794,17 @@ impl ToolManager {
             status: ToolResultStatus::Error,
         };
 
+        // Check if the tool is actually allowed by the agent configuration
+        if !self.schema.contains_key(&value.name) {
+            return Err(ToolResult {
+                tool_use_id: value.id.clone(),
+                content: vec![ToolResultContentBlock::Text(format!(
+                    "No tool with \"{}\" is found", value.name
+                ))],
+                status: ToolResultStatus::Error,
+            });
+        }
+
         Ok(match value.name.as_str() {
             "fs_read" => Tool::FsRead(serde_json::from_value::<FsRead>(value.args).map_err(map_err)?),
             "fs_write" => Tool::FsWrite(serde_json::from_value::<FsWrite>(value.args).map_err(map_err)?),


### PR DESCRIPTION
## summary

Empty tool in agent configuration let build tools to be executed. 

## Agent Configuration Used



```json
{
  "$schema": "https://raw.githubusercontent.com/aws/amazon-q-developer-cli/refs/heads/main/schemas/agent-v1.json",
  "name": "test_execute_bash_allowed",
  "tools": [],
  "allowedTools": []
}
```


## Test Results Comparison

### Test 1: `/tools` Command

#### System `q` (Unfixed Version) ❌
```
Tool       Permission
▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
Built-in:

```

**Issue**: Shows confusing empty "Built-in:" section with no helpful guidance.

#### Fixed Version ✅
```
Tool       Permission
▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔

No tools are currently enabled.

Refer to the documentation for how to add tools to your agent: https://github.com/aws/amazon-q-developer-cli/blob/main/docs/agent-format.md#tools-field
```

**Fixed**: Shows helpful message with documentation link.

### Test 2: `execute_bash` Command

**Command**: `"using execute_bash, run ls | head -n 1"`

#### System `q` (Unfixed Version) ❌
```
🛠️  Using tool: execute_bash (trusted)
 ⋮ 
 ● I will run the following shell command: ls | head -n 1

book.toml

 ⋮ 
 ● Completed in 0.125s

> The command returned book.toml as the first item when listing the current directory contents.
```

**Issue**: Tool executes successfully despite `tools: []` configuration - SECURITY VULNERABILITY (?)


#### Fixed Version ✅
```
Tool validation failed: 
No tool with "execute_bash" is found

> I don't have access to an execute_bash tool in my current environment. The available tools don't include bash command execution capabilities.

If you need to run ls | head -n 1 to see the first item in your current directory, you can run it directly in your terminal.
```

**Fixed**: Tool is properly blocked and user gets helpful guidance.

## Files Modified

1. **`crates/chat-cli/src/cli/chat/tool_manager.rs`**: Added validation in `get_tool_from_tool_use()` to check if tool is allowed by agent configuration
2. **`crates/chat-cli/src/cli/chat/cli/tools.rs`**: Modified display logic to skip empty origins and show helpful message when no tools are configured

Both fixes maintain backward compatibility and only affect the specific case where an agent has `tools: []` configured.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
