### PR TITLE
Properly handle path with trailing slash in file matching

### DIFF
--- a/crates/chat-cli/src/util/directories.rs
+++ b/crates/chat-cli/src/util/directories.rs
@@ -288,30 +288,30 @@ mod linux_tests {
         let direct_file = "/home/user/a.txt";
         let nested_file = "/home/user/folder/a.txt";
         let other_file = "/home/admin/a.txt";
-        
+
         // Case 1: Path with trailing slash
         let mut builder1 = GlobSetBuilder::new();
         add_gitignore_globs(&mut builder1, "/home/user/").unwrap();
         let globset1 = builder1.build().unwrap();
-        
+
         assert!(globset1.is_match(direct_file));
         assert!(globset1.is_match(nested_file));
         assert!(!globset1.is_match(other_file));
-        
+
         // Case 2: Path without trailing slash - should behave same as case 1
         let mut builder2 = GlobSetBuilder::new();
         add_gitignore_globs(&mut builder2, "/home/user").unwrap();
         let globset2 = builder2.build().unwrap();
-        
+
         assert!(globset2.is_match(direct_file));
         assert!(globset2.is_match(nested_file));
         assert!(!globset1.is_match(other_file));
-        
+
         // Case 3: File path - should only match exact file
         let mut builder3 = GlobSetBuilder::new();
         add_gitignore_globs(&mut builder3, "/home/user/a.txt").unwrap();
         let globset3 = builder3.build().unwrap();
-        
+
         assert!(globset3.is_match(direct_file));
         assert!(!globset3.is_match(nested_file));
         assert!(!globset1.is_match(other_file));

--- a/crates/chat-cli/src/util/directories.rs
+++ b/crates/chat-cli/src/util/directories.rs
@@ -193,7 +193,11 @@ pub fn canonicalizes_path(os: &Os, path_as_str: &str) -> Result<String> {
 /// patterns to exist in a globset.
 pub fn add_gitignore_globs(builder: &mut GlobSetBuilder, path: &str) -> Result<()> {
     let glob_for_file = Glob::new(path)?;
-    let glob_for_dir = Glob::new(&format!("{path}/**"))?;
+
+    // remove existing slash in path so we don't end up with double slash
+    // Glob doesn't normalize the path so it doesn't work with double slash
+    let dir_pattern: String = format!("{}/**", path.trim_end_matches('/'));
+    let glob_for_dir = Glob::new(&dir_pattern)?;
 
     builder.add(glob_for_file);
     builder.add(glob_for_dir);
@@ -277,6 +281,40 @@ mod linux_tests {
     fn all_paths() {
         assert!(logs_dir().is_ok());
         assert!(settings_path().is_ok());
+    }
+
+    #[test]
+    fn test_add_gitignore_globs() {
+        let direct_file = "/home/user/a.txt";
+        let nested_file = "/home/user/folder/a.txt";
+        let other_file = "/home/admin/a.txt";
+        
+        // Case 1: Path with trailing slash
+        let mut builder1 = GlobSetBuilder::new();
+        add_gitignore_globs(&mut builder1, "/home/user/").unwrap();
+        let globset1 = builder1.build().unwrap();
+        
+        assert!(globset1.is_match(direct_file));
+        assert!(globset1.is_match(nested_file));
+        assert!(!globset1.is_match(other_file));
+        
+        // Case 2: Path without trailing slash - should behave same as case 1
+        let mut builder2 = GlobSetBuilder::new();
+        add_gitignore_globs(&mut builder2, "/home/user").unwrap();
+        let globset2 = builder2.build().unwrap();
+        
+        assert!(globset2.is_match(direct_file));
+        assert!(globset2.is_match(nested_file));
+        assert!(!globset1.is_match(other_file));
+        
+        // Case 3: File path - should only match exact file
+        let mut builder3 = GlobSetBuilder::new();
+        add_gitignore_globs(&mut builder3, "/home/user/a.txt").unwrap();
+        let globset3 = builder3.build().unwrap();
+        
+        assert!(globset3.is_match(direct_file));
+        assert!(!globset3.is_match(nested_file));
+        assert!(!globset1.is_match(other_file));
     }
 }
 


### PR DESCRIPTION
Today if a path has a trailing slash, the glob pattern will look like "/path-to-folder//**" (note the double slash). Glob doesn't work with double slash actually (it doesn't match anything). As a result, the permission management for fs_read and fs_write is broken when allowed or denied path has trailing slash.

The fix is to just manually remove the trailing slash.

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


## Testing
Unit test

Integration test:
1. Create an agent like this
```
{
  "$schema": "https://raw.githubusercontent.com/aws/amazon-q-developer-cli/refs/heads/main/schemas/agent-v1.json",
  "name": "test-write",
  "description": "test write permission",
  "prompt": "You are a test agent designed to test write permissions. Focus on file operations and system interactions that require write access.",
  "mcpServers": {},
  "tools": [
    "*"
  ],
  "toolAliases": {},
  "allowedTools": [
    "fs_read"
  ],
  "resources": [
    "file://AmazonQ.md",
    "file://README.md",
    "file://.amazonq/rules/**/*.md"
  ],
  "hooks": {},
  "toolsSettings": {
    "fs_write": {
      "deniedPaths": ["/Users/moerben/Documents/Work/2025/Project/Test-dir/"]
    }
  },
  "useLegacyMcpJson": false
}

```

2. Launch Q, try to write to /Users/moerben/Documents/Work/2025/Project/Test-dir/a.txt
3. Without this change
```
~/Documents/Work/2025/Project/amazon-q-developer-cli $ q chat --agent test-write
[test-write] > write "hello world" to /Users/moerben/Documents/Work/2025/Project/Test-dir/a.txt

> I'll write "hello world" to the specified file path.


🛠️  Using tool: fs_write
 ⋮ 
 ● Path: /Users/moerben/Documents/Work/2025/Project/Test-dir/a.txt

+    1: hello world

 ⋮ 
 ↳ Purpose: Write "hello world" to a.txt

Allow this action? Use 't' to trust (always allow) this tool for the session. [y/n/t]:
```

With this change:
```
~/Documents/Work/2025/Project/amazon-q-developer-cli $ Q_DEBUG_REQUESTS=1 ./target/debug/chat_cli chat --agent test-write
[test-write] > write "hello world" to /Users/moerben/Documents/Work/2025/Project/Test-dir/a.txt

> I'll write "hello world" to the specified file path.


Command fs_write is rejected because it matches one or more rules on the denied list:
  - /Users/moerben/Documents/Work/2025/Project/Test-dir/
```