### PR TITLE
feat: add --no-banner option to disable ASCII logo display

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -227,6 +227,9 @@ pub struct ChatArgs {
     /// Control line wrapping behavior (default: auto-detect)
     #[arg(short = 'w', long, value_enum)]
     pub wrap: Option<WrapMode>,
+    /// Disable the ASCII banner/logo display
+    #[arg(long)]
+    pub no_banner: bool,
 }
 
 impl ChatArgs {
@@ -430,6 +433,7 @@ impl ChatArgs {
             !self.no_interactive,
             mcp_enabled,
             self.wrap,
+            self.no_banner,
         )
         .await?
         .spawn(os)
@@ -644,6 +648,7 @@ pub struct ChatSession {
     inner: Option<ChatState>,
     ctrlc_rx: broadcast::Receiver<()>,
     wrap: Option<WrapMode>,
+    no_banner: bool,
 }
 
 impl ChatSession {
@@ -664,6 +669,7 @@ impl ChatSession {
         interactive: bool,
         mcp_enabled: bool,
         wrap: Option<WrapMode>,
+        no_banner: bool,
     ) -> Result<Self> {
         // Reload prior conversation
         let mut existing_conversation = false;
@@ -756,6 +762,7 @@ impl ChatSession {
             inner: Some(ChatState::default()),
             ctrlc_rx,
             wrap,
+            no_banner,
         })
     }
 
@@ -1236,11 +1243,12 @@ impl ChatSession {
 
     async fn spawn(&mut self, os: &mut Os) -> Result<()> {
         let is_small_screen = self.terminal_width() < GREETING_BREAK_POINT;
-        if os
-            .database
-            .settings
-            .get_bool(Setting::ChatGreetingEnabled)
-            .unwrap_or(true)
+        if !self.no_banner
+            && os
+                .database
+                .settings
+                .get_bool(Setting::ChatGreetingEnabled)
+                .unwrap_or(true)
         {
             let welcome_text = match self.existing_conversation {
                 true => RESUME_TEXT,
@@ -3409,6 +3417,7 @@ mod tests {
             true,
             false,
             None,
+            false,
         )
         .await
         .unwrap()
@@ -3552,6 +3561,7 @@ mod tests {
             true,
             false,
             None,
+            false,
         )
         .await
         .unwrap()
@@ -3650,6 +3660,7 @@ mod tests {
             true,
             false,
             None,
+            false,
         )
         .await
         .unwrap()
@@ -3726,6 +3737,7 @@ mod tests {
             true,
             false,
             None,
+            false,
         )
         .await
         .unwrap()
@@ -3778,6 +3790,7 @@ mod tests {
             true,
             false,
             None,
+            false,
         )
         .await
         .unwrap()

--- a/crates/chat-cli/src/cli/mod.rs
+++ b/crates/chat-cli/src/cli/mod.rs
@@ -382,6 +382,7 @@ mod test {
                 trust_tools: None,
                 no_interactive: false,
                 wrap: None,
+                no_banner: false,
             })),
             verbose: 2,
             help_all: false,
@@ -422,6 +423,7 @@ mod test {
                 trust_tools: None,
                 no_interactive: false,
                 wrap: None,
+                no_banner: false,
             })
         );
     }
@@ -439,6 +441,7 @@ mod test {
                 trust_tools: None,
                 no_interactive: false,
                 wrap: None,
+                no_banner: false,
             })
         );
     }
@@ -456,6 +459,7 @@ mod test {
                 trust_tools: None,
                 no_interactive: false,
                 wrap: None,
+                no_banner: false,
             })
         );
     }
@@ -473,6 +477,7 @@ mod test {
                 trust_tools: None,
                 no_interactive: true,
                 wrap: None,
+                no_banner: false,
             })
         );
         assert_parse!(
@@ -486,6 +491,7 @@ mod test {
                 trust_tools: None,
                 no_interactive: true,
                 wrap: None,
+                no_banner: false,
             })
         );
     }
@@ -503,6 +509,7 @@ mod test {
                 trust_tools: None,
                 no_interactive: false,
                 wrap: None,
+                no_banner: false,
             })
         );
     }
@@ -520,6 +527,7 @@ mod test {
                 trust_tools: Some(vec!["".to_string()]),
                 no_interactive: false,
                 wrap: None,
+                no_banner: false,
             })
         );
     }
@@ -537,6 +545,7 @@ mod test {
                 trust_tools: Some(vec!["fs_read".to_string(), "fs_write".to_string()]),
                 no_interactive: false,
                 wrap: None,
+                no_banner: false,
             })
         );
     }
@@ -554,6 +563,7 @@ mod test {
                 trust_tools: None,
                 no_interactive: false,
                 wrap: Some(Never),
+                no_banner: false,
             })
         );
         assert_parse!(
@@ -567,6 +577,7 @@ mod test {
                 trust_tools: None,
                 no_interactive: false,
                 wrap: Some(Always),
+                no_banner: false,
             })
         );
         assert_parse!(
@@ -580,6 +591,25 @@ mod test {
                 trust_tools: None,
                 no_interactive: false,
                 wrap: Some(Auto),
+                no_banner: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_chat_with_no_banner() {
+        assert_parse!(
+            ["chat", "--no-banner"],
+            RootSubcommand::Chat(ChatArgs {
+                resume: false,
+                input: None,
+                agent: None,
+                model: None,
+                trust_all_tools: false,
+                trust_tools: None,
+                no_interactive: false,
+                wrap: None,
+                no_banner: true,
             })
         );
     }


### PR DESCRIPTION
This PR allows us to disable the Q ASCII banner on startup, which allows a lot of user/tool flows to happen without messing up the output.

Issue: #2074

*Description of changes:*
feat: add --no-banner option to disable ASCII logo display

- Add --no-banner CLI flag to ChatArgs
- Update ChatSession to respect banner preference
- Modify banner display logic to check both CLI flag and settings
- Update all call sites and tests for compatibility
- Maintain backward compatibility with existing behavior

Usage: `q chat --no-banner`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
