### PR TITLE
feat(use_aws): respect AWS_PROFILE environment variable and add agent profile configuration (#2088)

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -2954,7 +2954,7 @@ impl ChatSession {
 
         tool_use
             .tool
-            .queue_description(os, &mut self.stdout)
+            .queue_description(os, &mut self.stdout, self.conversation.agents.get_active())
             .await
             .map_err(|e| ChatError::Custom(format!("failed to print tool, `{}`: {}", tool_use.name, e).into()))?;
 

--- a/crates/chat-cli/src/cli/chat/tools/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/mod.rs
@@ -137,7 +137,7 @@ impl Tool {
             Tool::FsRead(fs_read) => fs_read.invoke(os, stdout).await,
             Tool::FsWrite(fs_write) => fs_write.invoke(os, stdout, line_tracker).await,
             Tool::ExecuteCommand(execute_command) => execute_command.invoke(os, stdout).await,
-            Tool::UseAws(use_aws) => use_aws.invoke(os, stdout).await,
+            Tool::UseAws(use_aws) => use_aws.invoke(os, stdout, agent).await,
             Tool::Custom(custom_tool) => custom_tool.invoke(os, stdout).await,
             Tool::GhIssue(gh_issue) => gh_issue.invoke(os, stdout).await,
             Tool::Introspect(introspect) => introspect.invoke(os, stdout).await,
@@ -148,12 +148,12 @@ impl Tool {
     }
 
     /// Queues up a tool's intention in a human readable format
-    pub async fn queue_description(&self, os: &Os, output: &mut impl Write) -> Result<()> {
+    pub async fn queue_description(&self, os: &Os, output: &mut impl Write, agent: Option<&crate::cli::agent::Agent>) -> Result<()> {
         match self {
             Tool::FsRead(fs_read) => fs_read.queue_description(os, output).await,
             Tool::FsWrite(fs_write) => fs_write.queue_description(os, output),
             Tool::ExecuteCommand(execute_command) => execute_command.queue_description(output),
-            Tool::UseAws(use_aws) => use_aws.queue_description(output),
+            Tool::UseAws(use_aws) => use_aws.queue_description(output, agent),
             Tool::Custom(custom_tool) => custom_tool.queue_description(output),
             Tool::GhIssue(gh_issue) => gh_issue.queue_description(output),
             Tool::Introspect(_) => Introspect::queue_description(output),


### PR DESCRIPTION
# Support AWS_PROFILE environment variable in use_aws tool

## Description

This PR implements support for the `AWS_PROFILE` environment variable in the `use_aws` tool to align with AWS CLI credential precedence behavior.

Closes #2088

## Background

The `use_aws` tool currently ignores the `AWS_PROFILE` environment variable and always defaults to the "default" profile, which breaks expected AWS CLI behavior consistency. This is particularly problematic for users with SSO authentication workflows who rely on environment variables for profile switching.

## Changes

This implementation follows AWS CLI credential precedence:
1. Explicit `profile_name` parameter (highest priority)
2. `AWS_PROFILE` environment variable 
3. "default" profile (lowest priority)

### Modified Files
- Updated profile resolution logic to check `AWS_PROFILE` environment variable before defaulting to "default"
- Maintained backward compatibility with existing explicit `profile_name` parameter usage
- Added appropriate error handling for invalid profile names

## Testing

- [x] Verified that explicit `profile_name` parameter still takes precedence
- [x] Confirmed `AWS_PROFILE` environment variable is respected when no explicit profile is specified
- [x] Ensured fallback to "default" profile works when neither is set
- [x] Tested with SSO-configured profiles
- [x] Validated behavior matches standard AWS CLI precedence

## Agent Configuration Examples

```json
{
  "$schema": "https://raw.githubusercontent.com/aws/amazon-q-developer-cli/refs/heads/main/schemas/agent-v1.json",
  "name": "test-profile",
  "description": "AWS agent with test-profile profile as default",
  "tools": ["*"],
  "allowedTools": ["use_aws", "fs_read", "fs_write", "execute_bash"],
  "toolsSettings": {
    "use_aws": {
      "profile_name": "test-profile"
    }
  }
}
```

## Testing Result

### Before (Issue) 
**Problem: AWS_PROFILE environment variable ignored**

<img width="1053" height="455" alt="스크린샷 2025-09-18 오전 9 56 30" src="https://github.com/user-attachments/assets/37d62f4d-fab4-4e43-8b46-56c1338a6390" />

### After (Fixed)
**Solution: AWS_PROFILE environment variable respected**

<img width="855" height="690" alt="스크린샷 2025-09-18 오전 9 55 37" src="https://github.com/user-attachments/assets/fe63eec6-9d2b-496f-b58d-9b45ce17bc10" />

## Breaking Changes

None. This change is fully backward compatible.

## Impact

- ✅ Improves consistency with AWS CLI behavior
- ✅ Enhances user experience for SSO workflows
- ✅ Reduces need for explicit profile specification
- ✅ Maintains all existing functionality

## Checklist

- [x] The code follows the project's coding standards
- [x] Self-review of the code has been performed
- [x] Changes are backward compatible
- [x] The solution addresses the specific issue described in #2088
- [x] Testing has been performed to verify the fix works as expected
- [x] No breaking changes introduced

## Additional Notes

This implementation specifically benefits users who:
- Use AWS SSO authentication
- Rely on environment variables for profile management
- Switch between multiple AWS profiles regularly
- Expect consistent behavior between AWS CLI and Amazon Q Developer CLI