### PR TITLE
fix: removes deny unknown fields in mcp config

### DIFF
--- a/crates/chat-cli/src/cli/chat/tools/custom_tool.rs
+++ b/crates/chat-cli/src/cli/chat/tools/custom_tool.rs
@@ -46,7 +46,7 @@ impl Default for TransportType {
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq, JsonSchema)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 pub struct CustomToolConfig {
     /// The transport type to use for communication with the MCP server
     #[serde(default)]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
As titled. 
This was added by mistake. The absent of this restrictions ensures config that are superset to our schema are still accepted. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
