### PR TITLE
chore: remove need for --name flag for /agent set-default command

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/profile.rs
+++ b/crates/chat-cli/src/cli/chat/cli/profile.rs
@@ -102,7 +102,6 @@ pub enum AgentSubcommand {
     /// Define a default agent to use when q chat launches
     SetDefault {
         /// Name of the agent to set as default
-        #[arg(long, short)]
         name: String,
     },
     /// Swap to a new agent at runtime


### PR DESCRIPTION
### Why?
I've find it quite annoying that the `/agent swap` command you can simply use `/agent swap myagent` while the `set-default` command requires an extra flag `/agent set-default --name myagent`.

### What?
This PR simply removes the need for the `--name` flag for the `set-default` command.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
