### PR TITLE
fix: consolidate tool permission logic for consistent display and exe…

### DIFF
--- a/crates/chat-cli/src/cli/agent/mod.rs
+++ b/crates/chat-cli/src/cli/agent/mod.rs
@@ -716,7 +716,7 @@ impl Agents {
 
             DEFAULT_AGENT_NAME.to_string()
         };
-        
+
         let _ = output.flush();
 
         // Post parsing validation here
@@ -776,14 +776,14 @@ impl Agents {
 
     /// Returns a label to describe the permission status for a given tool.
     pub fn display_label(&self, tool_name: &str, origin: &ToolOrigin) -> String {
-        use crate::util::tool_permission_checker::is_tool_allowed;
+        use crate::util::tool_permission_checker::is_tool_in_allowlist;
 
         let tool_trusted = self.get_active().is_some_and(|a| {
             let server_name = match origin {
                 ToolOrigin::Native => None,
                 _ => Some(<ToolOrigin as Borrow<str>>::borrow(origin)),
             };
-            is_tool_allowed(&a.allowed_tools, tool_name, server_name)
+            is_tool_in_allowlist(&a.allowed_tools, tool_name, server_name)
         });
 
         if tool_trusted || self.trust_all_tools {

--- a/crates/chat-cli/src/cli/chat/tools/custom_tool.rs
+++ b/crates/chat-cli/src/cli/chat/tools/custom_tool.rs
@@ -174,9 +174,9 @@ impl CustomTool {
     }
 
     pub fn eval_perm(&self, _os: &Os, agent: &Agent) -> PermissionEvalResult {
-        use crate::util::tool_permission_checker::is_tool_allowed;
-        
-        if is_tool_allowed(&agent.allowed_tools, &self.name, Some(&self.server_name)) {
+        use crate::util::tool_permission_checker::is_tool_in_allowlist;
+
+        if is_tool_in_allowlist(&agent.allowed_tools, &self.name, Some(&self.server_name)) {
             PermissionEvalResult::Allow
         } else {
             PermissionEvalResult::Ask

--- a/crates/chat-cli/src/cli/chat/tools/execute/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/execute/mod.rs
@@ -23,7 +23,7 @@ use crate::cli::chat::tools::{
 };
 use crate::cli::chat::util::truncate_safe;
 use crate::os::Os;
-use crate::util::pattern_matching::matches_any_pattern;
+use crate::util::tool_permission_checker::is_tool_in_allowlist;
 
 // Platform-specific modules
 #[cfg(windows)]
@@ -205,7 +205,7 @@ impl ExecuteCommand {
 
         let Self { command, .. } = self;
         let tool_name = if cfg!(windows) { "execute_cmd" } else { "execute_bash" };
-        let is_in_allowlist = matches_any_pattern(&agent.allowed_tools, tool_name);
+        let is_in_allowlist = is_tool_in_allowlist(&agent.allowed_tools, tool_name, None);
         match agent.tools_settings.get(tool_name) {
             Some(settings) => {
                 let Settings {

--- a/crates/chat-cli/src/cli/chat/tools/fs_read.rs
+++ b/crates/chat-cli/src/cli/chat/tools/fs_read.rs
@@ -46,7 +46,7 @@ use crate::cli::chat::{
 };
 use crate::os::Os;
 use crate::util::directories;
-use crate::util::pattern_matching::matches_any_pattern;
+use crate::util::tool_permission_checker::is_tool_in_allowlist;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct FsRead {
@@ -113,7 +113,7 @@ impl FsRead {
             allow_read_only: bool,
         }
 
-        let is_in_allowlist = matches_any_pattern(&agent.allowed_tools, "fs_read");
+        let is_in_allowlist = is_tool_in_allowlist(&agent.allowed_tools, "fs_read", None);
         let settings = agent
             .tools_settings
             .get("fs_read")

--- a/crates/chat-cli/src/cli/chat/tools/fs_write.rs
+++ b/crates/chat-cli/src/cli/chat/tools/fs_write.rs
@@ -45,7 +45,7 @@ use crate::cli::agent::{
 use crate::cli::chat::line_tracker::FileLineTracker;
 use crate::os::Os;
 use crate::util::directories;
-use crate::util::pattern_matching::matches_any_pattern;
+use crate::util::tool_permission_checker::is_tool_in_allowlist;
 
 static SYNTAX_SET: LazyLock<SyntaxSet> = LazyLock::new(SyntaxSet::load_defaults_newlines);
 static THEME_SET: LazyLock<ThemeSet> = LazyLock::new(ThemeSet::load_defaults);
@@ -470,7 +470,7 @@ impl FsWrite {
             denied_paths: Vec<String>,
         }
 
-        let is_in_allowlist = matches_any_pattern(&agent.allowed_tools, "fs_write");
+        let is_in_allowlist = is_tool_in_allowlist(&agent.allowed_tools, "fs_write", None);
         match agent.tools_settings.get("fs_write") {
             Some(settings) => {
                 let Settings {

--- a/crates/chat-cli/src/cli/chat/tools/knowledge.rs
+++ b/crates/chat-cli/src/cli/chat/tools/knowledge.rs
@@ -20,7 +20,7 @@ use crate::cli::agent::{
 use crate::database::settings::Setting;
 use crate::os::Os;
 use crate::util::knowledge_store::KnowledgeStore;
-use crate::util::pattern_matching::matches_any_pattern;
+use crate::util::tool_permission_checker::is_tool_in_allowlist;
 
 /// The Knowledge tool allows storing and retrieving information across chat sessions.
 /// It provides semantic search capabilities for files, directories, and text content.
@@ -497,7 +497,7 @@ impl Knowledge {
         _ = self;
         _ = os;
 
-        if matches_any_pattern(&agent.allowed_tools, "knowledge") {
+        if is_tool_in_allowlist(&agent.allowed_tools, "knowledge", None) {
             PermissionEvalResult::Allow
         } else {
             PermissionEvalResult::Ask

--- a/crates/chat-cli/src/cli/chat/tools/use_aws.rs
+++ b/crates/chat-cli/src/cli/chat/tools/use_aws.rs
@@ -29,7 +29,7 @@ use crate::cli::agent::{
     PermissionEvalResult,
 };
 use crate::os::Os;
-use crate::util::pattern_matching::matches_any_pattern;
+use crate::util::tool_permission_checker::is_tool_in_allowlist;
 
 const READONLY_OPS: [&str; 6] = ["get", "describe", "list", "ls", "search", "batch_get"];
 
@@ -187,7 +187,7 @@ impl UseAws {
         }
 
         let Self { service_name, .. } = self;
-        let is_in_allowlist = matches_any_pattern(&agent.allowed_tools, "use_aws");
+        let is_in_allowlist = is_tool_in_allowlist(&agent.allowed_tools, "use_aws", None);
         match agent.tools_settings.get("use_aws") {
             Some(settings) => {
                 let settings = match serde_json::from_value::<Settings>(settings.clone()) {

--- a/crates/chat-cli/src/util/mod.rs
+++ b/crates/chat-cli/src/util/mod.rs
@@ -3,11 +3,11 @@ pub mod directories;
 pub mod knowledge_store;
 pub mod open;
 pub mod pattern_matching;
-pub mod tool_permission_checker;
 pub mod spinner;
 pub mod system_info;
 #[cfg(test)]
 pub mod test;
+pub mod tool_permission_checker;
 pub mod ui;
 
 use std::fmt::Display;

--- a/crates/chat-cli/src/util/tool_permission_checker.rs
+++ b/crates/chat-cli/src/util/tool_permission_checker.rs
@@ -1,16 +1,13 @@
 use std::collections::HashSet;
 
-use crate::util::pattern_matching::matches_any_pattern;
+use tracing::debug;
+
 use crate::util::MCP_SERVER_TOOL_DELIMITER;
-use tracing::info;
+use crate::util::pattern_matching::matches_any_pattern;
 
 /// Checks if a tool is allowed based on the agent's allowed_tools configuration.
 /// This function handles both native tools and MCP tools with wildcard pattern support.
-pub fn is_tool_allowed(
-    allowed_tools: &HashSet<String>,
-    tool_name: &str,
-    server_name: Option<&str>,
-) -> bool {
+pub fn is_tool_in_allowlist(allowed_tools: &HashSet<String>, tool_name: &str, server_name: Option<&str>) -> bool {
     let filter_patterns = |predicate: fn(&str) -> bool| -> HashSet<String> {
         allowed_tools
             .iter()
@@ -18,57 +15,58 @@ pub fn is_tool_allowed(
             .cloned()
             .collect()
     };
-    
+
     match server_name {
         // Native tool
         None => {
             let patterns = filter_patterns(|p| !p.starts_with('@'));
-            info!("Native patterns: {:?}", patterns);
+            debug!("Native patterns: {:?}", patterns);
             let result = matches_any_pattern(&patterns, tool_name);
-            info!("Native tool '{}' permission check result: {}", tool_name, result);
+            debug!("Native tool '{}' permission check result: {}", tool_name, result);
             result
         },
         // MCP tool
         Some(server) => {
             let patterns = filter_patterns(|p| p.starts_with('@'));
-            info!("MCP patterns: {:?}", patterns);
-            
+            debug!("MCP patterns: {:?}", patterns);
+
             // Check server-level permission first: @server_name
             let server_pattern = format!("@{}", server);
-            info!("Checking server-level pattern: '{}'", server_pattern);
+            debug!("Checking server-level pattern: '{}'", server_pattern);
             if matches_any_pattern(&patterns, &server_pattern) {
-                info!("Server-level permission granted for '{}'", server_pattern);
+                debug!("Server-level permission granted for '{}'", server_pattern);
                 return true;
             }
-            
+
             // Check tool-specific permission: @server_name/tool_name
             let tool_pattern = format!("@{}{}{}", server, MCP_SERVER_TOOL_DELIMITER, tool_name);
-            info!("Checking tool-specific pattern: '{}'", tool_pattern);
+            debug!("Checking tool-specific pattern: '{}'", tool_pattern);
             let result = matches_any_pattern(&patterns, &tool_pattern);
-            info!("Tool-specific permission result for '{}': {}", tool_pattern, result);
+            debug!("Tool-specific permission result for '{}': {}", tool_pattern, result);
             result
-        }
+        },
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::collections::HashSet;
+
+    use super::*;
 
     #[test]
     fn test_native_vs_mcp_separation() {
         let mut allowed = HashSet::new();
         allowed.insert("fs_*".to_string());
         allowed.insert("@git".to_string());
-        
+
         // Native patterns only apply to native tools
-        assert!(is_tool_allowed(&allowed, "fs_read", None));
-        assert!(!is_tool_allowed(&allowed, "fs_read", Some("server")));
-        
+        assert!(is_tool_in_allowlist(&allowed, "fs_read", None));
+        assert!(!is_tool_in_allowlist(&allowed, "fs_read", Some("server")));
+
         // MCP patterns only apply to MCP tools
-        assert!(is_tool_allowed(&allowed, "status", Some("git")));
-        assert!(!is_tool_allowed(&allowed, "git", None));
+        assert!(is_tool_in_allowlist(&allowed, "status", Some("git")));
+        assert!(!is_tool_in_allowlist(&allowed, "git", None));
     }
 
     #[test]
@@ -76,9 +74,9 @@ mod tests {
         let mut allowed = HashSet::new();
         allowed.insert("@*quip*".to_string());
         allowed.insert("@git/read_*".to_string());
-        
-        assert!(is_tool_allowed(&allowed, "tool", Some("quip-server")));
-        assert!(is_tool_allowed(&allowed, "read_file", Some("git")));
-        assert!(!is_tool_allowed(&allowed, "write_file", Some("git")));
+
+        assert!(is_tool_in_allowlist(&allowed, "tool", Some("quip-server")));
+        assert!(is_tool_in_allowlist(&allowed, "read_file", Some("git")));
+        assert!(!is_tool_in_allowlist(&allowed, "write_file", Some("git")));
     }
 }


### PR DESCRIPTION
*Issue #, if available:* None


## Overview
This change consolidates tool permission checking logic to ensure consistent behavior between the /tools display and actual tool execution in Q CLI.

## Background
The CLI had two separate implementations for checking tool permissions:

Display path: Used for showing trust status in /tools command

Execution path: Used when actually running tools

These implementations had different wildcard pattern support, leading to inconsistent user experience.

## Documentation Reference
https://github.com/aws/amazon-q-developer-cli/blob/main/docs/agent-format.md#allowedtools-field

### According to the allowedTools specification:
#### Pattern Types:

* Native tools: "fs_read", "fs_*"

* MCP tools: "@server", "@server/tool", "@*quip*"

#### Key Rules:

* Patterns starting with @ apply to MCP tools

* Patterns without @ apply to native tools

Both support wildcard patterns (*, ?)

### Solution
Created a centralized tool_permission_checker utility that:

* Provides single source of truth for permission logic

* Properly separates native vs MCP pattern matching

* Ensures consistent wildcard support across all code paths

* Stays consistent with Q cli documentation on allowedTools instructions

### Testing
* Ran cargo tests and all test succeeded
* Check comment for detailed testing 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

