### PR TITLE
Support preToolUse and postToolUse hook

### DIFF
--- a/crates/chat-cli/src/cli/agent/hook.rs
+++ b/crates/chat-cli/src/cli/agent/hook.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::fmt::Display;
 
 use schemars::JsonSchema;
@@ -11,9 +10,6 @@ const DEFAULT_TIMEOUT_MS: u64 = 30_000;
 const DEFAULT_MAX_OUTPUT_SIZE: usize = 1024 * 10;
 const DEFAULT_CACHE_TTL_SECONDS: u64 = 0;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, JsonSchema)]
-pub struct Hooks(HashMap<HookTrigger, Hook>);
-
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, PartialEq, JsonSchema, Hash)]
 #[serde(rename_all = "camelCase")]
 pub enum HookTrigger {
@@ -21,6 +17,10 @@ pub enum HookTrigger {
     AgentSpawn,
     /// Triggered per user message submission
     UserPromptSubmit,
+    /// Triggered before tool execution
+    PreToolUse,
+    /// Triggered after tool execution
+    PostToolUse,
 }
 
 impl Display for HookTrigger {
@@ -28,6 +28,8 @@ impl Display for HookTrigger {
         match self {
             HookTrigger::AgentSpawn => write!(f, "agentSpawn"),
             HookTrigger::UserPromptSubmit => write!(f, "userPromptSubmit"),
+            HookTrigger::PreToolUse => write!(f, "preToolUse"),
+            HookTrigger::PostToolUse => write!(f, "postToolUse"),
         }
     }
 }
@@ -61,6 +63,11 @@ pub struct Hook {
     #[serde(default = "Hook::default_cache_ttl_seconds")]
     pub cache_ttl_seconds: u64,
 
+    /// Optional regex matcher for hook
+    /// Currently used for matching tool name of PreToolUse and PostToolUse hook
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub matcher: Option<String>,
+
     #[schemars(skip)]
     #[serde(default, skip_serializing)]
     pub source: Source,
@@ -73,6 +80,7 @@ impl Hook {
             timeout_ms: Self::default_timeout_ms(),
             max_output_size: Self::default_max_output_size(),
             cache_ttl_seconds: Self::default_cache_ttl_seconds(),
+            matcher: None,
             source,
         }
     }

--- a/crates/chat-cli/src/cli/agent/hook.rs
+++ b/crates/chat-cli/src/cli/agent/hook.rs
@@ -63,7 +63,7 @@ pub struct Hook {
     #[serde(default = "Hook::default_cache_ttl_seconds")]
     pub cache_ttl_seconds: u64,
 
-    /// Optional regex matcher for hook
+    /// Optional glob matcher for hook
     /// Currently used for matching tool name of PreToolUse and PostToolUse hook
     #[serde(skip_serializing_if = "Option::is_none")]
     pub matcher: Option<String>,

--- a/crates/chat-cli/src/cli/agent/legacy/hooks.rs
+++ b/crates/chat-cli/src/cli/agent/legacy/hooks.rs
@@ -80,6 +80,7 @@ impl From<LegacyHook> for Option<Hook> {
             timeout_ms: value.timeout_ms,
             max_output_size: value.max_output_size,
             cache_ttl_seconds: value.cache_ttl_seconds,
+            matcher: None,
             source: Default::default(),
         })
     }

--- a/crates/chat-cli/src/cli/chat/cli/hooks.rs
+++ b/crates/chat-cli/src/cli/chat/cli/hooks.rs
@@ -271,18 +271,20 @@ impl HookExecutor {
 
         let timeout = Duration::from_millis(hook.1.timeout_ms);
 
-        // Set USER_PROMPT environment variable if provided
-        if let Some(prompt) = prompt {
-            // Sanitize the prompt to avoid issues with special characters
-            let sanitized_prompt = sanitize_user_prompt(prompt);
-            cmd.env("USER_PROMPT", sanitized_prompt);
-        }
-
         // Generate hook command input in JSON format
         let mut hook_input = serde_json::json!({
             "hook_event_name": hook.0.to_string(),
             "cwd": cwd
         });
+
+        // Set USER_PROMPT environment variable and add to JSON input if provided
+        if let Some(prompt) = prompt {
+            // Sanitize the prompt to avoid issues with special characters
+            let sanitized_prompt = sanitize_user_prompt(prompt);
+            cmd.env("USER_PROMPT", sanitized_prompt);
+            hook_input["prompt"] = serde_json::Value::String(prompt.to_string());
+        }
+
         // ToolUse specific input
         if let Some(tool_ctx) = tool_context {
             hook_input["tool_name"] = serde_json::Value::String(tool_ctx.tool_name);

--- a/crates/chat-cli/src/cli/chat/cli/hooks.rs
+++ b/crates/chat-cli/src/cli/chat/cli/hooks.rs
@@ -44,6 +44,31 @@ use crate::cli::chat::{
     ChatSession,
     ChatState,
 };
+use crate::util::pattern_matching::matches_any_pattern;
+
+/// Hook execution result: (exit_code, output)
+/// Output is stdout if exit_code is 0, stderr otherwise.
+pub type HookOutput = (i32, String);
+
+/// Check if a hook matches a tool name based on its matcher pattern
+fn hook_matches_tool(hook: &Hook, tool_name: &str) -> bool {
+    match &hook.matcher {
+        None => true, // No matcher means the hook runs for all tools
+        Some(pattern) => {
+            // Convert single pattern to HashSet for matches_any_pattern
+            let mut patterns = std::collections::HashSet::new();
+            patterns.insert(pattern.clone());
+            matches_any_pattern(&patterns, tool_name)
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ToolContext {
+    pub tool_name: String,
+    pub tool_input: serde_json::Value,
+    pub tool_response: Option<serde_json::Value>,
+}
 
 #[derive(Debug, Clone)]
 pub struct CachedHook {
@@ -74,22 +99,32 @@ impl HookExecutor {
         &mut self,
         hooks: HashMap<HookTrigger, Vec<Hook>>,
         output: &mut impl Write,
+        cwd: &str,
         prompt: Option<&str>,
-    ) -> Result<Vec<((HookTrigger, Hook), String)>, ChatError> {
+        tool_context: Option<ToolContext>,
+    ) -> Result<Vec<((HookTrigger, Hook), HookOutput)>, ChatError> {
         let mut cached = vec![];
         let mut futures = FuturesUnordered::new();
         for hook in hooks
             .into_iter()
             .flat_map(|(trigger, hooks)| hooks.into_iter().map(move |hook| (trigger, hook)))
         {
+            // Filter hooks by tool matcher
+            if let Some(tool_ctx) = &tool_context {
+                if !hook_matches_tool(&hook.1, &tool_ctx.tool_name) {
+                    continue; // Skip this hook - doesn't match tool
+                }
+            }
+            
             if let Some(cache) = self.get_cache(&hook) {
-                cached.push((hook.clone(), cache.clone()));
+                // Note: we only cache successful hook run. hence always using 0 as exit code for cached hook
+                cached.push((hook.clone(), (0, cache)));
                 continue;
             }
-            futures.push(self.run_hook(hook, prompt));
+            futures.push(self.run_hook(hook, cwd, prompt, tool_context.clone()));
         }
 
-        let mut complete = 0;
+        let mut complete = 0; // number of hooks that are run successfully with exit code 0
         let total = futures.len();
         let mut spinner = None;
         let spinner_text = |complete: usize, total: usize| {
@@ -138,9 +173,25 @@ impl HookExecutor {
             }
 
             // Process results regardless of output enabled
-            if let Ok(output) = result {
-                complete += 1;
-                results.push((hook, output));
+            if let Ok((exit_code, hook_output)) = &result {
+                // Print warning if exit code is not 0
+                if *exit_code != 0 {
+                    queue!(
+                        output,
+                        style::SetForegroundColor(style::Color::Red),
+                        style::Print("✗ "),
+                        style::ResetColor,
+                        style::Print(format!("{} \"", hook.0)),
+                        style::Print(&hook.1.command),
+                        style::Print("\""),
+                        style::SetForegroundColor(style::Color::Red),
+                        style::Print(format!(" failed with exit code: {}, stderr: {})\n", exit_code, hook_output.trim_end())),
+                        style::ResetColor,
+                    )?;
+                } else {
+                    complete += 1;
+                }
+                results.push((hook, result.unwrap()));
             }
 
             // Display ending summary or add a new spinner
@@ -167,12 +218,17 @@ impl HookExecutor {
         drop(futures);
 
         // Fill cache with executed results, skipping what was already from cache
-        for ((trigger, hook), output) in &results {
+        for ((trigger, hook), (exit_code, output)) in &results {
+            if *exit_code != 0 {
+                continue; // Only cache successful hooks
+            }
             self.cache.insert((*trigger, hook.clone()), CachedHook {
                 output: output.clone(),
                 expiry: match trigger {
                     HookTrigger::AgentSpawn => None,
                     HookTrigger::UserPromptSubmit => Some(Instant::now() + Duration::from_secs(hook.cache_ttl_seconds)),
+                    HookTrigger::PreToolUse => Some(Instant::now() + Duration::from_secs(hook.cache_ttl_seconds)),
+                    HookTrigger::PostToolUse => Some(Instant::now() + Duration::from_secs(hook.cache_ttl_seconds)),
                 },
             });
         }
@@ -185,8 +241,10 @@ impl HookExecutor {
     async fn run_hook(
         &self,
         hook: (HookTrigger, Hook),
+        cwd: &str,
         prompt: Option<&str>,
-    ) -> ((HookTrigger, Hook), Result<String>, Duration) {
+        tool_context: Option<ToolContext>,
+    ) -> ((HookTrigger, Hook), Result<HookOutput>, Duration) {
         let start_time = Instant::now();
 
         let command = &hook.1.command;
@@ -220,26 +278,52 @@ impl HookExecutor {
             cmd.env("USER_PROMPT", sanitized_prompt);
         }
 
-        let command_future = cmd.output();
+        // Generate hook command input in JSON format
+        let mut hook_input = serde_json::json!({
+            "hook_event_name": hook.0.to_string(),
+            "cwd": cwd
+        });
+        // ToolUse specific input
+        if let Some(tool_ctx) = tool_context {
+            hook_input["tool_name"] = serde_json::Value::String(tool_ctx.tool_name);
+            hook_input["tool_input"] = tool_ctx.tool_input;
+            if let Some(response) = tool_ctx.tool_response {
+                hook_input["tool_response"] = response;
+            }
+        }
+        let json_input = serde_json::to_string(&hook_input).unwrap_or_default();
+
+        // Build a future for hook command w/ the JSON input passed in through STDIN
+        let command_future = async move {
+            let mut child = cmd.spawn()?;
+            if let Some(stdin) = child.stdin.take() {
+                use tokio::io::AsyncWriteExt;
+                let mut stdin = stdin;
+                let _ = stdin.write_all(json_input.as_bytes()).await;
+                let _ = stdin.shutdown().await;
+            }
+            child.wait_with_output().await
+        };
 
         // Run with timeout
         let result = match tokio::time::timeout(timeout, command_future).await {
-            Ok(Ok(result)) => {
-                if result.status.success() {
-                    let stdout = result.stdout.to_str_lossy();
-                    let stdout = format!(
-                        "{}{}",
-                        truncate_safe(&stdout, hook.1.max_output_size),
-                        if stdout.len() > hook.1.max_output_size {
-                            " ... truncated"
-                        } else {
-                            ""
-                        }
-                    );
-                    Ok(stdout)
+            Ok(Ok(output)) => {
+                let exit_code = output.status.code().unwrap_or(-1);
+                let raw_output = if exit_code == 0 {
+                    output.stdout.to_str_lossy()
                 } else {
-                    Err(eyre!("command returned non-zero exit code: {}", result.status))
-                }
+                    output.stderr.to_str_lossy()
+                };
+                let formatted_output = format!(
+                    "{}{}",
+                    truncate_safe(&raw_output, hook.1.max_output_size),
+                    if raw_output.len() > hook.1.max_output_size {
+                        " ... truncated"
+                    } else {
+                        ""
+                    }
+                );
+                Ok((exit_code, formatted_output))
             },
             Ok(Err(err)) => Err(eyre!("failed to execute command: {}", err)),
             Err(_) => Err(eyre!("command timed out after {} ms", timeout.as_millis())),
@@ -328,5 +412,208 @@ impl HooksArgs {
         Ok(ChatState::PromptUser {
             skip_printing_tools: true,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use crate::cli::agent::hook::{Hook, HookTrigger};
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_hook_matches_tool() {
+        let hook_no_matcher = Hook {
+            command: "echo test".to_string(),
+            timeout_ms: 5000,
+            cache_ttl_seconds: 0,
+            max_output_size: 1000,
+            matcher: None,
+            source: crate::cli::agent::hook::Source::Session,
+        };
+        
+        let fs_write_hook = Hook {
+            command: "echo test".to_string(),
+            timeout_ms: 5000,
+            cache_ttl_seconds: 0,
+            max_output_size: 1000,
+            matcher: Some("fs_write".to_string()),
+            source: crate::cli::agent::hook::Source::Session,
+        };
+        
+        let fs_wildcard_hook = Hook {
+            command: "echo test".to_string(),
+            timeout_ms: 5000,
+            cache_ttl_seconds: 0,
+            max_output_size: 1000,
+            matcher: Some("fs_*".to_string()),
+            source: crate::cli::agent::hook::Source::Session,
+        };
+        
+        // No matcher should match all tools
+        assert!(hook_matches_tool(&hook_no_matcher, "fs_write"));
+        assert!(hook_matches_tool(&hook_no_matcher, "execute_bash"));
+        
+        // Exact matcher should only match exact tool
+        assert!(hook_matches_tool(&fs_write_hook, "fs_write"));
+        assert!(!hook_matches_tool(&fs_write_hook, "fs_read"));
+        
+        // Wildcard matcher should match pattern
+        assert!(hook_matches_tool(&fs_wildcard_hook, "fs_write"));
+        assert!(hook_matches_tool(&fs_wildcard_hook, "fs_read"));
+        assert!(!hook_matches_tool(&fs_wildcard_hook, "execute_bash"));
+    }
+
+    #[tokio::test]
+    async fn test_hook_executor_with_tool_context() {
+        let mut executor = HookExecutor::new();
+        let mut output = Vec::new();
+        
+        // Create temp directory and file
+        let temp_dir = TempDir::new().unwrap();
+        let test_file = temp_dir.path().join("hook_output.json");
+        let test_file_str = test_file.to_string_lossy();
+        
+        // Create a simple hook that writes JSON input to a file
+        #[cfg(unix)]
+        let command = format!("cat > {}", test_file_str);
+        #[cfg(windows)]
+        let command = format!("type > {}", test_file_str);
+        
+        let hook = Hook {
+            command,
+            timeout_ms: 5000,
+            cache_ttl_seconds: 0,
+            max_output_size: 1000,
+            matcher: Some("fs_write".to_string()),
+            source: crate::cli::agent::hook::Source::Session,
+        };
+        
+        let mut hooks = HashMap::new();
+        hooks.insert(HookTrigger::PreToolUse, vec![hook]);
+        
+        let tool_context = ToolContext {
+            tool_name: "fs_write".to_string(),
+            tool_input: serde_json::json!({
+                "command": "create",
+                "path": "/test/file.py"
+            }),
+            tool_response: None,
+        };
+        
+        // Run the hook
+        let result = executor.run_hooks(
+            hooks,
+            &mut output,
+            ".",
+            None,
+            Some(tool_context)
+        ).await;
+        
+        assert!(result.is_ok());
+        
+        // Verify the hook wrote the JSON input to the file
+        if let Ok(content) = std::fs::read_to_string(&test_file) {
+            let json: serde_json::Value = serde_json::from_str(&content).unwrap();
+            assert_eq!(json["hook_event_name"], "preToolUse");
+            assert_eq!(json["tool_name"], "fs_write");
+            assert_eq!(json["tool_input"]["command"], "create");
+            assert_eq!(json["cwd"], ".");
+        }
+        // TempDir automatically cleans up when dropped
+    }
+
+    #[tokio::test]
+    async fn test_hook_filtering_no_match() {
+        let mut executor = HookExecutor::new();
+        let mut output = Vec::new();
+        
+        // Hook that matches execute_bash (should NOT run for fs_write tool call)
+        let execute_bash_hook = Hook {
+            command: "echo 'should not run'".to_string(),
+            timeout_ms: 5000,
+            cache_ttl_seconds: 0,
+            max_output_size: 1000,
+            matcher: Some("execute_bash".to_string()),
+            source: crate::cli::agent::hook::Source::Session,
+        };
+        
+        let mut hooks = HashMap::new();
+        hooks.insert(HookTrigger::PostToolUse, vec![execute_bash_hook]);
+        
+        let tool_context = ToolContext {
+            tool_name: "fs_write".to_string(),
+            tool_input: serde_json::json!({"command": "create"}),
+            tool_response: Some(serde_json::json!({"success": true})),
+        };
+        
+        // Run the hooks
+        let result = executor.run_hooks(
+            hooks,
+            &mut output,
+            ".", // cwd - using current directory for now
+            None, // prompt - no user prompt for this test
+            Some(tool_context)
+        ).await;
+        
+        assert!(result.is_ok());
+        let hook_results = result.unwrap();
+        
+        // Should run 0 hooks because matcher doesn't match tool_name
+        assert_eq!(hook_results.len(), 0);
+        
+        // Output should be empty since no hooks ran
+        assert!(output.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_hook_exit_code_2() {
+        let mut executor = HookExecutor::new();
+        let mut output = Vec::new();
+
+        // Create a hook that exits with code 2 and outputs to stderr
+        #[cfg(unix)]
+        let command = "echo 'Tool execution blocked by security policy' >&2; exit 2";
+        #[cfg(windows)]
+        let command = "echo Tool execution blocked by security policy 1>&2 & exit /b 2";
+        
+        let hook = Hook {
+            command: command.to_string(),
+            timeout_ms: 5000,
+            cache_ttl_seconds: 0,
+            max_output_size: 1000,
+            matcher: Some("fs_write".to_string()),
+            source: crate::cli::agent::hook::Source::Session,
+        };
+
+        let hooks = HashMap::from([
+            (HookTrigger::PreToolUse, vec![hook])
+        ]);
+
+        let tool_context = ToolContext {
+            tool_name: "fs_write".to_string(),
+            tool_input: serde_json::json!({
+                "command": "create",
+                "path": "/sensitive/file.py"
+            }),
+            tool_response: None,
+        };
+
+        let results = executor.run_hooks(
+            hooks,
+            &mut output,
+            ".", // cwd
+            None, // prompt
+            Some(tool_context)
+        ).await.unwrap();
+
+        // Should have one result
+        assert_eq!(results.len(), 1);
+        
+        let ((trigger, _hook), (exit_code, hook_output)) = &results[0];
+        assert_eq!(*trigger, HookTrigger::PreToolUse);
+        assert_eq!(*exit_code, 2);
+        assert!(hook_output.contains("Tool execution blocked by security policy"));
     }
 }

--- a/crates/chat-cli/src/cli/chat/context.rs
+++ b/crates/chat-cli/src/cli/chat/context.rs
@@ -16,6 +16,7 @@ use serde::{
 
 use super::cli::model::context_window_tokens;
 use super::util::drop_matched_context_files;
+use super::cli::hooks::HookOutput;
 use crate::cli::agent::Agent;
 use crate::cli::agent::hook::{
     Hook,
@@ -247,11 +248,14 @@ impl ContextManager {
         &mut self,
         trigger: HookTrigger,
         output: &mut impl Write,
+        os: &crate::os::Os,
         prompt: Option<&str>,
-    ) -> Result<Vec<((HookTrigger, Hook), String)>, ChatError> {
+        tool_context: Option<crate::cli::chat::cli::hooks::ToolContext>,
+    ) -> Result<Vec<((HookTrigger, Hook), HookOutput)>, ChatError> {
         let mut hooks = self.hooks.clone();
         hooks.retain(|t, _| *t == trigger);
-        self.hook_executor.run_hooks(hooks, output, prompt).await
+        let cwd = os.env.current_dir()?.to_string_lossy().to_string();
+        self.hook_executor.run_hooks(hooks, output, &cwd, prompt, tool_context).await
     }
 }
 

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -42,6 +42,7 @@ use clap::{
     ValueEnum,
 };
 use cli::compact::CompactStrategy;
+use cli::hooks::ToolContext;
 use cli::model::{
     find_model,
     get_available_models,
@@ -2261,6 +2262,7 @@ impl ChatSession {
             });
         }
 
+        // All tools are allowed now
         // Execute the requested tools.
         let mut tool_results = vec![];
         let mut image_blocks: Vec<RichImageBlock> = Vec::new();
@@ -2423,6 +2425,42 @@ impl ChatSession {
                         );
                     }
                 },
+            }
+        }
+
+        // Run PostToolUse hooks for all executed tools after we have the tool_results
+        if let Some(cm) = self.conversation.context_manager.as_mut() {
+            for result in &tool_results {
+                if let Some(tool) = self.tool_uses.iter().find(|t| t.id == result.tool_use_id) {
+                    let content: Vec<serde_json::Value> = result.content.iter().map(|block| {
+                        match block {
+                            ToolUseResultBlock::Text(text) => serde_json::Value::String(text.clone()),
+                            ToolUseResultBlock::Json(json) => json.clone(),
+                        }
+                    }).collect();
+                    
+                    let tool_response = match result.status {
+                        ToolResultStatus::Success => serde_json::json!({"success": true, "result": content}),
+                        ToolResultStatus::Error => serde_json::json!({"success": false, "error": content}),
+                    };
+                    
+                    let tool_context = ToolContext {
+                        tool_name: tool.name.clone(),
+                        tool_input: tool.tool_input.clone(),
+                        tool_response: Some(tool_response),
+                    };
+                    
+                    // Here is how we handle postToolUse output:
+                    // Exit code is 0: nothing. stdout is not shown to user. We don't support processing the PostToolUse hook output yet.
+                    // Exit code is non-zero: display an error to user (already taken care of by the ContextManager.run_hooks)
+                    let _ = cm.run_hooks(
+                        crate::cli::agent::hook::HookTrigger::PostToolUse,
+                        &mut std::io::stderr(),
+                        os,
+                        None,
+                        Some(tool_context)
+                    ).await;
+                }
             }
         }
 
@@ -2761,6 +2799,7 @@ impl ChatSession {
         }
     }
 
+    // Validate the tool use request from LLM, including basic checks like fs_read file should exist, as well as user-defined preToolUse hook check.
     async fn validate_tools(&mut self, os: &Os, tool_uses: Vec<AssistantToolUse>) -> Result<ChatState, ChatError> {
         let conv_id = self.conversation.conversation_id().to_owned();
         debug!(?tool_uses, "Validating tool uses");
@@ -2770,6 +2809,7 @@ impl ChatSession {
         for tool_use in tool_uses {
             let tool_use_id = tool_use.id.clone();
             let tool_use_name = tool_use.name.clone();
+            let tool_input = tool_use.args.clone();
             let mut tool_telemetry = ToolUseEventBuilder::new(
                 conv_id.clone(),
                 tool_use.id.clone(),
@@ -2791,6 +2831,7 @@ impl ChatSession {
                                 name: tool_use_name,
                                 tool,
                                 accepted: false,
+                                tool_input,
                             });
                         },
                         Err(err) => {
@@ -2862,9 +2903,72 @@ impl ChatSession {
             ));
         }
 
+        // Execute PreToolUse hooks for all validated tools
+        // The mental model is preToolHook is like validate tools, but its behavior can be customized by user
+        // Note that after preTookUse hook, user can still reject the took run
+        if let Some(cm) = self.conversation.context_manager.as_mut() {
+            for tool in &queued_tools {
+                let tool_context = ToolContext {
+                    tool_name: tool.name.clone(),
+                    tool_input: tool.tool_input.clone(),
+                    tool_response: None,
+                };
+                
+                let hook_results = cm.run_hooks(
+                    crate::cli::agent::hook::HookTrigger::PreToolUse,
+                    &mut std::io::stderr(),
+                    os,
+                    None, /* prompt */
+                    Some(tool_context)
+                ).await?;
+
+                // Here is how we handle the preToolUse hook output:
+                // Exit code is 0: nothing. stdout is not shown to user.
+                // Exit code is 2: block the tool use. return stderr to LLM. show warning to user
+                // Other error: show warning to user.
+                
+                // Check for exit code 2 and add to tool_results
+                for (_, (exit_code, output)) in &hook_results {
+                    if *exit_code == 2 {
+                        tool_results.push(ToolUseResult {
+                            tool_use_id: tool.id.clone(),
+                            content: vec![ToolUseResultBlock::Text(format!("PreToolHook blocked the tool execution: {}", output))],
+                            status: ToolResultStatus::Error,
+                        });
+                    }
+                }
+            }
+        }
+
+        // If we have any hook validation errors, return them immediately to the model
+        if !tool_results.is_empty() {
+            debug!(?tool_results, "Error found in PreToolUse hooks");
+            for tool_result in &tool_results {
+                for block in &tool_result.content {
+                    if let ToolUseResultBlock::Text(content) = block {
+                        queue!(
+                            self.stderr,
+                            style::Print("\n"),
+                            style::SetForegroundColor(Color::Red),
+                            style::Print(format!("{}\n", content)),
+                            style::SetForegroundColor(Color::Reset),
+                        )?;
+                    }
+                }
+            }
+
+            self.conversation.add_tool_results(tool_results);
+            return Ok(ChatState::HandleResponseStream(
+                self.conversation
+                    .as_sendable_conversation_state(os, &mut self.stderr, false)
+                    .await?,
+            ));
+        }
+
         self.tool_uses = queued_tools;
         self.pending_tool_index = Some(0);
         self.tool_turn_start_time = Some(Instant::now());
+        
         Ok(ChatState::ExecuteTools)
     }
 
@@ -3784,6 +3888,244 @@ mod tests {
         .spawn(&mut os)
         .await
         .unwrap();
+    }
+
+    // Integration test for PreToolUse hook functionality.
+    // 
+    // In this integration test we create a preToolUse hook that logs tool info into a file 
+    // and we run fs_read and verify the log is generated with the correct ToolContext data.
+    #[tokio::test]
+    async fn test_tool_hook_integration() {
+        use crate::cli::agent::hook::{Hook, HookTrigger};
+        use std::collections::HashMap;
+
+        let mut os = Os::new().await.unwrap();
+        os.client.set_mock_output(serde_json::json!([
+            [
+                "I'll read that file for you",
+                {
+                    "tool_use_id": "1",
+                    "name": "fs_read",
+                    "args": {
+                        "operations": [
+                            {
+                                "mode": "Line",
+                                "path": "/test.txt",
+                                "start_line": 1,
+                                "end_line": 3
+                            }
+                        ]
+                    }
+                }
+            ],
+            [
+                "Here's the file content!",
+            ],
+        ]));
+
+        // Create test file
+        os.fs.write("/test.txt", "line1\nline2\nline3\n").await.unwrap();
+
+        // Create agent with PreToolUse and PostToolUse hooks
+        let mut agents = Agents::default();
+        let mut hooks = HashMap::new();
+        
+        // Get the real path in the temp directory for the hooks to write to
+        let pre_hook_log_path = os.fs.chroot_path_str("/pre-hook-test.log");
+        let post_hook_log_path = os.fs.chroot_path_str("/post-hook-test.log");
+        let pre_hook_command = format!("cat > {}", pre_hook_log_path);
+        let post_hook_command = format!("cat > {}", post_hook_log_path);
+        
+        hooks.insert(HookTrigger::PreToolUse, vec![Hook {
+            command: pre_hook_command,
+            timeout_ms: 5000,
+            max_output_size: 1024,
+            cache_ttl_seconds: 0,
+            matcher: Some("fs_*".to_string()), // Match fs_read, fs_write, etc.
+            source: crate::cli::agent::hook::Source::Agent,
+        }]);
+
+        hooks.insert(HookTrigger::PostToolUse, vec![Hook {
+            command: post_hook_command,
+            timeout_ms: 5000,
+            max_output_size: 1024,
+            cache_ttl_seconds: 0,
+            matcher: Some("fs_*".to_string()), // Match fs_read, fs_write, etc.
+            source: crate::cli::agent::hook::Source::Agent,
+        }]);
+
+        let agent = Agent {
+            name: "TestAgent".to_string(),
+            hooks,
+            ..Default::default()
+        };
+        agents.agents.insert("TestAgent".to_string(), agent);
+        agents.switch("TestAgent").expect("Failed to switch agent");
+
+        let tool_manager = ToolManager::default();
+        let tool_config = serde_json::from_str::<HashMap<String, ToolSpec>>(include_str!("tools/tool_index.json"))
+            .expect("Tools failed to load");
+
+        // Test that PreToolUse hook runs
+        ChatSession::new(
+            &mut os,
+            std::io::stdout(),
+            std::io::stderr(),
+            "fake_conv_id",
+            agents,
+            None, // No initial input
+            InputSource::new_mock(vec![
+                "read /test.txt".to_string(),
+                "y".to_string(), // Accept tool execution
+                "exit".to_string(),
+            ]),
+            false,
+            || Some(80),
+            tool_manager,
+            None,
+            tool_config,
+            true,
+            false,
+            None,
+        )
+        .await
+        .unwrap()
+        .spawn(&mut os)
+        .await
+        .unwrap();
+
+        // Verify the PreToolUse hook was called
+        if let Ok(pre_log_content) = os.fs.read_to_string("/pre-hook-test.log").await {
+            let pre_hook_data: serde_json::Value = serde_json::from_str(&pre_log_content)
+                .expect("PreToolUse hook output should be valid JSON");
+            
+            assert_eq!(pre_hook_data["hook_event_name"], "preToolUse");
+            assert_eq!(pre_hook_data["tool_name"], "fs_read");
+            assert_eq!(pre_hook_data["tool_response"], serde_json::Value::Null);
+            
+            let tool_input = &pre_hook_data["tool_input"];
+            assert!(tool_input["operations"].is_array());
+            
+            println!("✓ PreToolUse hook validation passed: {}", pre_log_content);
+        } else {
+            panic!("PreToolUse hook log file not found - hook may not have been called");
+        }
+
+        // Verify the PostToolUse hook was called
+        if let Ok(post_log_content) = os.fs.read_to_string("/post-hook-test.log").await {
+            let post_hook_data: serde_json::Value = serde_json::from_str(&post_log_content)
+                .expect("PostToolUse hook output should be valid JSON");
+            
+            assert_eq!(post_hook_data["hook_event_name"], "postToolUse");
+            assert_eq!(post_hook_data["tool_name"], "fs_read");
+            
+            // Validate tool_response structure for successful execution
+            let tool_response = &post_hook_data["tool_response"];
+            assert_eq!(tool_response["success"], true);
+            assert!(tool_response["result"].is_array());
+            
+            let result_blocks = tool_response["result"].as_array().unwrap();
+            assert!(!result_blocks.is_empty());
+            let content = result_blocks[0].as_str().unwrap();
+            assert!(content.contains("line1\nline2\nline3"));
+            
+            println!("✓ PostToolUse hook validation passed: {}", post_log_content);
+        } else {
+            panic!("PostToolUse hook log file not found - hook may not have been called");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_pretool_hook_blocking_integration() {
+        use crate::cli::agent::hook::{Hook, HookTrigger};
+        use std::collections::HashMap;
+
+        let mut os = Os::new().await.unwrap();
+        
+        // Create a test file to read
+        os.fs.write("/sensitive.txt", "classified information").await.unwrap();
+        
+        // Mock LLM responses: first tries fs_read, gets blocked, then responds to error
+        os.client.set_mock_output(serde_json::json!([
+            [
+                "I'll read that file for you",
+                {
+                    "tool_use_id": "1", 
+                    "name": "fs_read",
+                    "args": {
+                        "operations": [
+                            {
+                                "mode": "Line",
+                                "path": "/sensitive.txt"
+                            }
+                        ]
+                    }
+                }
+            ],
+            [
+                "I understand the security policy blocked access to that file.",
+            ],
+        ]));
+
+        // Create agent with blocking PreToolUse hook
+        let mut agents = Agents::default();
+        let mut hooks = HashMap::new();
+        
+        // Create a hook that blocks fs_read of sensitive files with exit code 2
+        #[cfg(unix)]
+        let hook_command = "echo 'Security policy violation: cannot read sensitive files' >&2; exit 2";
+        #[cfg(windows)]
+        let hook_command = "echo Security policy violation: cannot read sensitive files 1>&2 & exit /b 2";
+        
+        hooks.insert(HookTrigger::PreToolUse, vec![Hook {
+            command: hook_command.to_string(),
+            timeout_ms: 5000,
+            max_output_size: 1024,
+            cache_ttl_seconds: 0,
+            matcher: Some("fs_read".to_string()),
+            source: crate::cli::agent::hook::Source::Agent,
+        }]);
+
+        let agent = Agent {
+            name: "SecurityAgent".to_string(),
+            hooks,
+            ..Default::default()
+        };
+        agents.agents.insert("SecurityAgent".to_string(), agent);
+        agents.switch("SecurityAgent").expect("Failed to switch agent");
+
+        let tool_manager = ToolManager::default();
+        let tool_config = serde_json::from_str::<HashMap<String, ToolSpec>>(include_str!("tools/tool_index.json"))
+            .expect("Tools failed to load");
+
+        // Run chat session - hook should block tool execution
+        let result = ChatSession::new(
+            &mut os,
+            std::io::stdout(),
+            std::io::stderr(),
+            "test_conv_id",
+            agents,
+            None,
+            InputSource::new_mock(vec![
+                "read /sensitive.txt".to_string(),
+                "exit".to_string(),
+            ]),
+            false,
+            || Some(80),
+            tool_manager,
+            None,
+            tool_config,
+            true,
+            false,
+            None,
+        )
+        .await
+        .unwrap()
+        .spawn(&mut os)
+        .await;
+
+        // The session should complete successfully (hook blocks tool but doesn't crash)
+        assert!(result.is_ok(), "Chat session should complete successfully even when hook blocks tool");
     }
 
     #[test]

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -2445,7 +2445,10 @@ impl ChatSession {
                     };
                     
                     let tool_context = ToolContext {
-                        tool_name: tool.name.clone(),
+                        tool_name: match &tool.tool {
+                            Tool::Custom(custom_tool) => custom_tool.namespaced_tool_name(), // for MCP tool, pass MCP name to the hook
+                            _ => tool.name.clone(),
+                        },
                         tool_input: tool.tool_input.clone(),
                         tool_response: Some(tool_response),
                     };
@@ -2909,7 +2912,10 @@ impl ChatSession {
         if let Some(cm) = self.conversation.context_manager.as_mut() {
             for tool in &queued_tools {
                 let tool_context = ToolContext {
-                    tool_name: tool.name.clone(),
+                    tool_name: match &tool.tool {
+                        Tool::Custom(custom_tool) => custom_tool.namespaced_tool_name(), // for MCP tool, pass MCP name to the hook
+                        _ => tool.name.clone(),
+                    },
                     tool_input: tool.tool_input.clone(),
                     tool_response: None,
                 };

--- a/crates/chat-cli/src/cli/chat/tool_manager.rs
+++ b/crates/chat-cli/src/cli/chat/tool_manager.rs
@@ -99,8 +99,7 @@ use crate::util::MCP_SERVER_TOOL_DELIMITER;
 use crate::util::directories::home_dir;
 
 const NAMESPACE_DELIMITER: &str = "___";
-// This applies for both mcp server and tool name since in the end the tool name as seen by the
-// model is just {server_name}{NAMESPACE_DELIMITER}{tool_name}
+// This applies for both mcp server and tool name
 const VALID_TOOL_NAME: &str = "^[a-zA-Z][a-zA-Z0-9_]*$";
 const SPINNER_CHARS: [char; 10] = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 
@@ -873,7 +872,7 @@ impl ToolManager {
             "thinking" => Tool::Thinking(serde_json::from_value::<Thinking>(value.args).map_err(map_err)?),
             "knowledge" => Tool::Knowledge(serde_json::from_value::<Knowledge>(value.args).map_err(map_err)?),
             "todo_list" => Tool::Todo(serde_json::from_value::<TodoList>(value.args).map_err(map_err)?),
-            // Note that this name is namespaced with server_name{DELIMITER}tool_name
+            // Note that this name is NO LONGER namespaced with server_name{DELIMITER}tool_name
             name => {
                 // Note: tn_map also has tools that underwent no transformation. In otherwords, if
                 // it is a valid tool name, we should get a hit.

--- a/crates/chat-cli/src/cli/chat/tools/custom_tool.rs
+++ b/crates/chat-cli/src/cli/chat/tools/custom_tool.rs
@@ -95,6 +95,11 @@ pub struct CustomTool {
 }
 
 impl CustomTool {
+    /// Returns the full tool name with server prefix in the format @server_name/tool_name
+    pub fn namespaced_tool_name(&self) -> String {
+        format!("@{}{}{}", self.server_name, MCP_SERVER_TOOL_DELIMITER, self.name)
+    }
+
     pub async fn invoke(&self, _os: &Os, _updates: &mut impl Write) -> Result<InvokeOutput> {
         let params = CallToolRequestParam {
             name: Cow::from(self.name.clone()),
@@ -156,7 +161,6 @@ impl CustomTool {
     }
 
     pub fn eval_perm(&self, _os: &Os, agent: &Agent) -> PermissionEvalResult {
-        let Self { name: tool_name, .. } = self;
         let server_name = &self.server_name;
 
         let server_pattern = format!("@{server_name}");
@@ -164,7 +168,7 @@ impl CustomTool {
             return PermissionEvalResult::Allow;
         }
 
-        let tool_pattern = format!("@{server_name}{MCP_SERVER_TOOL_DELIMITER}{tool_name}");
+        let tool_pattern = self.namespaced_tool_name();
         if matches_any_pattern(&agent.allowed_tools, &tool_pattern) {
             return PermissionEvalResult::Allow;
         }

--- a/crates/chat-cli/src/cli/chat/tools/introspect.rs
+++ b/crates/chat-cli/src/cli/chat/tools/introspect.rs
@@ -71,6 +71,9 @@ impl Introspect {
         documentation.push_str("\n\n--- docs/todo-lists.md ---\n");
         documentation.push_str(include_str!("../../../../../../docs/todo-lists.md"));
 
+        documentation.push_str("\n\n--- docs/hooks.md ---\n");
+        documentation.push_str(include_str!("../../../../../../docs/hooks.md"));
+
         documentation.push_str("\n\n--- changelog (from feed.json) ---\n");
         // Include recent changelog entries from feed.json
         let feed = crate::cli::feed::Feed::load();
@@ -120,6 +123,8 @@ impl Introspect {
         );
         documentation
             .push_str("• Todo Lists: https://github.com/aws/amazon-q-developer-cli/blob/main/docs/todo-lists.md\n");
+        documentation
+            .push_str("• Hooks: https://github.com/aws/amazon-q-developer-cli/blob/main/docs/hooks.md\n");
         documentation
             .push_str("• Contributing: https://github.com/aws/amazon-q-developer-cli/blob/main/CONTRIBUTING.md\n");
 

--- a/crates/chat-cli/src/cli/chat/tools/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/mod.rs
@@ -271,6 +271,7 @@ pub struct QueuedTool {
     pub name: String,
     pub accepted: bool,
     pub tool: Tool,
+    pub tool_input: serde_json::Value,
 }
 
 /// The schema specification describing a tool's fields.

--- a/docs/agent-format.md
+++ b/docs/agent-format.md
@@ -256,7 +256,9 @@ Resources can include:
 
 ## Hooks Field
 
-The `hooks` field defines commands to run at specific trigger points. The output of these commands is added to the agent's context.
+The `hooks` field defines commands to run at specific trigger points during agent lifecycle and tool execution.
+
+For detailed information about hook behavior, input/output formats, and examples, see the [Hooks documentation](hooks.md).
 
 ```json
 {
@@ -270,6 +272,22 @@ The `hooks` field defines commands to run at specific trigger points. The output
       {
         "command": "ls -la"
       }
+    ],
+    "preToolUse": [
+      {
+        "matcher": "execute_bash",
+        "command": "{ echo \"$(date) - Bash command:\"; cat; echo; } >> /tmp/bash_audit_log"
+      },
+      {
+        "matcher": "use_aws",
+        "command": "{ echo \"$(date) - AWS CLI call:\"; cat; echo; } >> /tmp/aws_audit_log"
+      }
+    ],
+    "postToolUse": [
+      {
+        "matcher": "fs_write",
+        "command": "cargo fmt --all"
+      }
     ]
   }
 }
@@ -277,10 +295,13 @@ The `hooks` field defines commands to run at specific trigger points. The output
 
 Each hook is defined with:
 - `command` (required): The command to execute
+- `matcher` (optional): Pattern to match tool names for `preToolUse` and `postToolUse` hooks. See [built-in tools documentation](./built-in-tools.md) for available tool names.
 
 Available hook triggers:
-- `agentSpawn`: Triggered when the agent is initialized
-- `userPromptSubmit`: Triggered when the user submits a message
+- `agentSpawn`: Triggered when the agent is initialized.
+- `userPromptSubmit`: Triggered when the user submits a message.
+- `preToolUse`: Triggered before a tool is executed. Can block the tool use.
+- `postToolUse`: Triggered after a tool is executed.
 
 ## UseLegacyMcpJson Field
 

--- a/docs/agent-format.md
+++ b/docs/agent-format.md
@@ -263,12 +263,12 @@ The `hooks` field defines commands to run at specific trigger points. The output
   "hooks": {
     "agentSpawn": [
       {
-        "command": "git status",
+        "command": "git status"
       }
     ],
     "userPromptSubmit": [
       {
-        "command": "ls -la",
+        "command": "ls -la"
       }
     ]
   }

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -31,8 +31,9 @@ For tool-related hooks, additional fields are included:
 ## Tool Matching
 
 Use the `matcher` field to specify which tools the hook applies to:
-- `"fs_write"` - Exact match
-- `"fs_*"` - Wildcard pattern
+- `"fs_write"` - Exact match for built-in tools
+- `"fs_*"` - Wildcard pattern for built-in tools
+- `"query"` - Exact match for MCP tools (e.g., query tool from postgres MCP, uses base tool name only)
 - No matcher - Applies to all tools
 
 ## Hook Types

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,137 @@
+# Hooks
+
+Hooks allow you to execute custom commands at specific points during agent lifecycle and tool execution. This enables security validation, logging, formatting, context gathering, and other custom behaviors.
+
+## Defining Hooks
+
+Hooks are defined in the agent configuration file. See the [agent format documentation](agent-format.md#hooks-field) for the complete syntax and examples.
+
+## Hook Input (STDIN)
+
+Hooks receive JSON input via STDIN containing context about the hook execution:
+
+```json
+{
+  "hook_event_name": "agentSpawn",
+  "cwd": "/current/working/directory"
+}
+```
+
+For tool-related hooks, additional fields are included:
+- `tool_name`: Name of the tool being executed
+- `tool_input`: Tool-specific parameters (see individual tool documentation)
+- `tool_response`: Tool execution results (PostToolUse only)
+
+## Hook Output
+
+- **Exit code 0**: Hook succeeded. STDOUT is captured but not shown to user.
+- **Exit code 2**: (PreToolUse only) Block tool execution. STDERR is returned to the LLM.
+- **Other exit codes**: Hook failed. STDERR is shown as warning to user.
+
+## Tool Matching
+
+Use the `matcher` field to specify which tools the hook applies to:
+- `"fs_write"` - Exact match
+- `"fs_*"` - Wildcard pattern
+- No matcher - Applies to all tools
+
+## Hook Types
+
+### AgentSpawn
+
+Runs when agent is activated. No tool context provided.
+
+**Input JSON:**
+```json
+{
+  "hook_event_name": "agentSpawn",
+  "cwd": "/current/working/directory"
+}
+```
+
+**Exit Code Behavior:**
+- **0**: Hook succeeded, STDOUT is added to agent's context
+- **Other**: Show STDERR warning to user
+
+### UserPromptSubmit
+
+Runs when user submits a prompt. Output is added to conversation context.
+
+**Input JSON:**
+```json
+{
+  "hook_event_name": "userPromptSubmit",
+  "cwd": "/current/working/directory",
+  "prompt": "user's input prompt"
+}
+```
+
+**Exit Code Behavior:**
+- **0**: Hook succeeded, STDOUT is added to agent's context
+- **Other**: Show STDERR warning to user
+
+### PreToolUse
+
+Runs before tool execution. Can validate and block tool usage.
+
+**Input JSON:**
+```json
+{
+  "hook_event_name": "preToolUse",
+  "cwd": "/current/working/directory",
+  "tool_name": "fs_read",
+  "tool_input": {
+    "operations": [
+      {
+        "mode": "Line",
+        "path": "/current/working/directory/docs/hooks.md"
+      }
+    ]
+  }
+}
+```
+
+**Exit Code Behavior:**
+- **0**: Allow tool execution.
+- **2**: Block tool execution, return STDERR to LLM.
+- **Other**: Show STDERR warning to user, allow tool execution.
+
+### PostToolUse
+
+Runs after tool execution with access to tool results.
+
+**Input JSON:**
+```json
+{
+  "hook_event_name": "postToolUse",
+  "cwd": "/current/working/directory",
+  "tool_name": "fs_read",
+  "tool_input": {
+    "operations": [
+      {
+        "mode": "Line",
+        "path": "/current/working/directory/docs/hooks.md"
+      }
+    ]
+  },
+  "tool_response": {
+    "success": true,
+    "result": ["# Hooks\n\nHooks allow you to execute..."]
+  }
+}
+```
+
+**Exit Code Behavior:**
+- **0**: Hook succeeded.
+- **Other**: Show STDERR warning to user. Tool already ran.
+
+## Timeout
+
+Default timeout is 30 seconds (30,000ms). Configure with `timeout_ms` field.
+
+## Caching
+
+Successfull hook results are cached based on `cache_ttl_seconds`:
+- `0`: No caching (default)
+- `> 0`: Cache successful results for specified seconds
+- AgentSpawn hooks are never cached

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -6,9 +6,9 @@ Hooks allow you to execute custom commands at specific points during agent lifec
 
 Hooks are defined in the agent configuration file. See the [agent format documentation](agent-format.md#hooks-field) for the complete syntax and examples.
 
-## Hook Input (STDIN)
+## Hook Event
 
-Hooks receive JSON input via STDIN containing context about the hook execution:
+Hooks receive hook event in JSON format via STDIN:
 
 ```json
 {
@@ -31,10 +31,17 @@ For tool-related hooks, additional fields are included:
 ## Tool Matching
 
 Use the `matcher` field to specify which tools the hook applies to:
+
+### Examples
 - `"fs_write"` - Exact match for built-in tools
 - `"fs_*"` - Wildcard pattern for built-in tools
-- `"query"` - Exact match for MCP tools (e.g., query tool from postgres MCP, uses base tool name only)
+- `"@git"` - All tools from git MCP server
+- `"@git/status"` - Specific tool from git MCP server
+- `"*"` - All tools (built-in and MCP)
+- `"@builtin"` - All built-in tools only
 - No matcher - Applies to all tools
+
+For complete tool reference format, see [agent format documentation](agent-format.md#tools-field).
 
 ## Hook Types
 
@@ -42,7 +49,7 @@ Use the `matcher` field to specify which tools the hook applies to:
 
 Runs when agent is activated. No tool context provided.
 
-**Input JSON:**
+**Hook Event**
 ```json
 {
   "hook_event_name": "agentSpawn",
@@ -58,7 +65,7 @@ Runs when agent is activated. No tool context provided.
 
 Runs when user submits a prompt. Output is added to conversation context.
 
-**Input JSON:**
+**Hook Event**
 ```json
 {
   "hook_event_name": "userPromptSubmit",
@@ -75,7 +82,7 @@ Runs when user submits a prompt. Output is added to conversation context.
 
 Runs before tool execution. Can validate and block tool usage.
 
-**Input JSON:**
+**Hook Event**
 ```json
 {
   "hook_event_name": "preToolUse",
@@ -101,7 +108,7 @@ Runs before tool execution. Can validate and block tool usage.
 
 Runs after tool execution with access to tool results.
 
-**Input JSON:**
+**Hook Event**
 ```json
 {
   "hook_event_name": "postToolUse",
@@ -125,6 +132,22 @@ Runs after tool execution with access to tool results.
 **Exit Code Behavior:**
 - **0**: Hook succeeded.
 - **Other**: Show STDERR warning to user. Tool already ran.
+
+### MCP Example
+
+For MCP tools, the tool name includes the full namespaced format including the MCP Server name:
+
+**Hook Event**
+```json
+{
+  "hook_event_name": "preToolUse",
+  "cwd": "/current/working/directory",
+  "tool_name": "@postgres/query",
+  "tool_input": {
+    "sql": "SELECT * FROM orders LIMIT 10;"
+  }
+}
+```
 
 ## Timeout
 


### PR DESCRIPTION
    feat: Add hook support for preToolUse and postToolUse
    
    With this change, customer can define arbitrary command to be run
    before and after tool use. Example definition:
    
    ```
      "hooks": {
        "preToolUse": [
          {
            "matcher": "execute_bash",
            "command": "cat >> /tmp/bash_audit_log && echo >> /tmp/bash_audit_log"
          }
        ],
        "postToolUse": [
          {
            "matcher": "fs_write",
            "command": "cargo fmt --all"
          }
        ]
      }
    ```
    
    Hook command receives input from STDIN in JSON format. Hook command is run as a
    separate process. It can return exit code and write to stdout / stderr.
    
    Overall life cycle of a tool call:
    system-level tool validation -> preToolUse -> user prompt for approving tool -> running tool -> postToolUse
    
    Hook input
    - hook_event_name
    - cwd
    - tool_name
    - tool_input
    - tool_response
    
    Hook output handling
    preToolUse
    - Exit code 0: nothing.
    - Exit code 2: tool run is blocked. the relevant context including hook stderr is sent back to LLM.
    - Other code: print stderr to screen. does NOT block tool.
    postToolUse:
    - Exit code 0: nothing.
    - Other code: print stderr to screen.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
