### PR TITLE
fix(chat): reset pending tool state when clearing conversation

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/clear.rs
+++ b/crates/chat-cli/src/cli/chat/cli/clear.rs
@@ -52,6 +52,12 @@ impl ClearArgs {
             if let Some(cm) = session.conversation.context_manager.as_mut() {
                 cm.hook_executor.cache.clear();
             }
+
+            // Reset pending tool state to prevent orphaned tool approval prompts
+            session.tool_uses.clear();
+            session.pending_tool_index = None;
+            session.tool_turn_start_time = None;
+            
             execute!(
                 session.stderr,
                 style::SetForegroundColor(Color::Green),


### PR DESCRIPTION
Reset tool_uses, pending_tool_index, and tool_turn_start_time to prevent orphaned tool approval prompts after conversation history is cleared.

*Issue #, if available:* #2782


*Description of changes:*
https://github.com/aws/amazon-q-developer-cli/issues/2782

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
