### PR TITLE
fix: normalize relative paths in agent toolsSettings

### DIFF
--- a/crates/chat-cli/src/util/directories.rs
+++ b/crates/chat-cli/src/util/directories.rs
@@ -186,7 +186,7 @@ pub fn canonicalizes_path(os: &Os, path_as_str: &str) -> Result<String> {
     let home_dir = || os.env.home().map(|p| p.to_string_lossy().to_string());
 
     let expanded = shellexpand::full_with_context(path_as_str, home_dir, context)?;
-    
+
     // Convert all relative paths to absolute paths (including glob patterns)
     if !expanded.starts_with("/") && !expanded.starts_with("~") {
         let current_dir = os.env.current_dir()?;
@@ -198,7 +198,7 @@ pub fn canonicalizes_path(os: &Os, path_as_str: &str) -> Result<String> {
                 // If canonicalize fails (e.g., path doesn't exist), do manual normalization
                 let normalized = normalize_path(&absolute_path);
                 Ok(normalized.to_string_lossy().to_string())
-            }
+            },
         }
     } else {
         Ok(expanded.to_string())
@@ -212,14 +212,14 @@ fn normalize_path(path: &std::path::Path) -> std::path::PathBuf {
         match component {
             std::path::Component::CurDir => {
                 // Skip current directory components
-            }
+            },
             std::path::Component::ParentDir => {
                 // Pop the last component for parent directory
                 components.pop();
-            }
+            },
             _ => {
                 components.push(component);
-            }
+            },
         }
     }
     components.iter().collect()
@@ -440,7 +440,7 @@ mod tests {
 
         // Test environment variable expansion
         let result = canonicalizes_path(&test_os, "$TEST_VAR/path").unwrap();
-        assert_eq!(result, "test_value/path");
+        assert_eq!(result, "/test_value/path");
 
         // Test combined expansion
         let result = canonicalizes_path(&test_os, "~/$TEST_VAR").unwrap();
@@ -450,14 +450,15 @@ mod tests {
         let result = canonicalizes_path(&test_os, "/absolute/path").unwrap();
         assert_eq!(result, "/absolute/path");
 
-        // Test relative path (no expansion needed)
+        // Test relative path (which should be expanded because now all inputs are converted to
+        // absolute)
         let result = canonicalizes_path(&test_os, "relative/path").unwrap();
-        assert_eq!(result, "relative/path");
+        assert_eq!(result, "/relative/path");
 
         // Test glob prefixed paths
         let result = canonicalizes_path(&test_os, "**/path").unwrap();
-        assert_eq!(result, "**/path");
+        assert_eq!(result, "/**/path");
         let result = canonicalizes_path(&test_os, "**/middle/**/path").unwrap();
-        assert_eq!(result, "**/middle/**/path");
+        assert_eq!(result, "/**/middle/**/path");
     }
 }


### PR DESCRIPTION
Fixes an issue where relative path patterns in agent toolsSettings (e.g., './denied/**') would not match files accessed with different relative path formats (e.g., 'denied/file.txt').

Changes:
- Enhanced canonicalizes_path() to properly normalize relative paths
- Added path component resolution for '.' and '..' segments
- Ensures consistent path matching for both fs_read and fs_write tools

This resolves a security issue where deniedPaths could be bypassed by using different relative path formats.

*Issue #2818

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
