### PR TITLE
feat: add AGENTS.md to default agent resources

### DIFF
--- a/crates/chat-cli/src/cli/agent/mod.rs
+++ b/crates/chat-cli/src/cli/agent/mod.rs
@@ -181,7 +181,7 @@ impl Default for Agent {
                 set.extend(default_approve);
                 set
             },
-            resources: vec!["file://AmazonQ.md", "file://README.md", "file://.amazonq/rules/**/*.md"]
+            resources: vec!["file://AmazonQ.md", "file://AGENTS.md", "file://README.md", "file://.amazonq/rules/**/*.md"]
                 .into_iter()
                 .map(Into::into)
                 .collect::<Vec<_>>(),

--- a/crates/chat-cli/src/cli/chat/conversation.rs
+++ b/crates/chat-cli/src/cli/chat/conversation.rs
@@ -1195,6 +1195,7 @@ mod tests {
     use crate::cli::chat::tool_manager::ToolManager;
 
     const AMAZONQ_FILENAME: &str = "AmazonQ.md";
+    const AGENTS_FILENAME: &str = "AGENTS.md";
 
     fn assert_conversation_state_invariants(state: FigConversationState, assertion_iteration: usize) {
         if let Some(Some(msg)) = state.history.as_ref().map(|h| h.first()) {
@@ -1407,11 +1408,13 @@ mod tests {
             let mut agents = Agents::default();
             let mut agent = Agent::default();
             agent.resources.push(AMAZONQ_FILENAME.into());
+            agent.resources.push(AGENTS_FILENAME.into());
             agents.agents.insert("TestAgent".to_string(), agent);
             agents.switch("TestAgent").expect("Agent switch failed");
             agents
         };
         os.fs.write(AMAZONQ_FILENAME, "test context").await.unwrap();
+        os.fs.write(AGENTS_FILENAME, "test agents context").await.unwrap();
         let mut output = vec![];
 
         let mut tool_manager = ToolManager::default();


### PR DESCRIPTION
- Add file://AGENTS.md to default resources list alongside AmazonQ.md
- Update test to include both AmazonQ.md and AGENTS.md files
- Ensures AGENTS.md is included everywhere AmazonQ.md was previously included

*Description of changes:*

Enabling support for AGENTS.md in Q CLI.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
