### PR TITLE
fix: consolidate tool permission logic for consistent display and exe…

### DIFF
--- a/crates/chat-cli/src/cli/agent/mod.rs
+++ b/crates/chat-cli/src/cli/agent/mod.rs
@@ -716,7 +716,21 @@ impl Agents {
 
             DEFAULT_AGENT_NAME.to_string()
         };
-
+        let _ = execute!(
+                            output,
+                            style::SetForegroundColor(Color::Yellow),
+                            style::Print("Niraj "),
+                            style::ResetColor,
+                            style::Print("Agent config "),
+                        
+                            style::ResetColor,
+                            style::Print(&active_idx),
+                            style::SetForegroundColor(Color::Yellow),
+                           
+                            style::ResetColor,
+                            
+                        );
+        
         let _ = output.flush();
 
         // Post parsing validation here
@@ -776,32 +790,14 @@ impl Agents {
 
     /// Returns a label to describe the permission status for a given tool.
     pub fn display_label(&self, tool_name: &str, origin: &ToolOrigin) -> String {
-        use crate::util::pattern_matching::matches_any_pattern;
+        use crate::util::tool_permission_checker::is_tool_allowed;
 
         let tool_trusted = self.get_active().is_some_and(|a| {
-            if matches!(origin, &ToolOrigin::Native) {
-                return matches_any_pattern(&a.allowed_tools, tool_name);
-            }
-
-            a.allowed_tools.iter().any(|name| {
-                name.strip_prefix("@").is_some_and(|remainder| {
-                    remainder
-                        .split_once(MCP_SERVER_TOOL_DELIMITER)
-                        .is_some_and(|(_left, right)| right == tool_name)
-                        || remainder == <ToolOrigin as Borrow<str>>::borrow(origin)
-                }) || {
-                    if let Some(server_name) = name.strip_prefix("@").and_then(|s| s.split('/').next()) {
-                        if server_name == <ToolOrigin as Borrow<str>>::borrow(origin) {
-                            let tool_pattern = format!("@{}/{}", server_name, tool_name);
-                            matches_any_pattern(&a.allowed_tools, &tool_pattern)
-                        } else {
-                            false
-                        }
-                    } else {
-                        false
-                    }
-                }
-            })
+            let server_name = match origin {
+                ToolOrigin::Native => None,
+                _ => Some(<ToolOrigin as Borrow<str>>::borrow(origin)),
+            };
+            is_tool_allowed(&a.allowed_tools, tool_name, server_name)
         });
 
         if tool_trusted || self.trust_all_tools {

--- a/crates/chat-cli/src/cli/chat/tools/custom_tool.rs
+++ b/crates/chat-cli/src/cli/chat/tools/custom_tool.rs
@@ -28,7 +28,6 @@ use crate::mcp_client::{
 };
 use crate::os::Os;
 use crate::util::MCP_SERVER_TOOL_DELIMITER;
-use crate::util::pattern_matching::matches_any_pattern;
 
 #[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
@@ -175,18 +174,12 @@ impl CustomTool {
     }
 
     pub fn eval_perm(&self, _os: &Os, agent: &Agent) -> PermissionEvalResult {
-        let server_name = &self.server_name;
-
-        let server_pattern = format!("@{server_name}");
-        if agent.allowed_tools.contains(&server_pattern) {
-            return PermissionEvalResult::Allow;
+        use crate::util::tool_permission_checker::is_tool_allowed;
+        
+        if is_tool_allowed(&agent.allowed_tools, &self.name, Some(&self.server_name)) {
+            PermissionEvalResult::Allow
+        } else {
+            PermissionEvalResult::Ask
         }
-
-        let tool_pattern = self.namespaced_tool_name();
-        if matches_any_pattern(&agent.allowed_tools, &tool_pattern) {
-            return PermissionEvalResult::Allow;
-        }
-
-        PermissionEvalResult::Ask
     }
 }

--- a/crates/chat-cli/src/util/mod.rs
+++ b/crates/chat-cli/src/util/mod.rs
@@ -3,6 +3,7 @@ pub mod directories;
 pub mod knowledge_store;
 pub mod open;
 pub mod pattern_matching;
+pub mod tool_permission_checker;
 pub mod spinner;
 pub mod system_info;
 #[cfg(test)]

--- a/crates/chat-cli/src/util/tool_permission_checker.rs
+++ b/crates/chat-cli/src/util/tool_permission_checker.rs
@@ -1,0 +1,84 @@
+use std::collections::HashSet;
+
+use crate::util::pattern_matching::matches_any_pattern;
+use crate::util::MCP_SERVER_TOOL_DELIMITER;
+use tracing::info;
+
+/// Checks if a tool is allowed based on the agent's allowed_tools configuration.
+/// This function handles both native tools and MCP tools with wildcard pattern support.
+pub fn is_tool_allowed(
+    allowed_tools: &HashSet<String>,
+    tool_name: &str,
+    server_name: Option<&str>,
+) -> bool {
+    let filter_patterns = |predicate: fn(&str) -> bool| -> HashSet<String> {
+        allowed_tools
+            .iter()
+            .filter(|pattern| predicate(pattern))
+            .cloned()
+            .collect()
+    };
+    
+    match server_name {
+        // Native tool
+        None => {
+            let patterns = filter_patterns(|p| !p.starts_with('@'));
+            info!("Native patterns: {:?}", patterns);
+            let result = matches_any_pattern(&patterns, tool_name);
+            info!("Native tool '{}' permission check result: {}", tool_name, result);
+            result
+        },
+        // MCP tool
+        Some(server) => {
+            let patterns = filter_patterns(|p| p.starts_with('@'));
+            info!("MCP patterns: {:?}", patterns);
+            
+            // Check server-level permission first: @server_name
+            let server_pattern = format!("@{}", server);
+            info!("Checking server-level pattern: '{}'", server_pattern);
+            if matches_any_pattern(&patterns, &server_pattern) {
+                info!("Server-level permission granted for '{}'", server_pattern);
+                return true;
+            }
+            
+            // Check tool-specific permission: @server_name/tool_name
+            let tool_pattern = format!("@{}{}{}", server, MCP_SERVER_TOOL_DELIMITER, tool_name);
+            info!("Checking tool-specific pattern: '{}'", tool_pattern);
+            let result = matches_any_pattern(&patterns, &tool_pattern);
+            info!("Tool-specific permission result for '{}': {}", tool_pattern, result);
+            result
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn test_native_vs_mcp_separation() {
+        let mut allowed = HashSet::new();
+        allowed.insert("fs_*".to_string());
+        allowed.insert("@git".to_string());
+        
+        // Native patterns only apply to native tools
+        assert!(is_tool_allowed(&allowed, "fs_read", None));
+        assert!(!is_tool_allowed(&allowed, "fs_read", Some("server")));
+        
+        // MCP patterns only apply to MCP tools
+        assert!(is_tool_allowed(&allowed, "status", Some("git")));
+        assert!(!is_tool_allowed(&allowed, "git", None));
+    }
+
+    #[test]
+    fn test_mcp_wildcard_patterns() {
+        let mut allowed = HashSet::new();
+        allowed.insert("@*quip*".to_string());
+        allowed.insert("@git/read_*".to_string());
+        
+        assert!(is_tool_allowed(&allowed, "tool", Some("quip-server")));
+        assert!(is_tool_allowed(&allowed, "read_file", Some("git")));
+        assert!(!is_tool_allowed(&allowed, "write_file", Some("git")));
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*

## Overview*
This change consolidates tool permission checking logic to ensure consistent behavior between the /tools display and actual tool execution in Q CLI.

## Background
The CLI had two separate implementations for checking tool permissions:

Display path: Used for showing trust status in /tools command

Execution path: Used when actually running tools

These implementations had different wildcard pattern support, leading to inconsistent user experience.

## Documentation Reference
https://github.com/aws/amazon-q-developer-cli/blob/main/docs/agent-format.md#allowedtools-field

### According to the allowedTools specification:
#### Pattern Types:

* Native tools: "fs_read", "fs_*"

* MCP tools: "@server", "@server/tool", "@*quip*"

#### Key Rules:

* Patterns starting with @ apply to MCP tools

Patterns without @ apply to native tools

Both support wildcard patterns (*, ?)

## Example Scenario
Configuration: in Agent mcp config file
```
{
 {
    "name": "amazon_q_default",
    "description": "Default agent configuration",
    "mcpServers": {

        "quip-mcp-server": {
            "command": "/home/Workspace/src/quip-mcp-server/dist/index.js",
            "transportType": "stdio",
            "timeout": 300000
        }
    },
    "tools": [
        "*"
    ],
    "allowedTools": [
        "fsRead",
        "*quip*"
    ],
    "toolsSettings": {
        "execute_bash": {
            "alwaysAllow": [{
                "preset": "readOnly"
            }]
        },
        "use_aws": {
            "alwaysAllow": [{
                "preset": "readOnly"
            }]
        }
    },
    "resources": [
        "..."
    ],
    ...
    ...
    ..rest of config
} 
}
```
## Previous Behavior:
### On running /tools displays MCP tools from `quip-server` showed as "not trusted"
```
🤖 You are chatting with claude-sonnet-4

[amazon_q_default] > /tools
Built-in:
- execute_bash                        * trust read-only commands
- fs_read                             * trust working directory
- fs_write                            * not trusted
- introspect                          * trusted
- knowledge                           * not trusted
- report_issue                        * trusted
- use_aws                             * trust read-only commands
- 
quip-mcp-server (MCP):
- get_quip_documents                  * not trusted
- search_quip_documents               * not trusted

```
### On running q to read a quip document 
Execution: Same tools were actually allowed
```
[amazon_q_default] > read quip doc using quip mcp <<url to quip>>

> I'll read the Quip document for you. I notice there's a typo in the URL (.coam instead of .com), so I'll use the correct domain.


🛠️  Using tool: get_quip_documents (trusted) from mcp server quip-mcp-server
 ⋮ 
 ● Running get_quip_documents with the param:
 ⋮  {
 ⋮    "urls": [
 ⋮      "<url to quip>"
 ⋮    ]
 ⋮  }
^C
```

### Solution
Created a centralized tool_permission_checker utility that:

* Provides single source of truth for permission logic

* Properly separates native vs MCP pattern matching

* Ensures consistent wildcard support across all code paths

* Stays consistent with Q cli documentation 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
