### PR TITLE
feat: Path based loading for agent

### DIFF
--- a/crates/chat-cli/src/cli/agent/root_command_args.rs
+++ b/crates/chat-cli/src/cli/agent/root_command_args.rs
@@ -286,7 +286,7 @@ impl AgentArgs {
             },
             Some(AgentSubcommands::SetDefault { name }) => {
                 let mut agents = Agents::load(os, None, true, &mut stderr, mcp_enabled).await.0;
-                match agents.switch(&name) {
+                match agents.switch(&name, os) {
                     Ok(agent) => {
                         os.database
                             .settings
@@ -352,7 +352,7 @@ pub async fn create_agent(
     }
 
     let prepopulated_content = if let Some(from) = from {
-        let mut agent_to_copy = agents.switch(from.as_str())?.clone();
+        let mut agent_to_copy = agents.switch(from.as_str(), os)?.clone();
         agent_to_copy.name = name.clone();
         agent_to_copy
     } else {

--- a/crates/chat-cli/src/cli/chat/conversation.rs
+++ b/crates/chat-cli/src/cli/chat/conversation.rs
@@ -750,8 +750,8 @@ IMPORTANT: Return ONLY raw JSON with NO markdown formatting, NO code blocks, NO 
 Your task is to generate an agent configuration file for an agent named '{}' with the following description: {}\n\n\
 The configuration must conform to this JSON schema:\n{}\n\n\
 We have a prepopulated template: {} \n\n\
-Please change the useLegacyMcpJson field to false. 
-Please generate the prompt field using user provided description, and fill in the MCP tools that user has selected {}. 
+Please change the useLegacyMcpJson field to false.
+Please generate the prompt field using user provided description, and fill in the MCP tools that user has selected {}.
 Return only the JSON configuration, no additional text.",
    agent_name, agent_description, schema, prepopulated_content, selected_servers
         );
@@ -940,7 +940,7 @@ Return only the JSON configuration, no additional text.",
         output: &mut impl Write,
         agent_name: &str,
     ) -> Result<(), ChatError> {
-        let agent = self.agents.switch(agent_name).map_err(ChatError::AgentSwapError)?;
+        let agent = self.agents.switch(agent_name, os).map_err(ChatError::AgentSwapError)?;
         self.context_manager.replace({
             ContextManager::from_agent(agent, calc_max_context_files_size(self.model_info.as_ref()))
                 .map_err(|e| ChatError::Custom(format!("Context manager has failed to instantiate: {e}").into()))?
@@ -1493,7 +1493,7 @@ mod tests {
             agent.resources.push(AMAZONQ_FILENAME.into());
             agent.resources.push(AGENTS_FILENAME.into());
             agents.agents.insert("TestAgent".to_string(), agent);
-            agents.switch("TestAgent").expect("Agent switch failed");
+            agents.switch("TestAgent", &os).expect("Agent switch failed");
             agents
         };
         os.fs.write(AMAZONQ_FILENAME, "test context").await.unwrap();

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -651,7 +651,7 @@ impl ChatSession {
                         input = Some(input.unwrap_or("In a few words, summarize our conversation so far.".to_owned()));
                         cs.tool_manager = tool_manager;
                         if let Some(profile) = cs.current_profile() {
-                            if agents.switch(profile).is_err() {
+                            if agents.switch(profile, os).is_err() {
                                 execute!(
                                     &mut control_end_stderr,
                                     StyledText::error_fg(),
@@ -661,7 +661,7 @@ impl ChatSession {
                                         ": cannot resume conversation with {profile} because it no longer exists. Using default.\n"
                                     ))
                                 )?;
-                                let _ = agents.switch(DEFAULT_AGENT_NAME);
+                                let _ = agents.switch(DEFAULT_AGENT_NAME, os);
                             }
                         }
                         cs.agents = agents;
@@ -3619,7 +3619,7 @@ impl ChatSession {
         };
         let request_content = format!(
             "[SYSTEM NOTE: This is an automated request, not from the user]\n
-            Read the TODO list contents below and understand the task description, completed tasks, and provided context.\n 
+            Read the TODO list contents below and understand the task description, completed tasks, and provided context.\n
             Call the `load` command of the todo_list tool with the given ID as an argument to display the TODO list to the user and officially resume execution of the TODO list tasks.\n
             You do not need to display the tasks to the user yourself. You can begin completing the tasks after calling the `load` command.\n
             TODO LIST CONTENTS: {}\n
@@ -3797,7 +3797,7 @@ mod tests {
                 .expect("Failed to write test agent to file");
         }
         agents.agents.insert("TestAgent".to_string(), agent);
-        agents.switch("TestAgent").expect("Failed to switch agent");
+        agents.switch("TestAgent", os).expect("Failed to switch agent");
         agents
     }
 


### PR DESCRIPTION
People can now do `q chat --agent team/myagent` in addition to the current `q chat --agent myagent`. This will enable better management of agents in Q CLI directory

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
