### PR TITLE
Change autocomplete shortcut from ctrl-f to ctrl-g

### DIFF
--- a/crates/chat-cli/src/cli/chat/prompt.rs
+++ b/crates/chat-cli/src/cli/chat/prompt.rs
@@ -479,9 +479,13 @@ pub fn rl(
         EventHandler::Simple(Cmd::Insert(1, "\n".to_string())),
     );
 
-    // Add custom keybinding for Ctrl+g to accept hint (like fish shell)
+    // Add custom keybinding for autocompletion hint acceptance (configurable)
+    let autocompletion_key_char = match os.database.settings.get_string(Setting::AutocompletionKey) {
+        Some(key) if key.len() == 1 => key.chars().next().unwrap_or('g'),
+        _ => 'g', // Default to 'g' if setting is missing or invalid
+    };
     rl.bind_sequence(
-        KeyEvent(KeyCode::Char('g'), Modifiers::CTRL),
+        KeyEvent(KeyCode::Char(autocompletion_key_char), Modifiers::CTRL),
         EventHandler::Simple(Cmd::CompleteHint),
     );
 

--- a/crates/chat-cli/src/cli/chat/prompt.rs
+++ b/crates/chat-cli/src/cli/chat/prompt.rs
@@ -473,19 +473,19 @@ pub fn rl(
         EventHandler::Simple(Cmd::Insert(1, "\n".to_string())),
     );
 
-    // Add custom keybinding for Ctrl+J to insert a newline
+    // Add custom keybinding for Ctrl+j to insert a newline
     rl.bind_sequence(
         KeyEvent(KeyCode::Char('j'), Modifiers::CTRL),
         EventHandler::Simple(Cmd::Insert(1, "\n".to_string())),
     );
 
-    // Add custom keybinding for Ctrl+F to accept hint (like fish shell)
+    // Add custom keybinding for Ctrl+g to accept hint (like fish shell)
     rl.bind_sequence(
-        KeyEvent(KeyCode::Char('f'), Modifiers::CTRL),
+        KeyEvent(KeyCode::Char('g'), Modifiers::CTRL),
         EventHandler::Simple(Cmd::CompleteHint),
     );
 
-    // Add custom keybinding for Ctrl+T to toggle tangent mode (configurable)
+    // Add custom keybinding for Ctrl+t to toggle tangent mode (configurable)
     let tangent_key_char = match os.database.settings.get_string(Setting::TangentModeKey) {
         Some(key) if key.len() == 1 => key.chars().next().unwrap_or('t'),
         _ => 't', // Default to 't' if setting is missing or invalid
@@ -720,5 +720,36 @@ mod tests {
 
         let hint = hinter.hint(line, pos, &ctx);
         assert_eq!(hint, None);
+    }
+
+    #[tokio::test]
+    // If you get a unit test failure for key override, please consider using a new key binding instead.
+    // The list of reserved keybindings here are the standard in UNIX world so please don't take them
+    async fn test_no_emacs_keybindings_overridden() {
+        let (sender, _) = tokio::sync::broadcast::channel::<PromptQuery>(1);
+        let (_, receiver) = tokio::sync::broadcast::channel::<PromptQueryResult>(1);
+
+        // Create a mock Os for testing
+        let mock_os = crate::os::Os::new().await.unwrap();
+        let mut test_editor = rl(&mock_os, sender, receiver).unwrap();
+
+        // Reserved Emacs keybindings that should not be overridden
+        let reserved_keys = ['a', 'e', 'f', 'b', 'k'];
+
+        for &key in &reserved_keys {
+            let key_event = KeyEvent(KeyCode::Char(key), Modifiers::CTRL);
+
+            // Try to bind and get the previous handler
+            let previous_handler = test_editor.bind_sequence(
+                key_event,
+                EventHandler::Simple(Cmd::Noop)
+            );
+
+            // If there was a previous handler, it means the key was already bound
+            // (which could be our custom binding overriding Emacs)
+            if previous_handler.is_some() {
+                panic!("Ctrl+{} appears to be overridden (found existing binding)", key);
+            }
+        }
     }
 }

--- a/crates/chat-cli/src/database/settings.rs
+++ b/crates/chat-cli/src/database/settings.rs
@@ -41,6 +41,8 @@ pub enum Setting {
     KnowledgeIndexType,
     #[strum(message = "Key binding for fuzzy search command (single character)")]
     SkimCommandKey,
+    #[strum(message = "Key binding for autocompletion hint acceptance (single character)")]
+    AutocompletionKey,
     #[strum(message = "Enable tangent mode feature (boolean)")]
     EnabledTangentMode,
     #[strum(message = "Key binding for tangent mode toggle (single character)")]
@@ -94,6 +96,7 @@ impl AsRef<str> for Setting {
             Self::KnowledgeChunkOverlap => "knowledge.chunkOverlap",
             Self::KnowledgeIndexType => "knowledge.indexType",
             Self::SkimCommandKey => "chat.skimCommandKey",
+            Self::AutocompletionKey => "chat.autocompletionKey",
             Self::EnabledTangentMode => "chat.enableTangentMode",
             Self::TangentModeKey => "chat.tangentModeKey",
             Self::IntrospectTangentMode => "introspect.tangentMode",
@@ -139,6 +142,7 @@ impl TryFrom<&str> for Setting {
             "knowledge.chunkOverlap" => Ok(Self::KnowledgeChunkOverlap),
             "knowledge.indexType" => Ok(Self::KnowledgeIndexType),
             "chat.skimCommandKey" => Ok(Self::SkimCommandKey),
+            "chat.autocompletionKey" => Ok(Self::AutocompletionKey),
             "chat.enableTangentMode" => Ok(Self::EnabledTangentMode),
             "chat.tangentModeKey" => Ok(Self::TangentModeKey),
             "introspect.tangentMode" => Ok(Self::IntrospectTangentMode),


### PR DESCRIPTION
*Description of changes:*

The reason is ctrl-f is the standard shortcut in UNIX for moving cursor forward by 1 character. You can find it being supported everywhere... in your browser, your terminal, etc.

## Test

Manually tested ctrl-g and ctrl-f in the CLI


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Also tested overriding the shortcut through config:
```
~/Documents/Work/2025/Project/amazon-q-developer-cli/crates/chat-cli $ cargo run --bin chat_cli -- settings chat.autocompletionKey o
   Compiling chat_cli v1.15.0 (/Users/moerben/Documents/Work/2025/Project/amazon-q-developer-cli/crates/chat-cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 11.86s
     Running `/Users/moerben/Documents/Work/2025/Project/amazon-q-developer-cli/target/debug/chat_cli settings chat.autocompletionKey o`
```

verified ctrl-o works in the above example ^^
