### PR TITLE
feat: implement hierarchical agent config discovery

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -5,7 +5,7 @@ mod conversation;
 mod input_source;
 mod message;
 mod parse;
-use std::path::MAIN_SEPARATOR;
+use std::path::{MAIN_SEPARATOR, PathBuf};
 pub mod checkpoint;
 mod line_tracker;
 mod parser;
@@ -1871,7 +1871,30 @@ impl ChatSession {
         };
 
         // Save the final agent config to file
-        if let Err(err) = save_agent_config(os, &final_agent_config, agent_name, is_global).await {
+        let agent_dir = if is_global {
+            directories::chat_global_agent_path(os)
+                .map_err(|e| ChatError::Custom(format!("Could not find global agent directory: {}", e).into()))?
+        } else {
+            // For local agents, try to use the same directory as the active agent
+            self.conversation.agents.get_active()
+                .and_then(|agent| agent.path.as_ref())
+                .and_then(|path| path.parent())
+                .and_then(|dir| {
+                    // Don't use global directory even if that's where current agent is from
+                    let global_dir = directories::chat_global_agent_path(os).ok()?;
+                    if dir == global_dir {
+                        None // Fall back to local directory
+                    } else {
+                        Some(dir.to_path_buf())
+                    }
+                })
+                .unwrap_or_else(|| {
+                    directories::chat_local_agent_dir(os)
+                        .unwrap_or_else(|_| std::env::current_dir().unwrap_or_default().join(".amazonq/agents"))
+                })
+        };
+        
+        if let Err(err) = save_agent_config(&final_agent_config, agent_name, agent_dir).await {
             execute!(
                 self.stderr,
                 style::SetForegroundColor(Color::Red),
@@ -4430,20 +4453,16 @@ mod tests {
 }
 
 // Helper method to save the agent config to file
-async fn save_agent_config(os: &mut Os, config: &Agent, agent_name: &str, is_global: bool) -> Result<(), ChatError> {
-    let config_dir = if is_global {
-        directories::chat_global_agent_path(os)
-            .map_err(|e| ChatError::Custom(format!("Could not find global agent directory: {}", e).into()))?
-    } else {
-        directories::chat_local_agent_dir(os)
-            .map_err(|e| ChatError::Custom(format!("Could not find local agent directory: {}", e).into()))?
-    };
-
-    tokio::fs::create_dir_all(&config_dir)
+async fn save_agent_config(
+    config: &Agent, 
+    agent_name: &str, 
+    agent_dir: PathBuf
+) -> Result<(), ChatError> {
+    tokio::fs::create_dir_all(&agent_dir)
         .await
         .map_err(|e| ChatError::Custom(format!("Failed to create config directory: {}", e).into()))?;
 
-    let config_file = config_dir.join(format!("{}.json", agent_name));
+    let config_file = agent_dir.join(format!("{}.json", agent_name));
     let config_json = serde_json::to_string_pretty(config)
         .map_err(|e| ChatError::Custom(format!("Failed to serialize agent config: {}", e).into()))?;
 

--- a/crates/chat-cli/src/util/directories.rs
+++ b/crates/chat-cli/src/util/directories.rs
@@ -183,6 +183,11 @@ pub fn chat_local_agent_dir(os: &Os) -> Result<PathBuf> {
     Ok(cwd.join(WORKSPACE_AGENT_DIR_RELATIVE))
 }
 
+/// Directory for agent config relative to given path
+pub fn chat_relative_agent_dir(dir: PathBuf) -> Result<PathBuf> {
+    Ok(dir.join(WORKSPACE_AGENT_DIR_RELATIVE))
+}
+
 /// The directory containing global prompts
 pub fn chat_global_prompts_dir(os: &Os) -> Result<PathBuf> {
     Ok(home_dir(os)?.join(GLOBAL_PROMPTS_DIR_RELATIVE_TO_HOME))


### PR DESCRIPTION
# Implement hierarchical agent config discovery

## Overview

This pull request modifies local agent discovery to look for `.amazonq/cli-agents/` not just in the current directory but in
all directories above. 

## Problem Statement

The AWS documentation for Q CLI states, under [Managing custom agents](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-custom-agents-management.html) that "Project-level custom agents" are "Available only within the specific project directory and its subdirectories."

However this is not _quite_ correct. Project-level custom agents are available _only_ in the specific project directory, and not in its subdirectories.

This change fixes the behavior to match the documentation.

## Key Changes Made

- loading and `/agent swap` now perform hierarchical traversal upward through parent directories.
- added `/agent info` command to show the path of the current agent.
- modified `/agent generate` to save to the same location as the current agent if "local" was specified

### Summary of Changes by File:

**1. `crates/chat-cli/src/cli/agent/mod.rs` (75 lines changed)**
- **`get_agent_by_name`**: Replaced single directory lookup with hierarchical traversal upward through parent directories
- **`Agents::load`**: Changed from loading only current directory to traversing upward through all parent directories
- **Agent precedence**: Changed HashMap creation from `collect()` to `entry().or_insert()` so first-found (most local) agents take precedence

**2. `crates/chat-cli/src/cli/chat/cli/profile.rs` (30 lines added)**
- **Added `Info` subcommand**: New enum variant with documentation
- **Added Info handler**: Shows active agent name and path (with styling)
- **Updated help text**: Changed from "cwd/.amazonq/cli-agents" to "cwd or any parent directory"
- **Added Info to name() method**: Returns "info" string

**3. `crates/chat-cli/src/cli/chat/mod.rs` (23 lines changed)**
- **Added PathBuf import**: For new parameter type
- **Modified `generate_agent_config_impl`**: Gets active agent's directory and passes it to save function
- **Updated `save_agent_config`**: The directory for saving the file is calculated in `generate_agent_config_impl`, based on user input. 

**4. `crates/chat-cli/src/util/directories.rs` (5 lines added)**
- **Added `chat_relative_agent_dir`**: Helper function that takes any directory path and appends the agent config subdirectory

The changes enable agents to be discovered from parent directories while maintaining local override behavior, and ensure new agents are created in the same location as the currently active agent.

## Testing & Verification

### Build Verification ✅
- ✅ **Successful compilation**: `cargo build --release` completes without errors
- ✅ **Clean warnings**: Only expected warnings about unused helper functions
- ✅ **No breaking changes**: All existing functionality preserved

### Manual Testing Performed
- Created ./amazonq/cli-agents/MyAgent.json
- Verified that `chat_cli -- chat --agent=MyAgent` worked in directory with .amazonq/... and subdirectories.
- Verified that if an agent with the same name exists in current and parent directory, then the one in the current directory is used. 
- Verified that named agent not found in subdirectories, only the current working directory or it's parents.

## Backward Compatibility
- ✅ All existing functionality preserved
- ✅ No API changes
- ✅ No configuration changes required
- ✅ No breaking changes to existing workflows


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
