### PR TITLE
feat: Add /tangent tail to preserve the last tangent conversation

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/tangent.rs
+++ b/crates/chat-cli/src/cli/chat/cli/tangent.rs
@@ -1,4 +1,7 @@
-use clap::Args;
+use clap::{
+    Args,
+    Subcommand,
+};
 use crossterm::execute;
 use crossterm::style::{
     self,
@@ -14,9 +17,33 @@ use crate::database::settings::Setting;
 use crate::os::Os;
 
 #[derive(Debug, PartialEq, Args)]
-pub struct TangentArgs;
+pub struct TangentArgs {
+    #[command(subcommand)]
+    pub subcommand: Option<TangentSubcommand>,
+}
+
+#[derive(Debug, PartialEq, Subcommand)]
+pub enum TangentSubcommand {
+    /// Exit tangent mode and keep the last conversation entry (user question + assistant response)
+    Tail,
+}
 
 impl TangentArgs {
+    async fn send_tangent_telemetry(os: &Os, session: &ChatSession, duration_seconds: i64) {
+        if let Err(err) = os
+            .telemetry
+            .send_tangent_mode_session(
+                &os.database,
+                session.conversation.conversation_id().to_string(),
+                crate::telemetry::TelemetryResult::Succeeded,
+                crate::telemetry::core::TangentModeSessionArgs { duration_seconds },
+            )
+            .await
+        {
+            tracing::warn!(?err, "Failed to send tangent mode session telemetry");
+        }
+    }
+
     pub async fn execute(self, os: &Os, session: &mut ChatSession) -> Result<ChatState, ChatError> {
         // Check if tangent mode is enabled
         if !os
@@ -35,69 +62,86 @@ impl TangentArgs {
                 skip_printing_tools: true,
             });
         }
-        if session.conversation.is_in_tangent_mode() {
-            // Get duration before exiting tangent mode
-            let duration_seconds = session.conversation.get_tangent_duration_seconds().unwrap_or(0);
 
-            session.conversation.exit_tangent_mode();
+        match self.subcommand {
+            Some(TangentSubcommand::Tail) => {
+                if session.conversation.is_in_tangent_mode() {
+                    let duration_seconds = session.conversation.get_tangent_duration_seconds().unwrap_or(0);
+                    session.conversation.exit_tangent_mode_with_tail();
+                    Self::send_tangent_telemetry(os, session, duration_seconds).await;
 
-            // Send telemetry for tangent mode session
-            if let Err(err) = os
-                .telemetry
-                .send_tangent_mode_session(
-                    &os.database,
-                    session.conversation.conversation_id().to_string(),
-                    crate::telemetry::TelemetryResult::Succeeded,
-                    crate::telemetry::core::TangentModeSessionArgs { duration_seconds },
-                )
-                .await
-            {
-                tracing::warn!(?err, "Failed to send tangent mode session telemetry");
-            }
+                    execute!(
+                        session.stderr,
+                        style::SetForegroundColor(Color::DarkGrey),
+                        style::Print("Restored conversation from checkpoint ("),
+                        style::SetForegroundColor(Color::Yellow),
+                        style::Print("↯"),
+                        style::SetForegroundColor(Color::DarkGrey),
+                        style::Print(") with last conversation entry preserved.\n"),
+                        style::SetForegroundColor(Color::Reset)
+                    )?;
+                } else {
+                    execute!(
+                        session.stderr,
+                        style::SetForegroundColor(Color::Red),
+                        style::Print("You need to be in tangent mode to use tail.\n"),
+                        style::SetForegroundColor(Color::Reset)
+                    )?;
+                }
+            },
+            None => {
+                if session.conversation.is_in_tangent_mode() {
+                    let duration_seconds = session.conversation.get_tangent_duration_seconds().unwrap_or(0);
+                    session.conversation.exit_tangent_mode();
+                    Self::send_tangent_telemetry(os, session, duration_seconds).await;
 
-            execute!(
-                session.stderr,
-                style::SetForegroundColor(Color::DarkGrey),
-                style::Print("Restored conversation from checkpoint ("),
-                style::SetForegroundColor(Color::Yellow),
-                style::Print("↯"),
-                style::SetForegroundColor(Color::DarkGrey),
-                style::Print("). - Returned to main conversation.\n"),
-                style::SetForegroundColor(Color::Reset)
-            )?;
-        } else {
-            session.conversation.enter_tangent_mode();
+                    execute!(
+                        session.stderr,
+                        style::SetForegroundColor(Color::DarkGrey),
+                        style::Print("Restored conversation from checkpoint ("),
+                        style::SetForegroundColor(Color::Yellow),
+                        style::Print("↯"),
+                        style::SetForegroundColor(Color::DarkGrey),
+                        style::Print("). - Returned to main conversation.\n"),
+                        style::SetForegroundColor(Color::Reset)
+                    )?;
+                } else {
+                    session.conversation.enter_tangent_mode();
 
-            // Get the configured tangent mode key for display
-            let tangent_key_char = match os
-                .database
-                .settings
-                .get_string(crate::database::settings::Setting::TangentModeKey)
-            {
-                Some(key) if key.len() == 1 => key.chars().next().unwrap_or('t'),
-                _ => 't', // Default to 't' if setting is missing or invalid
-            };
-            let tangent_key_display = format!("ctrl + {}", tangent_key_char.to_lowercase());
+                    // Get the configured tangent mode key for display
+                    let tangent_key_char = match os
+                        .database
+                        .settings
+                        .get_string(crate::database::settings::Setting::TangentModeKey)
+                    {
+                        Some(key) if key.len() == 1 => key.chars().next().unwrap_or('t'),
+                        _ => 't', // Default to 't' if setting is missing or invalid
+                    };
+                    let tangent_key_display = format!("ctrl + {}", tangent_key_char.to_lowercase());
 
-            execute!(
-                session.stderr,
-                style::SetForegroundColor(Color::DarkGrey),
-                style::Print("Created a conversation checkpoint ("),
-                style::SetForegroundColor(Color::Yellow),
-                style::Print("↯"),
-                style::SetForegroundColor(Color::DarkGrey),
-                style::Print("). Use "),
-                style::SetForegroundColor(Color::Green),
-                style::Print(&tangent_key_display),
-                style::SetForegroundColor(Color::DarkGrey),
-                style::Print(" or "),
-                style::SetForegroundColor(Color::Green),
-                style::Print("/tangent"),
-                style::SetForegroundColor(Color::DarkGrey),
-                style::Print(" to restore the conversation later.\n"),
-                style::Print("Note: this functionality is experimental and may change or be removed in the future.\n"),
-                style::SetForegroundColor(Color::Reset)
-            )?;
+                    execute!(
+                        session.stderr,
+                        style::SetForegroundColor(Color::DarkGrey),
+                        style::Print("Created a conversation checkpoint ("),
+                        style::SetForegroundColor(Color::Yellow),
+                        style::Print("↯"),
+                        style::SetForegroundColor(Color::DarkGrey),
+                        style::Print("). Use "),
+                        style::SetForegroundColor(Color::Green),
+                        style::Print(&tangent_key_display),
+                        style::SetForegroundColor(Color::DarkGrey),
+                        style::Print(" or "),
+                        style::SetForegroundColor(Color::Green),
+                        style::Print("/tangent"),
+                        style::SetForegroundColor(Color::DarkGrey),
+                        style::Print(" to restore the conversation later.\n"),
+                        style::Print(
+                            "Note: this functionality is experimental and may change or be removed in the future.\n"
+                        ),
+                        style::SetForegroundColor(Color::Reset)
+                    )?;
+                }
+            },
         }
 
         Ok(ChatState::PromptUser {

--- a/docs/tangent-mode.md
+++ b/docs/tangent-mode.md
@@ -32,6 +32,13 @@ Use `/tangent` or Ctrl+T again:
 Restored conversation from checkpoint (↯). - Returned to main conversation.
 ```
 
+### Exit Tangent Mode with Tail
+Use `/tangent tail` to preserve the last conversation entry (question + answer):
+```
+↯ > /tangent tail
+Restored conversation from checkpoint (↯) with last conversation entry preserved.
+```
+
 ## Usage Examples
 
 ### Example 1: Exploring Alternatives
@@ -93,6 +100,29 @@ Restored conversation from checkpoint (↯).
 > Here's my query: SELECT * FROM orders...
 ```
 
+### Example 4: Keeping Useful Information
+```
+> Help me debug this Python error
+
+I can help you debug that. Could you share the error message?
+
+> /tangent
+Created a conversation checkpoint (↯).
+
+↯ > What are the most common Python debugging techniques?
+
+Here are the most effective Python debugging techniques:
+1. Use print statements strategically
+2. Leverage the Python debugger (pdb)...
+
+↯ > /tangent tail
+Restored conversation from checkpoint (↯) with last conversation entry preserved.
+
+> Here's my error: TypeError: unsupported operand type(s)...
+
+# The preserved entry (question + answer about debugging techniques) is now part of main conversation
+```
+
 ## Configuration
 
 ### Keyboard Shortcut
@@ -131,6 +161,7 @@ q settings introspect.tangentMode true
 2. **Return promptly** - Don't forget you're in tangent mode
 3. **Use for clarification** - Perfect for "wait, what does X mean?" questions
 4. **Experiment safely** - Test ideas without affecting main conversation
+5. **Use `/tangent tail`** - When both the tangent question and answer are useful for main conversation
 
 ## Limitations
 


### PR DESCRIPTION

<img width="1724" height="811" alt="image" src="https://github.com/user-attachments/assets/157bb080-2cc5-495f-9654-10b4e20d4baf" />


Users can now keep the final question and answer from tangent mode by using `/tangent tail` instead of `/tangent`. This preserves the last Q&A pair when returning to the main conversation, making it easy to retain helpful insights discovered during exploration.

- `/tangent` - exits tangent mode (existing behavior unchanged)
- `/tangent tail` - exits tangent mode but keeps the last Q&A pair

This enables users to safely explore topics without losing the final valuable insight that could benefit their main conversation flow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
