### PR TITLE
feat: Add persistent chat history with directory isolation

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/clear.rs
+++ b/crates/chat-cli/src/cli/chat/cli/clear.rs
@@ -14,13 +14,14 @@ use crate::cli::chat::{
     ChatSession,
     ChatState,
 };
+use crate::os::Os;
 
 #[deny(missing_docs)]
 #[derive(Debug, PartialEq, Args)]
 pub struct ClearArgs;
 
 impl ClearArgs {
-    pub async fn execute(self, session: &mut ChatSession) -> Result<ChatState, ChatError> {
+    pub async fn execute(self, os: &Os, session: &mut ChatSession) -> Result<ChatState, ChatError> {
         execute!(
             session.stderr,
             style::SetForegroundColor(Color::DarkGrey),
@@ -41,7 +42,7 @@ impl ClearArgs {
         )?;
 
         // Setting `exit_on_single_ctrl_c` for better ux: exit the confirmation dialog rather than the CLI
-        let user_input = match session.read_user_input("> ".yellow().to_string().as_str(), true) {
+        let user_input = match session.read_user_input(os, "> ".yellow().to_string().as_str(), true) {
             Some(input) => input,
             None => "".to_string(),
         };

--- a/crates/chat-cli/src/cli/chat/cli/mod.rs
+++ b/crates/chat-cli/src/cli/chat/cli/mod.rs
@@ -95,7 +95,7 @@ impl SlashCommand {
     pub async fn execute(self, os: &mut Os, session: &mut ChatSession) -> Result<ChatState, ChatError> {
         match self {
             Self::Quit => Ok(ChatState::Exit),
-            Self::Clear(args) => args.execute(session).await,
+            Self::Clear(args) => args.execute(os, session).await,
             Self::Agent(subcommand) => subcommand.execute(os, session).await,
             Self::Profile => {
                 use crossterm::{

--- a/crates/chat-cli/src/cli/chat/cli/subscribe.rs
+++ b/crates/chat-cli/src/cli/chat/cli/subscribe.rs
@@ -148,7 +148,7 @@ async fn upgrade_to_pro(os: &mut Os, session: &mut ChatSession) -> Result<(), Ch
         "]: ".dark_grey(),
     );
 
-    let user_input = session.read_user_input(&prompt, true);
+    let user_input = session.read_user_input(os, &prompt, true);
     queue!(
         session.stderr,
         style::SetForegroundColor(Color::Reset),

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -1604,7 +1604,7 @@ impl ChatSession {
             style::SetAttribute(Attribute::Reset)
         )?;
         let prompt = self.generate_tool_trust_prompt();
-        let user_input = match self.read_user_input(&prompt, false) {
+        let user_input = match self.read_user_input(os, &prompt, false) {
             Some(input) => input,
             None => return Ok(ChatState::Exit),
         };
@@ -2609,10 +2609,10 @@ impl ChatSession {
     }
 
     /// Helper function to read user input with a prompt and Ctrl+C handling
-    fn read_user_input(&mut self, prompt: &str, exit_on_single_ctrl_c: bool) -> Option<String> {
+    fn read_user_input(&mut self, os: &Os, prompt: &str, exit_on_single_ctrl_c: bool) -> Option<String> {
         let mut ctrl_c = false;
         loop {
-            match (self.input_source.read_line(Some(prompt)), ctrl_c) {
+            match (self.input_source.read_line(Some(prompt), os), ctrl_c) {
                 (Ok(Some(line)), _) => {
                     if line.trim().is_empty() {
                         continue; // Reprompt if the input is empty

--- a/crates/chat-cli/src/database/sqlite_migrations/008_chat_readline_history_table.sql
+++ b/crates/chat-cli/src/database/sqlite_migrations/008_chat_readline_history_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE chat_readline_history (
+    id INTEGER PRIMARY KEY,
+    input TEXT NOT NULL,
+    cwd TEXT NOT NULL,
+    timestamp INTEGER NOT NULL DEFAULT (unixepoch('now', 'subsec') * 1000)
+);
+
+CREATE INDEX idx_chat_readline_history_cwd_timestamp ON chat_readline_history(cwd, timestamp);


### PR DESCRIPTION
*Issue #, if available:*
#2633 

Same as #2635, just a different branch from head repository.

*Description of changes:*

Implements persistent chat history that survives CLI restarts and is isolated by working directory.

Features:
- Chat history persists across CLI sessions using SQLite database
- History is isolated per working directory (/project/a vs /project/b)
- Up arrow navigation works with persistent history
- Dual cleanup limits: max 100 entries per directory, 1000 total
- Silent failure: history issues don't break CLI functionality
- Filters out empty/whitespace-only and confirmation inputs

Implementation:
- Database table: chat_readline_history(input TEXT, cwd TEXT, timestamp INTEGER) with index on cwd and timestamp
- Uses existing database infrastructure and Os abstraction
- Transactional insert+cleanup for data consistency
- Early return for empty inputs to avoid unnecessary DB operations

Files modified:
- crates/chat-cli/src/database/mod.rs: Added add_chat_readline_history_entry() and get_chat_readline_history()
- crates/chat-cli/src/cli/chat/input_source.rs: Load history on startup, save on input

Edge cases handled:
- Database failures (silent)
- Empty/whitespace and confirmation inputs (filtered)
- Working directory access failures (fallback to default)
- Unicode/special characters (parameterized queries)

Interaction with other features:
- Does not conflict with `--resume`. It enhances it.
- Does not conflict with `/load`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
