### PR TITLE
Fix bugs in execute_bash permission control

### DIFF
--- a/docs/built-in-tools.md
+++ b/docs/built-in-tools.md
@@ -36,7 +36,10 @@ Execute the specified bash command.
 |--------|------|---------|------------------------------------------------------------------------------------------|
 | `allowedCommands` | array of strings | `[]` | List of specific commands that are allowed without prompting. Supports regex formatting. Note that regex entered are anchored with \A and \z |
 | `deniedCommands` | array of strings | `[]` | List of specific commands that are denied. Supports regex formatting. Note that regex entered are anchored with \A and \z. Deny rules are evaluated before allow rules |
+| `denyByDefault` | boolean | `false` | When true, deny all commands not in allowedCommands instead of asking for approval |
 | `autoAllowReadonly` | boolean | `false` | Whether to allow read-only commands without prompting                                    |
+
+Note: regex does NOT support look-around, including look-ahead and look-behind.
 
 ## Fs_read Tool
 


### PR DESCRIPTION
Customer wants to allow some commands and deny all other commands.

To do that, today customer needs to add commands to allow list and use a negative regex in deny list to exclude other commands. That actually doesn't work.

The first issue is deny list regex we use in Rust doesn't work for such negative look around. When this happens the deny list doesn't match anything. The first change is to fallback deny list to "*" when regex compilation fails, instead of ignoring that failure.

The second issue is customer just want an easy way to deny by default. The 2nd change is to introduce a boolean flag called "denyByDefault" so anything not in allowed list is denied by default (instead of "ask" by default)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
