### PR TITLE
feat: binds Shift+Enter for newline on some terminals (eg iTerm2)

### DIFF
--- a/crates/chat-cli/src/cli/chat/prompt.rs
+++ b/crates/chat-cli/src/cli/chat/prompt.rs
@@ -480,6 +480,12 @@ pub fn rl(
         EventHandler::Simple(Cmd::Insert(1, "\n".to_string())),
     );
 
+    // Add custom keybinding for Shift+Enter to insert a newline (works in some terminals)
+    rl.bind_sequence(
+        KeyEvent(KeyCode::Enter, Modifiers::SHIFT),
+        EventHandler::Simple(Cmd::Insert(1, "\n".to_string())),
+    );
+
     // Add custom keybinding for autocompletion hint acceptance (configurable)
     let autocompletion_key_char = match os.database.settings.get_string(Setting::AutocompletionKey) {
         Some(key) if key.len() == 1 => key.chars().next().unwrap_or('g'),


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Adds addl means of creating a newline using "Shift+Enter". Works in some terminals (like iTerm2). Keeps original "Ctrl+j" keybinding for newlines.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
