### PR TITLE
chore(mcp): adds temp message to still loading section of /tools

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/tools.rs
+++ b/crates/chat-cli/src/cli/chat/cli/tools.rs
@@ -147,7 +147,11 @@ impl ToolsArgs {
             queue!(
                 session.stderr,
                 style::SetAttribute(Attribute::Bold),
-                style::Print("Servers still loading"),
+                style::Print("Servers loading (Some of these might need auth. See "),
+                style::SetForegroundColor(Color::Green),
+                style::Print("/mcp"),
+                style::SetForegroundColor(Color::Reset),
+                style::Print(" for details)"),
                 style::SetAttribute(Attribute::Reset),
                 style::Print("\n"),
                 style::Print("▔".repeat(terminal_width)),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
As titled. This is needed to make it more obvious to users that actions need to be taken to authenticate. 
The real solution would be a bit more involved. This is here to bridge the gap until that lands. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
