### PR TITLE
Fix q_cli_default agent override not loading custom resources

### DIFF
--- a/docs/default-agent-behavior.md
+++ b/docs/default-agent-behavior.md
@@ -95,11 +95,27 @@ q chat --agent specialized-agent
 ```
 
 ### Create a Custom Default
-You can create your own "default" agent by placing an agent file with the name `q_cli_default` in either:
-- `.amazonq/cli-agents/` (local)
+You can create your own "default" agent by placing an agent file with the name `q_cli_default.json` in either:
+- `.amazonq/cli-agents/` (local workspace)
 - `~/.aws/amazonq/cli-agents/` (global)
 
-This will override the built-in default agent configuration.
+This will completely override the built-in default agent configuration, including custom resources, tools, and settings.
+
+**Example:**
+```json
+{
+  "name": "q_cli_default",
+  "description": "My workspace default agent",
+  "resources": [
+    "file://README.md",
+    "file://.project-rules.md"
+  ],
+  "tools": ["*"],
+  "allowedTools": ["fs_read"]
+}
+```
+
+Local workspace configurations take precedence over global ones. This is useful for teams that want to automatically load project-specific context and rules when anyone runs `q chat` in their workspace.
 
 ## Best Practices
 


### PR DESCRIPTION
## Description

Fixes #2922 

This PR fixes the `q_cli_default` agent override feature that was not working as documented. The issue was that the code was directly using `Agent::default()` instead of checking for custom `q_cli_default.json` files.

## Changes Made

### Code Fix
- **File**: `crates/chat-cli/src/cli/agent/mod.rs` (lines ~689-693)
- **Change**: Added `Agent::get_agent_by_name(os, DEFAULT_AGENT_NAME)` check before falling back to `Agent::default()`
- **Impact**: Now properly loads custom `q_cli_default.json` files from local/global directories

### Documentation Fix  
- **File**: `docs/default-agent-behavior.md`
- **Change**: Added missing `.json` extension and clarified behavior
- **Impact**: Developers now know the correct filename format

### Test Coverage
- **File**: `crates/chat-cli/src/cli/agent/mod.rs`
- **Change**: Added comprehensive test `test_q_cli_default_override`
- **Impact**: Verifies fix works and prevents regression

## Testing

The new test:
- ✅ **Fails without the fix** (uses built-in default)
- ✅ **Passes with the fix** (loads custom agent)
- ✅ **Uses proper patterns** (no hardcoded paths/values)

## Use Case

This enables teams to automatically load project-specific context when anyone runs `q chat` in their workspace, improving developer experience and ensuring consistent AI assistance across the team.