### PR TITLE
Improve error messages for dispatch failures

### DIFF
--- a/crates/chat-cli/src/auth/mod.rs
+++ b/crates/chat-cli/src/auth/mod.rs
@@ -14,15 +14,17 @@ pub use builder_id::{
 pub use consts::START_URL;
 use thiserror::Error;
 
+use crate::aws_common::SdkErrorDisplay;
+
 #[derive(Debug, Error)]
 pub enum AuthError {
     #[error(transparent)]
     Ssooidc(Box<aws_sdk_ssooidc::Error>),
-    #[error(transparent)]
+    #[error("{}", SdkErrorDisplay(.0))]
     SdkRegisterClient(Box<SdkError<RegisterClientError>>),
-    #[error(transparent)]
+    #[error("{}", SdkErrorDisplay(.0))]
     SdkCreateToken(Box<SdkError<CreateTokenError>>),
-    #[error(transparent)]
+    #[error("{}", SdkErrorDisplay(.0))]
     SdkStartDeviceAuthorization(Box<SdkError<StartDeviceAuthorizationError>>),
     #[error(transparent)]
     Io(#[from] std::io::Error),

--- a/crates/chat-cli/src/cli/agent/mod.rs
+++ b/crates/chat-cli/src/cli/agent/mod.rs
@@ -1189,8 +1189,8 @@ mod tests {
         let execute_name = if cfg!(windows) { "execute_cmd" } else { "execute_bash" };
         let execute_bash_label = agents.display_label(execute_name, &ToolOrigin::Native);
         assert!(
-            execute_bash_label.contains("read-only"),
-            "execute_bash should show read-only by default, instead found: {}",
+            execute_bash_label.contains("not trusted"),
+            "execute_bash should not be trusted by default, instead found: {}",
             execute_bash_label
         );
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


```

80a9973c9950:amazon-q-developer-cli kkashilk$ cargo_run login
   Compiling chat_cli v1.16.2 (/Users/kkashilk/Documents/Q-Cli/personal-repo/amazon-q-developer-cli/crates/chat-cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 19.52s
     Running `target/debug/chat_cli login`
✔ Select login method · Use with Pro license
✔ Enter Start URL · https://amzn.awsapps.com/start
✔ Enter Region · us-east-1
error: OAuth error: Authentication failed: dispatch failure (io error): an i/o error occurred: error sending request for url (https://oidc.us-east-1.amazonaws.com/client/register)


vs 

80a9973c9950:amazon-q-developer-cli kkashilk$ q login
✔ Select login method · Use with Pro license
✔ Enter Start URL · https://amzn.awsapps.com/start
✔ Enter Region · us-east-1
error: dispatch failure
```

Another example - 

```
80a9973c9950:amazon-q-developer-cli kkashilk$ cargo_run login
   Compiling chat_cli v1.16.2 (/Users/kkashilk/Documents/Q-Cli/personal-repo/amazon-q-developer-cli/crates/chat-cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 19.98s
     Running `target/debug/chat_cli login`
✔ Select login method · Use with Pro license
✔ Enter Start URL · https://amzn.awsapps.com/start
✔ Enter Region · us-east-1 
error: dispatch failure (other): failed to apply endpoint `https://oidc.us-east-1 .amazonaws.com` to request `Request { body: SdkBody { inner: Once(Some(b"{\"clientName\":\"Amazon Q Developer for command line\",\"clientType\":\"public\",\"grantTypes\":[\"authorization_code\",\"refresh_token\"],\"issuerUrl\":\"https://amzn.awsapps.com/start\",\"redirectUris\":[\"http://127.0.0.1:54665/oauth/callback\"],\"scopes\":[\"codewhisperer:completions\",\"codewhisperer:analysis\",\"codewhisperer:conversations\"]}")), retryable: true }, uri: Uri { as_string: "/client/register", parsed: H0(/client/register) }, method: POST, extensions: Extensions { extensions_02x: Extensions, extensions_1x: Extensions }, headers: Headers { headers: {"content-type": HeaderValue { _private: H0("application/json") }, "content-length": HeaderValue { _private: H0("322") }} } }`

vs 

80a9973c9950:amazon-q-developer-cli kkashilk$ q login
✔ Select login method · Use with Pro license
✔ Enter Start URL · https://amzn.awsapps.com/start
✔ Enter Region · us-east-1
error: dispatch failure
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
