### PR TITLE
feat: support @filepath syntax for injecting file content into prompts

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -3393,11 +3393,7 @@ impl ChatSession {
     async fn format_file_content(&self, path: &std::path::Path) -> Result<String, std::io::Error> {
         let content = tokio::fs::read_to_string(path).await?;
 
-        let formatted_content = format!(
-            "Content from @{}:\n{}",
-            path.to_string_lossy(),
-            content.trim()
-        );
+        let formatted_content = format!("Content from @{}:\n{}", path.to_string_lossy(), content.trim());
 
         Ok(formatted_content)
     }

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -1933,6 +1933,11 @@ impl ChatSession {
     async fn handle_input(&mut self, os: &mut Os, mut user_input: String) -> Result<ChatState, ChatError> {
         queue!(self.stderr, style::Print('\n'))?;
         user_input = sanitize_unicode_tags(&user_input);
+
+        if let Some(injected_input) = self.inject_at_files(user_input.trim()).await {
+            user_input = injected_input;
+        }
+
         let input = user_input.trim();
 
         // handle image path
@@ -3349,6 +3354,52 @@ impl ChatSession {
                 .into_user_input_message(self.conversation.model.clone(), &self.conversation.tools)
                 .content,
         })
+    }
+
+    async fn inject_at_files(&self, input: &str) -> Option<String> {
+        use regex::Regex;
+
+        // Match @filepath patterns
+        let re = Regex::new(r"@([^\s]+)").ok()?;
+        let mut file_contents = Vec::new();
+
+        for mat in re.find_iter(input) {
+            let file_path = &mat.as_str()[1..]; // Remove the @ prefix
+            let path = std::path::Path::new(file_path);
+
+            if path.exists() && path.is_file() {
+                if let Ok(file_content) = self.format_file_content(path).await {
+                    file_contents.push(file_content);
+                }
+            }
+        }
+
+        if !file_contents.is_empty() {
+            let mut result = input.to_string();
+
+            result.push_str("\n\n--- Content from referenced files ---\n");
+            for content in file_contents {
+                result.push('\n');
+                result.push_str(&content);
+            }
+            result.push_str("\n--- End of content ---");
+
+            Some(result)
+        } else {
+            None
+        }
+    }
+
+    async fn format_file_content(&self, path: &std::path::Path) -> Result<String, std::io::Error> {
+        let content = tokio::fs::read_to_string(path).await?;
+
+        let formatted_content = format!(
+            "Content from @{}:\n{}",
+            path.to_string_lossy(),
+            content.trim()
+        );
+
+        Ok(formatted_content)
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:*
Issue #2961 

*Description of changes:*

Add file injection support for @ command

This change introduces the ability to reference and inject file contents using the @filepath syntax in chat commands. When users include @filepath in their input, the q cli automatically reads and appends the referenced file content to the message.

Key changes:
- Added inject_at_files() method to detect @filepath patterns using regex
- Added format_file_content() helper to read and format file contents
- File contents are appended with delimiters

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
