### PR TITLE
feat(use_aws): add configurable autoAllowReadonly setting

### DIFF
--- a/docs/built-in-tools.md
+++ b/docs/built-in-tools.md
@@ -139,7 +139,8 @@ Make AWS CLI API calls with the specified service, operation, and parameters.
   "toolsSettings": {
     "use_aws": {
       "allowedServices": ["s3", "lambda", "ec2"],
-      "deniedServices": ["eks", "rds"]
+      "deniedServices": ["eks", "rds"],
+      "autoAllowReadonly": true
     }
   }
 }
@@ -151,6 +152,7 @@ Make AWS CLI API calls with the specified service, operation, and parameters.
 |--------|------|---------|-------------|
 | `allowedServices` | array of strings | `[]` | List of AWS services that can be accessed without prompting |
 | `deniedServices` | array of strings | `[]` | List of AWS services to deny. Deny rules are evaluated before allow rules |
+| `autoAllowReadonly` | boolean | `false` | Whether to automatically allow read-only operations (get, describe, list, ls, search, batch_get) without prompting |
 
 ## Using Tool Settings in Agent Configuration
 


### PR DESCRIPTION
- Add auto_allow_readonly field to use_aws Settings struct (defaults to false)
- Update eval_perm method to use auto_allow_readonly setting instead of hardcoded behavior
- Default behavior: all AWS operations require user confirmation (secure by default)
- Opt-in behavior: when autoAllowReadonly=true, read-only operations are auto-approved
- Add comprehensive tests covering all scenarios

🤖 Assisted by Amazon Q Developer

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
