### PR TITLE
feat: add daily heartbeat telemetry

### DIFF
--- a/crates/chat-cli/src/cli/mod.rs
+++ b/crates/chat-cli/src/cli/mod.rs
@@ -144,6 +144,11 @@ impl RootSubcommand {
             );
         }
 
+        // Daily heartbeat check
+        if os.database.should_send_heartbeat() && os.telemetry.send_daily_heartbeat().is_ok() {
+            os.database.record_heartbeat_sent().ok();
+        }
+
         // Send executed telemetry.
         if self.valid_for_telemetry() {
             os.telemetry

--- a/crates/chat-cli/src/database/mod.rs
+++ b/crates/chat-cli/src/database/mod.rs
@@ -61,6 +61,7 @@ const IDC_REGION_KEY: &str = "auth.idc.region";
 // We include this key to remove for backwards compatibility
 const CUSTOMIZATION_STATE_KEY: &str = "api.selectedCustomization";
 const PROFILE_MIGRATION_KEY: &str = "profile.Migrated";
+const HEARTBEAT_DATE_KEY: &str = "telemetry.lastHeartbeatDate";
 
 const MIGRATIONS: &[Migration] = migrations![
     "000_migration_table",
@@ -309,6 +310,26 @@ impl Database {
     /// Set if user has already completed a migration
     pub fn set_has_migrated(&self) -> Result<usize, DatabaseError> {
         self.set_entry(Table::State, PROFILE_MIGRATION_KEY, true)
+    }
+
+    /// Check if daily heartbeat should be sent
+    pub fn should_send_heartbeat(&self) -> bool {
+        use chrono::Utc;
+        let today = Utc::now().format("%Y-%m-%d").to_string();
+
+        match self.get_entry::<String>(Table::State, HEARTBEAT_DATE_KEY) {
+            Ok(Some(last_date)) => last_date != today,
+            Ok(None) => true, // First time - definitely send
+            Err(_) => false,  // Database error - don't send (might have already sent)
+        }
+    }
+
+    /// Record that heartbeat was sent today
+    pub fn record_heartbeat_sent(&self) -> Result<(), DatabaseError> {
+        use chrono::Utc;
+        let today = Utc::now().format("%Y-%m-%d").to_string();
+        self.set_entry(Table::State, HEARTBEAT_DATE_KEY, today)?;
+        Ok(())
     }
 
     // /// Get the model id used for last conversation state.

--- a/crates/chat-cli/src/telemetry/core.rs
+++ b/crates/chat-cli/src/telemetry/core.rs
@@ -19,6 +19,7 @@ use crate::telemetry::definitions::metrics::{
     AmazonqMessageResponseError,
     AmazonqProfileState,
     AmazonqStartChat,
+    AmazonqcliDailyHeartbeat,
     CodewhispererterminalAddChatMessage,
     CodewhispererterminalAgentConfigInit,
     CodewhispererterminalAgentContribution,
@@ -499,6 +500,14 @@ impl Event {
                 }
                 .into_metric_datum(),
             ),
+            EventType::DailyHeartbeat {} => Some(
+                AmazonqcliDailyHeartbeat {
+                    create_time: self.created_time,
+                    value: None,
+                    source: None,
+                }
+                .into_metric_datum(),
+            ),
         }
     }
 }
@@ -689,6 +698,7 @@ pub enum EventType {
         message_id: Option<String>,
         context_file_length: Option<usize>,
     },
+    DailyHeartbeat {},
 }
 
 #[derive(Debug)]

--- a/crates/chat-cli/src/telemetry/mod.rs
+++ b/crates/chat-cli/src/telemetry/mod.rs
@@ -235,6 +235,10 @@ impl TelemetryThread {
         Ok(self.tx.send(Event::new(EventType::UserLoggedIn {}))?)
     }
 
+    pub fn send_daily_heartbeat(&self) -> Result<(), TelemetryError> {
+        Ok(self.tx.send(Event::new(EventType::DailyHeartbeat {}))?)
+    }
+
     pub async fn send_cli_subcommand_executed(
         &self,
         database: &Database,

--- a/crates/chat-cli/telemetry_definitions.json
+++ b/crates/chat-cli/telemetry_definitions.json
@@ -530,6 +530,14 @@
           { "type": "statusCode", "required": false },
           { "type": "codewhispererterminal_clientApplication" }
       ]
+    },
+    {
+      "name": "amazonqcli_dailyHeartbeat",
+      "description": "Daily heartbeat to track active CLI usage",
+      "unit": "None",
+      "metadata": [
+        { "type": "source", "required": false }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Tracks daily active users by sending amazonqcli_dailyHeartbeat event once per day. Uses fail-closed logic to prevent spam during database errors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
