### PR TITLE
Fix dotfile indexing in knowledge base

### DIFF
--- a/crates/semantic-search-client/src/client/background/file_processor.rs
+++ b/crates/semantic-search-client/src/client/background/file_processor.rs
@@ -45,10 +45,19 @@ impl FileProcessor {
                 .filter_map(|e| e.ok())
                 .filter(|e| e.file_type().is_file())
                 .filter(|e| {
-                    !e.path()
-                        .file_name()
-                        .and_then(|n| n.to_str())
-                        .is_some_and(|s| s.starts_with('.'))
+                    // Skip hidden files, but allow common configuration files
+                    if let Some(filename) = e.path().file_name().and_then(|n| n.to_str()) {
+                        if filename.starts_with('.') {
+                            // Allow common configuration files
+                            filename.ends_with("rc") 
+                                || filename.ends_with("config")
+                                || matches!(filename, ".gitignore" | ".env" | ".dockerignore")
+                        } else {
+                            true
+                        }
+                    } else {
+                        true
+                    }
                 })
                 .filter(|e| {
                     pattern_filter

--- a/crates/semantic-search-client/src/client/implementation.rs
+++ b/crates/semantic-search-client/src/client/implementation.rs
@@ -430,13 +430,18 @@ impl SemanticSearchClient {
         {
             let path = entry.path();
 
-            // Skip hidden files
-            if path
-                .file_name()
-                .and_then(|n| n.to_str())
-                .is_some_and(|s| s.starts_with('.'))
-            {
-                continue;
+            // Skip hidden files, but allow common configuration files
+            if let Some(filename) = path.file_name().and_then(|n| n.to_str()) {
+                if filename.starts_with('.') {
+                    // Allow common configuration files
+                    let is_config_file = filename.ends_with("rc") 
+                        || filename.ends_with("config")
+                        || matches!(filename, ".gitignore" | ".env" | ".dockerignore");
+                    
+                    if !is_config_file {
+                        continue;
+                    }
+                }
             }
 
             // Process the file

--- a/crates/semantic-search-client/src/client/utils.rs
+++ b/crates/semantic-search-client/src/client/utils.rs
@@ -73,13 +73,18 @@ where
     {
         let path = entry.path();
 
-        // Skip hidden files
-        if path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .is_some_and(|s| s.starts_with('.'))
-        {
-            continue;
+        // Skip hidden files, but allow common configuration files
+        if let Some(filename) = path.file_name().and_then(|n| n.to_str()) {
+            if filename.starts_with('.') {
+                // Allow common configuration files
+                let is_config_file = filename.ends_with("rc") 
+                    || filename.ends_with("config")
+                    || matches!(filename, ".gitignore" | ".env" | ".dockerignore");
+                
+                if !is_config_file {
+                    continue;
+                }
+            }
         }
 
         file_count += 1;


### PR DESCRIPTION
*Description of changes:*

- Treat dotfiles as text files instead of unknown file types
- Allow common config files (.bashrc, .vimrc, .raprc, etc.) through hidden file filters
- Add test cases for dotfile patterns (.bashrc, .vimrc, .raprc, .testrc, etc.)

Previously, dotfiles were classified as FileType::Unknown and skipped during directory processing, preventing configuration files from being indexed.

This change enables indexing of:
- Files ending in 'rc' (.bashrc, .vimrc, .raprc)
- Files ending in 'config' (.gitconfig, .npmconfig)
- Common dotfiles (.gitignore, .env, .dockerignore)

Fixes issue where configuration files showed 0 items after indexing.

Tested with .raprc and .testrc files - both now properly index content.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
