### PR TITLE
[fix] Reloads only the built-in tools only for /experiment

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/experiment.rs
+++ b/crates/chat-cli/src/cli/chat/cli/experiment.rs
@@ -12,7 +12,6 @@ use crossterm::{
 };
 use dialoguer::Select;
 
-use crate::cli::chat::conversation::format_tool_spec;
 use crate::cli::chat::{
     ChatError,
     ChatSession,
@@ -163,15 +162,12 @@ async fn select_experiment(os: &mut Os, session: &mut ChatSession) -> Result<Opt
             .await
             .map_err(|e| ChatError::Custom(format!("Failed to update experiment setting: {e}").into()))?;
 
-        // Reload tools to reflect the experiment change
-        let tools = session
+        // Reload built-in tools to reflect the experiment change while preserving MCP tools
+        session
             .conversation
-            .tool_manager
-            .load_tools(os, &mut session.stderr)
+            .reload_builtin_tools(os, &mut session.stderr)
             .await
             .map_err(|e| ChatError::Custom(format!("Failed to update tool spec: {e}").into()))?;
-
-        session.conversation.tools = format_tool_spec(tools);
 
         let status_text = if new_state { "enabled" } else { "disabled" };
 

--- a/crates/chat-cli/src/cli/chat/conversation.rs
+++ b/crates/chat-cli/src/cli/chat/conversation.rs
@@ -912,6 +912,21 @@ Return only the JSON configuration, no additional text.",
         Ok(())
     }
 
+    /// Reloads only built-in tools while preserving MCP tools
+    pub async fn reload_builtin_tools(&mut self, os: &mut Os, stderr: &mut impl Write) -> Result<(), ChatError> {
+        let builtin_tools = self
+            .tool_manager
+            .load_tools(os, stderr)
+            .await
+            .map_err(|e| ChatError::Custom(format!("Failed to reload built-in tools: {e}").into()))?;
+
+        // Remove existing built-in tools and add updated ones, preserving MCP tools
+        self.tools.retain(|origin, _| *origin != ToolOrigin::Native);
+        self.tools.extend(format_tool_spec(builtin_tools));
+
+        Ok(())
+    }
+
     /// Swapping agent involves the following:
     /// - Reinstantiate the context manager
     /// - Swap agent on tool manager


### PR DESCRIPTION
* Makes sure only built in tools are reloaded.

*Issue #, if available:*

When turning ON/OFF experiments, this makes sure only built-in tools are reloaded at any given time, as experiments would affect only that sub-set of tools.

*Description of changes:*

Enforces reload of only built-it tools.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
