### PR TITLE
feat(prompts): Enhanced MCP prompt management with improved UX

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/prompts.rs
+++ b/crates/chat-cli/src/cli/chat/cli/prompts.rs
@@ -470,7 +470,7 @@ impl PromptsArgs {
 
         // Calculate positions for three-column layout: Prompt | Description | Arguments
         let prompt_col_width = (UnicodeWidthStr::width(longest_name) + 4).max(20); // Min 20 chars for "Prompt"
-        let description_col_width = 40; // Fixed width for descriptions
+        let description_col_width = 41; // Fixed width for descriptions
         let description_pos = prompt_col_width;
         let arguments_pos = description_pos + description_col_width;
 

--- a/crates/chat-cli/src/cli/chat/cli/prompts.rs
+++ b/crates/chat-cli/src/cli/chat/cli/prompts.rs
@@ -3,7 +3,10 @@ use std::collections::{
     VecDeque,
 };
 use std::fs;
-use std::path::PathBuf;
+use std::path::{
+    Path,
+    PathBuf,
+};
 use std::sync::LazyLock;
 
 use clap::{
@@ -1210,7 +1213,7 @@ impl PromptsSubcommand {
     fn display_file_prompt_details(
         name: &str,
         content: &str,
-        source: &PathBuf,
+        source: &Path,
         session: &mut ChatSession,
     ) -> Result<(), ChatError> {
         let terminal_width = session.terminal_width();


### PR DESCRIPTION
*Issue #, if available:* #2789

*Description of changes:*

This PR improves the MCP prompts feature, focusing on better user experience and discoverability:

### New Features
- **Details command**: Added `/prompts details` to show comprehensive prompt information including metadata and argument details
- **Enhanced list view**: Improved `/prompts list` with three-column layout showing descriptions and better formatting
- **Content preview**: Display fetched prompt content before AI processing to eliminate user confusion

### Improvements
- **Better error handling**: Replace raw JSON MCP server errors with user-friendly, actionable messages
- **Usage guidance**: Generate helpful usage examples from PromptBundle data for invalid parameter errors
- **Visual formatting**: Consistent terminal styling and proper content display for all prompt message types

Here are screenshots to see key differences before and after these changes:

`/prompts list` before fix:
<img width="696" height="309" alt="Screenshot 2025-09-21 at 16 05 40" src="https://github.com/user-attachments/assets/d42cea9b-464b-4004-8d22-61c9319a6b43" />

`/prompts list` after fix:
<img width="695" height="307" alt="Screenshot 2025-09-21 at 16 05 49" src="https://github.com/user-attachments/assets/0e6ed21d-c92a-4429-92ae-65d6a48a6cbc" />

New `/prompts details` command:
<img width="913" height="961" alt="Screenshot 2025-09-21 at 16 07 23" src="https://github.com/user-attachments/assets/8ed46f50-38ce-4d63-813c-fce9c02b5eee" />

Invoking a prompt now displays the prompt before sending to the model:
<img width="1642" height="593" alt="Screenshot 2025-09-21 at 16 28 46" src="https://github.com/user-attachments/assets/8012c1b4-3eb5-4a7f-b413-99acf6074fb1" />

Better error messaging (no longer just raw MCP server responses):

Before fix:
<img width="888" height="683" alt="Screenshot 2025-09-21 at 16 31 25" src="https://github.com/user-attachments/assets/c0f80c33-7d37-48ca-a1c5-5497546d6ea8" />

After fix:
<img width="695" height="475" alt="Screenshot 2025-09-21 at 16 31 34" src="https://github.com/user-attachments/assets/92a8ed90-e2a4-4cae-99b0-185c3245dec1" />


🤖 Assisted by Amazon Q Developer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
