### PR TITLE
feat: add context usage percentage indicator to prompt

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/experiment.rs
+++ b/crates/chat-cli/src/cli/chat/cli/experiment.rs
@@ -50,6 +50,11 @@ static AVAILABLE_EXPERIMENTS: &[Experiment] = &[
         description: "Enables Q to create todo lists that can be viewed and managed using /todos",
         setting_key: Setting::EnabledTodoList,
     },
+    Experiment {
+        name: "Context Usage Indicator",
+        description: "Shows context usage percentage in the prompt (e.g., [rust-agent] 6% >)",
+        setting_key: Setting::EnabledContextUsageIndicator,
+    },
 ];
 
 #[derive(Debug, PartialEq, Args)]

--- a/crates/chat-cli/src/cli/chat/prompt.rs
+++ b/crates/chat-cli/src/cli/chat/prompt.rs
@@ -408,6 +408,18 @@ impl Highlighter for ChatHelper {
                 result.push_str(&format!("[{}] ", profile).cyan().to_string());
             }
 
+            // Add percentage part if present (colored by usage level)
+            if let Some(percentage) = components.usage_percentage {
+                let colored_percentage = if percentage < 50.0 {
+                    format!("{}% ", percentage as u32).green()
+                } else if percentage < 90.0 {
+                    format!("{}% ", percentage as u32).yellow()
+                } else {
+                    format!("{}% ", percentage as u32).red()
+                };
+                result.push_str(&colored_percentage.to_string());
+            }
+
             // Add tangent indicator if present (yellow)
             if components.tangent_mode {
                 result.push_str(&"↯ ".yellow().to_string());

--- a/crates/chat-cli/src/cli/chat/prompt_parser.rs
+++ b/crates/chat-cli/src/cli/chat/prompt_parser.rs
@@ -6,15 +6,16 @@ pub struct PromptComponents {
     pub profile: Option<String>,
     pub warning: bool,
     pub tangent_mode: bool,
+    pub usage_percentage: Option<f32>,
 }
 
 /// Parse prompt components from a plain text prompt
 pub fn parse_prompt_components(prompt: &str) -> Option<PromptComponents> {
-    // Expected format: "[agent] !> " or "> " or "!> " or "[agent] ↯ > " or "↯ > " or "[agent] ↯ !> "
-    // etc.
+    // Expected format: "[agent] 6% !> " or "> " or "!> " or "[agent] ↯ > " or "6% ↯ > " etc.
     let mut profile = None;
     let mut warning = false;
     let mut tangent_mode = false;
+    let mut usage_percentage = None;
     let mut remaining = prompt.trim();
 
     // Check for agent pattern [agent] first
@@ -24,6 +25,17 @@ pub fn parse_prompt_components(prompt: &str) -> Option<PromptComponents> {
                 let content = &remaining[start + 1..end];
                 profile = Some(content.to_string());
                 remaining = remaining[end + 1..].trim_start();
+            }
+        }
+    }
+
+    // Check for percentage pattern (e.g., "6% ")
+    if let Some(percent_pos) = remaining.find('%') {
+        let before_percent = &remaining[..percent_pos];
+        if let Ok(percentage) = before_percent.trim().parse::<f32>() {
+            usage_percentage = Some(percentage);
+            if let Some(space_after_percent) = remaining[percent_pos..].find(' ') {
+                remaining = remaining[percent_pos + space_after_percent + 1..].trim_start();
             }
         }
     }
@@ -46,13 +58,19 @@ pub fn parse_prompt_components(prompt: &str) -> Option<PromptComponents> {
             profile,
             warning,
             tangent_mode,
+            usage_percentage,
         })
     } else {
         None
     }
 }
 
-pub fn generate_prompt(current_profile: Option<&str>, warning: bool, tangent_mode: bool) -> String {
+pub fn generate_prompt(
+    current_profile: Option<&str>,
+    warning: bool,
+    tangent_mode: bool,
+    usage_percentage: Option<f32>,
+) -> String {
     // Generate plain text prompt that will be colored by highlight_prompt
     let warning_symbol = if warning { "!" } else { "" };
     let profile_part = current_profile
@@ -60,10 +78,12 @@ pub fn generate_prompt(current_profile: Option<&str>, warning: bool, tangent_mod
         .map(|p| format!("[{p}] "))
         .unwrap_or_default();
 
+    let percentage_part = usage_percentage.map(|p| format!("{:.0}% ", p)).unwrap_or_default();
+
     if tangent_mode {
-        format!("{profile_part}↯ {warning_symbol}> ")
+        format!("{profile_part}{percentage_part}↯ {warning_symbol}> ")
     } else {
-        format!("{profile_part}{warning_symbol}> ")
+        format!("{profile_part}{percentage_part}{warning_symbol}> ")
     }
 }
 
@@ -74,26 +94,43 @@ mod tests {
     #[test]
     fn test_generate_prompt() {
         // Test default prompt (no profile)
-        assert_eq!(generate_prompt(None, false, false), "> ");
+        assert_eq!(generate_prompt(None, false, false, None), "> ");
         // Test default prompt with warning
-        assert_eq!(generate_prompt(None, true, false), "!> ");
+        assert_eq!(generate_prompt(None, true, false, None), "!> ");
         // Test tangent mode
-        assert_eq!(generate_prompt(None, false, true), "↯ > ");
+        assert_eq!(generate_prompt(None, false, true, None), "↯ > ");
         // Test tangent mode with warning
-        assert_eq!(generate_prompt(None, true, true), "↯ !> ");
+        assert_eq!(generate_prompt(None, true, true, None), "↯ !> ");
         // Test default profile (should be same as no profile)
-        assert_eq!(generate_prompt(Some(DEFAULT_AGENT_NAME), false, false), "> ");
+        assert_eq!(generate_prompt(Some(DEFAULT_AGENT_NAME), false, false, None), "> ");
         // Test custom profile
-        assert_eq!(generate_prompt(Some("test-profile"), false, false), "[test-profile] > ");
+        assert_eq!(
+            generate_prompt(Some("test-profile"), false, false, None),
+            "[test-profile] > "
+        );
         // Test custom profile with tangent mode
         assert_eq!(
-            generate_prompt(Some("test-profile"), false, true),
+            generate_prompt(Some("test-profile"), false, true, None),
             "[test-profile] ↯ > "
         );
         // Test another custom profile with warning
-        assert_eq!(generate_prompt(Some("dev"), true, false), "[dev] !> ");
+        assert_eq!(generate_prompt(Some("dev"), true, false, None), "[dev] !> ");
         // Test custom profile with warning and tangent mode
-        assert_eq!(generate_prompt(Some("dev"), true, true), "[dev] ↯ !> ");
+        assert_eq!(generate_prompt(Some("dev"), true, true, None), "[dev] ↯ !> ");
+        // Test custom profile with usage percentage
+        assert_eq!(
+            generate_prompt(Some("rust-agent"), false, false, Some(6.2)),
+            "[rust-agent] 6% > "
+        );
+        // Test custom profile with usage percentage and warning
+        assert_eq!(
+            generate_prompt(Some("rust-agent"), true, false, Some(15.7)),
+            "[rust-agent] 16% !> "
+        );
+        // Test usage percentage without profile
+        assert_eq!(generate_prompt(None, false, false, Some(25.3)), "25% > ");
+        // Test usage percentage with tangent mode
+        assert_eq!(generate_prompt(None, false, true, Some(8.9)), "9% ↯ > ");
     }
 
     #[test]
@@ -103,48 +140,75 @@ mod tests {
         assert!(components.profile.is_none());
         assert!(!components.warning);
         assert!(!components.tangent_mode);
+        assert!(components.usage_percentage.is_none());
 
         // Test warning prompt
         let components = parse_prompt_components("!> ").unwrap();
         assert!(components.profile.is_none());
         assert!(components.warning);
         assert!(!components.tangent_mode);
+        assert!(components.usage_percentage.is_none());
 
         // Test tangent mode
         let components = parse_prompt_components("↯ > ").unwrap();
         assert!(components.profile.is_none());
         assert!(!components.warning);
         assert!(components.tangent_mode);
+        assert!(components.usage_percentage.is_none());
 
         // Test tangent mode with warning
         let components = parse_prompt_components("↯ !> ").unwrap();
         assert!(components.profile.is_none());
         assert!(components.warning);
         assert!(components.tangent_mode);
+        assert!(components.usage_percentage.is_none());
 
         // Test profile prompt
         let components = parse_prompt_components("[test] > ").unwrap();
         assert_eq!(components.profile.as_deref(), Some("test"));
         assert!(!components.warning);
         assert!(!components.tangent_mode);
+        assert!(components.usage_percentage.is_none());
 
         // Test profile with warning
         let components = parse_prompt_components("[dev] !> ").unwrap();
         assert_eq!(components.profile.as_deref(), Some("dev"));
         assert!(components.warning);
         assert!(!components.tangent_mode);
+        assert!(components.usage_percentage.is_none());
 
         // Test profile with tangent mode
         let components = parse_prompt_components("[dev] ↯ > ").unwrap();
         assert_eq!(components.profile.as_deref(), Some("dev"));
         assert!(!components.warning);
         assert!(components.tangent_mode);
+        assert!(components.usage_percentage.is_none());
 
         // Test profile with warning and tangent mode
         let components = parse_prompt_components("[dev] ↯ !> ").unwrap();
         assert_eq!(components.profile.as_deref(), Some("dev"));
         assert!(components.warning);
         assert!(components.tangent_mode);
+        assert!(components.usage_percentage.is_none());
+
+        // Test prompts with percentages
+        let components = parse_prompt_components("[rust-agent] 6% > ").unwrap();
+        assert_eq!(components.profile.as_deref(), Some("rust-agent"));
+        assert!(!components.warning);
+        assert!(!components.tangent_mode);
+        assert_eq!(components.usage_percentage, Some(6.0));
+
+        let components = parse_prompt_components("25% > ").unwrap();
+        assert!(components.profile.is_none());
+        assert!(!components.warning);
+        assert!(!components.tangent_mode);
+        assert_eq!(components.usage_percentage, Some(25.0));
+
+        let components = parse_prompt_components("8% ↯ > ").unwrap();
+        assert!(components.profile.is_none());
+        assert!(!components.warning);
+        assert!(components.tangent_mode);
+        assert_eq!(components.usage_percentage, Some(8.0));
 
         // Test invalid prompt
         assert!(parse_prompt_components("invalid").is_none());

--- a/crates/chat-cli/src/database/settings.rs
+++ b/crates/chat-cli/src/database/settings.rs
@@ -67,6 +67,8 @@ pub enum Setting {
     McpNoInteractiveTimeout,
     #[strum(message = "Track previously loaded MCP servers (boolean)")]
     McpLoadedBefore,
+    #[strum(message = "Show context usage percentage in prompt (boolean)")]
+    EnabledContextUsageIndicator,
     #[strum(message = "Default AI model for conversations (string)")]
     ChatDefaultModel,
     #[strum(message = "Disable markdown formatting in chat (boolean)")]
@@ -115,6 +117,7 @@ impl AsRef<str> for Setting {
             Self::ChatDisableAutoCompaction => "chat.disableAutoCompaction",
             Self::ChatEnableHistoryHints => "chat.enableHistoryHints",
             Self::EnabledTodoList => "chat.enableTodoList",
+            Self::EnabledContextUsageIndicator => "chat.enableContextUsageIndicator",
         }
     }
 }
@@ -161,6 +164,7 @@ impl TryFrom<&str> for Setting {
             "chat.disableAutoCompaction" => Ok(Self::ChatDisableAutoCompaction),
             "chat.enableHistoryHints" => Ok(Self::ChatEnableHistoryHints),
             "chat.enableTodoList" => Ok(Self::EnabledTodoList),
+            "chat.enableContextUsageIndicator" => Ok(Self::EnabledContextUsageIndicator),
             _ => Err(DatabaseError::InvalidSetting(value.to_string())),
         }
     }


### PR DESCRIPTION
Add experimental feature to show context window usage as a percentage in the chat prompt (e.g., "[rust-agent] 6% >"). The percentage is color-coded: green (<50%), yellow (50-89%), red (90-100%).

The feature is disabled by default and can be enabled via /experiment.

<img width="621" height="311" alt="image" src="https://github.com/user-attachments/assets/815a3e9e-696a-4af4-a6e8-932835342e74" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
