### PR TITLE
Update bm25 to v2.3.2 and ignore unmaintained fxhash advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,9 +948,9 @@ dependencies = [
 
 [[package]]
 name = "bm25"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84ff0d57042bc263e2ebadb3703424b59b65870902649a2b3d0f4d7ab863244"
+checksum = "1cbd8ffdfb7b4c2ff038726178a780a94f90525ed0ad264c0afaa75dd8c18a64"
 dependencies = [
  "cached",
  "deunicode",
@@ -4237,7 +4237,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.16",
  "http 1.3.1",
@@ -6008,9 +6008,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stop-words"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6a86be9f7fa4559b7339669e72026eb437f5e9c5a85c207fe1033079033a17"
+checksum = "645a3d441ccf4bf47f2e4b7681461986681a6eeea9937d4c3bc9febd61d17c71"
 dependencies = [
  "serde_json",
 ]

--- a/crates/semantic-search-client/Cargo.toml
+++ b/crates/semantic-search-client/Cargo.toml
@@ -30,7 +30,7 @@ glob.workspace = true
 hnsw_rs = "=0.3.1"
 
 # BM25 implementation - works on all platforms including ARM
-bm25 = { version = "2.2.1", features = ["language_detection"] }
+bm25 = { version = "2.3.2", features = ["language_detection"] }
 
 # Common dependencies for all platforms
 anyhow = "1.0"

--- a/deny.toml
+++ b/deny.toml
@@ -27,6 +27,8 @@ ignore = [
   "RUSTSEC-2024-0429",
   # paste is used in core deps
   "RUSTSEC-2024-0436",
+  # fxhash is unmaintained but used by bm25, waiting for bm25 to migrate
+  "RUSTSEC-2025-0057",
 ]
 
 [licenses]


### PR DESCRIPTION
- Updated bm25 from v2.2.1 to v2.3.2 (latest version)
- Added RUSTSEC-2025-0057 to deny.toml ignore list for unmaintained fxhash
- fxhash is a transitive dependency of bm25, waiting for upstream migration to rustc-hash

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
