### PR TITLE
fix(read none utf8 file)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,6 +1206,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chardetng"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b8f0b65b7b08ae3c8187e8d77174de20cb6777864c6b832d8ad365999cf1ea"
+dependencies = [
+ "cfg-if",
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
 name = "chat_cli"
 version = "1.15.0"
 dependencies = [
@@ -1233,6 +1244,7 @@ dependencies = [
  "bytes",
  "camino",
  "cfg-if",
+ "chardetng",
  "chrono",
  "clap",
  "clap_complete",
@@ -4237,7 +4249,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.16",
  "http 1.3.1",

--- a/crates/chat-cli/Cargo.toml
+++ b/crates/chat-cli/Cargo.toml
@@ -16,6 +16,7 @@ default = []
 wayland = ["arboard/wayland-data-control"]
 
 [dependencies]
+chardetng = "0.1"
 amzn-codewhisperer-client.workspace = true
 amzn-codewhisperer-streaming-client.workspace = true
 amzn-consolas-client.workspace = true

--- a/crates/chat-cli/src/cli/chat/tools/fs_read.rs
+++ b/crates/chat-cli/src/cli/chat/tools/fs_read.rs
@@ -2,6 +2,7 @@ use std::collections::VecDeque;
 use std::fs::Metadata;
 use std::io::Write;
 
+use chardetng::EncodingDetector;
 use crossterm::queue;
 use crossterm::style::{
     self,
@@ -500,9 +501,20 @@ impl FsLine {
     pub async fn invoke(&self, os: &Os, updates: &mut impl Write) -> Result<InvokeOutput> {
         let path = sanitize_path_tool_arg(os, &self.path);
         debug!(?path, "Reading");
+
+        // Read raw bytes from file
         let file_bytes = os.fs.read(&path).await?;
-        let file_content = String::from_utf8_lossy(&file_bytes);
-        let file_content = sanitize_unicode_tags(&file_content);
+
+        // Detect encoding
+        let mut detector = EncodingDetector::new();
+        detector.feed(&file_bytes, true);
+        let encoding = detector.guess(None, true);
+
+        // Decode to UTF-8
+        let (decoded, _, _) = encoding.decode(&file_bytes);
+        let file_content = sanitize_unicode_tags(&decoded);
+
+        // Count lines and calculate range
         let line_count = file_content.lines().count();
         let (start, end) = (
             convert_negative_index(line_count, self.start_line()),
@@ -1105,12 +1117,7 @@ mod tests {
             .unwrap();
 
         if let OutputKind::Text(text) = output.output {
-            assert!(text.contains('�'), "Binary data should contain replacement characters");
-            assert_eq!(text.chars().count(), 8, "Should have 8 replacement characters");
-            assert!(
-                text.chars().all(|c| c == '�'),
-                "All characters should be replacement characters"
-            );
+            assert_eq!(text.trim(), "ﳽ\u{fafb}\u{f8f9}");
         } else {
             panic!("expected text output");
         }
@@ -1138,11 +1145,7 @@ mod tests {
 
         if let OutputKind::Text(text) = output.output {
             // Latin-1 byte 233 (é) is invalid UTF-8, so it becomes a replacement character
-            assert!(text.starts_with("caf"), "Should start with 'caf'");
-            assert!(
-                text.contains('�'),
-                "Should contain replacement character for invalid UTF-8"
-            );
+            assert!(text.starts_with("café"), "Should start with 'café'");
         } else {
             panic!("expected text output");
         }
@@ -1235,12 +1238,7 @@ mod tests {
             .unwrap();
 
         if let OutputKind::Text(text) = output.output {
-            assert!(text.contains("Text with"), "Should contain readable text");
-            assert!(text.contains("smart quotes"), "Should contain readable text");
-            assert!(
-                text.contains('�'),
-                "Should contain replacement characters for invalid UTF-8"
-            );
+            assert_eq!(text.trim(), "Text with “smart quotes”");
         } else {
             panic!("expected text output");
         }
@@ -1305,7 +1303,6 @@ mod tests {
             .unwrap();
 
         if let OutputKind::Text(text) = output.output {
-            assert_eq!(text.chars().count(), 3, "Should have 3 replacement characters");
             assert!(text.chars().all(|c| c == '�'), "Should be all replacement characters");
         } else {
             panic!("expected text output");


### PR DESCRIPTION
*Issue #1101 , if available:*
so when u q cli read a file that are not utf8 encoded the program will get confused cause he only see  ?????? or sthg like that 
*Description of changes:*
so instead of that i make it detect the encoding used on that file then update it to utf8 so with that the ai can understand what is in the file   (and there are test in it)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
