### PR TITLE
feat(agent): implement new hook for when agent needs attention

### DIFF
--- a/crates/chat-cli/src/cli/agent/hook.rs
+++ b/crates/chat-cli/src/cli/agent/hook.rs
@@ -2,10 +2,7 @@ use std::collections::HashMap;
 use std::fmt::Display;
 
 use schemars::JsonSchema;
-use serde::{
-    Deserialize,
-    Serialize,
-};
+use serde::{Deserialize, Serialize};
 
 const DEFAULT_TIMEOUT_MS: u64 = 30_000;
 const DEFAULT_MAX_OUTPUT_SIZE: usize = 1024 * 10;
@@ -21,6 +18,8 @@ pub enum HookTrigger {
     AgentSpawn,
     /// Triggered per user message submission
     UserPromptSubmit,
+    /// Triggered when agent needs user attention (tool approval, confirmation, etc.)
+    AgentNeedsAttention,
 }
 
 impl Display for HookTrigger {
@@ -28,6 +27,7 @@ impl Display for HookTrigger {
         match self {
             HookTrigger::AgentSpawn => write!(f, "agentSpawn"),
             HookTrigger::UserPromptSubmit => write!(f, "userPromptSubmit"),
+            HookTrigger::AgentNeedsAttention => write!(f, "agentNeedsAttention"),
         }
     }
 }

--- a/crates/chat-cli/src/cli/chat/context.rs
+++ b/crates/chat-cli/src/cli/chat/context.rs
@@ -248,10 +248,11 @@ impl ContextManager {
         trigger: HookTrigger,
         output: &mut impl Write,
         prompt: Option<&str>,
+        additional_env: Option<&HashMap<String, String>>,
     ) -> Result<Vec<((HookTrigger, Hook), String)>, ChatError> {
         let mut hooks = self.hooks.clone();
         hooks.retain(|t, _| *t == trigger);
-        self.hook_executor.run_hooks(hooks, output, prompt).await
+        self.hook_executor.run_hooks(hooks, output, prompt, additional_env).await
     }
 }
 

--- a/crates/chat-cli/src/cli/chat/conversation.rs
+++ b/crates/chat-cli/src/cli/chat/conversation.rs
@@ -563,12 +563,12 @@ impl ConversationState {
         let mut agent_spawn_context = None;
         if let Some(cm) = self.context_manager.as_mut() {
             let user_prompt = self.next_message.as_ref().and_then(|m| m.prompt());
-            let agent_spawn = cm.run_hooks(HookTrigger::AgentSpawn, output, user_prompt).await?;
+            let agent_spawn = cm.run_hooks(HookTrigger::AgentSpawn, output, user_prompt, None).await?;
             agent_spawn_context = format_hook_context(&agent_spawn, HookTrigger::AgentSpawn);
 
             if let (true, Some(next_message)) = (run_perprompt_hooks, self.next_message.as_mut()) {
                 let per_prompt = cm
-                    .run_hooks(HookTrigger::UserPromptSubmit, output, next_message.prompt())
+                    .run_hooks(HookTrigger::UserPromptSubmit, output, next_message.prompt(), None)
                     .await?;
                 if let Some(ctx) = format_hook_context(&per_prompt, HookTrigger::UserPromptSubmit) {
                     next_message.additional_context = ctx;

--- a/docs/agent-format.md
+++ b/docs/agent-format.md
@@ -281,6 +281,7 @@ Each hook is defined with:
 Available hook triggers:
 - `agentSpawn`: Triggered when the agent is initialized
 - `userPromptSubmit`: Triggered when the user submits a message
+- `agentNeedsAttention`: Triggered when the agent needs user attention
 
 ## UseLegacyMcpJson Field
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,110 @@
+# Agent Hooks
+
+Agent hooks allow you to execute shell commands at specific trigger points during the agent's lifecycle. The output of these commands is added to the agent's context, enabling dynamic information injection and external notifications.
+
+## Hook Configuration
+
+Hooks are configured in the agent's JSON file under the `hooks` field:
+
+```json
+{
+  "hooks": {
+    "agentSpawn": [...],
+    "userPromptSubmit": [...],
+    "agentNeedsAttention": [...]
+  }
+}
+```
+
+Each hook trigger accepts an array of hook commands with the following properties:
+
+- `command` (required): The shell command to execute
+- `timeout_ms` (optional): Maximum execution time in milliseconds (default: 30000)
+- `max_output_size` (optional): Maximum output size in bytes (default: 10240)
+- `cache_ttl_seconds` (optional): How long to cache results in seconds (default: 0)
+
+## Available Hook Triggers
+
+### agentSpawn
+Triggered once when the agent is initialized.
+
+**Environment Variables:**
+- `USER_PROMPT`: The initial user prompt (if any)
+
+**Example:**
+```json
+{
+  "agentSpawn": [
+    {
+      "command": "git status --porcelain",
+      "timeout_ms": 5000
+    }
+  ]
+}
+```
+
+### userPromptSubmit
+Triggered each time the user submits a message.
+
+**Environment Variables:**
+- `USER_PROMPT`: The current user prompt (truncated to 4096 chars)
+
+**Example:**
+```json
+{
+  "userPromptSubmit": [
+    {
+      "command": "echo \"Processing: $USER_PROMPT\" >> /tmp/q-prompts.log",
+      "timeout_ms": 2000
+    }
+  ]
+}
+```
+
+### agentNeedsAttention
+Triggered when the agent needs user attention. Currently supports tool approval and completion notifications.
+
+**Environment Variables:**
+- `USER_PROMPT`: The current user prompt (truncated to 4096 chars)
+- `ATTENTION_REASON`: Reason for attention e.g. `tool_approval`
+- `TOOL_NAME`: Name of the tool requiring approval (when ATTENTION_REASON=tool_approval)
+- `TOOL_COMMAND`: Command/arguments that require approval (when ATTENTION_REASON=tool_approval)
+
+## Complete Example Agent
+
+```json
+{
+  "name": "notification-agent",
+  "description": "Agent with comprehensive notification hooks",
+  "hooks": {
+    "agentSpawn": [
+      {
+        "command": "echo \"[$(date)] Agent started\" >> /tmp/q-agent.log",
+        "timeout_ms": 2000
+      },
+      {
+        "command": "if command -v osascript >/dev/null 2>&1; then osascript -e 'display notification \"Q Developer agent ready\" with title \"Q Developer\"'; fi",
+        "timeout_ms": 3000
+      }
+    ],
+    "userPromptSubmit": [
+      {
+        "command": "echo \"[$(date)] User: $USER_PROMPT\" >> /tmp/q-agent.log",
+        "timeout_ms": 2000,
+        "max_output_size": 256
+      }
+    ],
+    "agentNeedsAttention": [
+      {
+        "command": "echo \"[$(date)] Attention: $ATTENTION_REASON\" >> /tmp/q-agent.log",
+        "timeout_ms": 2000
+      },
+      {
+        "command": "if [ \"$ATTENTION_REASON\" = \"tool_approval\" ] && command -v osascript >/dev/null 2>&1; then osascript -e \"display notification \\\"Approve: $TOOL_NAME\\\" with title \\\"Q Developer\\\" sound name \\\"Glass\\\"\"; fi",
+        "timeout_ms": 5000,
+        "cache_ttl_seconds": 0
+      }
+    ]
+  }
+}
+```

--- a/schemas/agent-v1.json
+++ b/schemas/agent-v1.json
@@ -138,6 +138,9 @@
         },
         "agentSpawn": {
           "$ref": "#/definitions/hookCommands"
+        },
+        "agentNeedsAttention": {
+          "$ref": "#/definitions/hookCommands"
         }
       },
       "default": {}


### PR DESCRIPTION
### Why this change?
A lot of times I want to leave Q working on a task and check it only when I need to approve some tool or plan.

This PR creates the basis for that by creating a new hook: `agentNeedsAttention` that allows me
to focus on other things while Q works.

### Demo

https://github.com/user-attachments/assets/73f5027d-3398-4240-baac-4cf761ce47bb



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
