### PR TITLE
fix unit test `test_display_label_default_permissions`

### DIFF
--- a/crates/chat-cli/src/cli/agent/mod.rs
+++ b/crates/chat-cli/src/cli/agent/mod.rs
@@ -1189,8 +1189,8 @@ mod tests {
         let execute_name = if cfg!(windows) { "execute_cmd" } else { "execute_bash" };
         let execute_bash_label = agents.display_label(execute_name, &ToolOrigin::Native);
         assert!(
-            execute_bash_label.contains("read-only"),
-            "execute_bash should show read-only by default, instead found: {}",
+            execute_bash_label.contains("not trusted"),
+            "execute_bash should show not trusted by default, instead found: {}",
             execute_bash_label
         );
     }


### PR DESCRIPTION
*Issue #, if available:*
Unit test failure caused by commit `c031c331b8683995ad514c26c1eab3eaf927ff96`
```
test os::diagnostics::tests::test_diagnostics_user_readable ... ok

failures:

---- cli::agent::tests::test_display_label_default_permissions stdout ----

thread 'cli::agent::tests::test_display_label_default_permissions' panicked at crates/chat-cli/src/cli/agent/mod.rs:1191:9:
execute_bash should show read-only by default, instead found: * not trusted
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    cli::agent::tests::test_display_label_default_permissions
```
*Description of changes:*
fix the unit test by change expect text

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
