### PR TITLE
Fix indentation loss when markdown rendering is disabled

### DIFF
--- a/crates/chat-cli/src/cli/chat/parse.rs
+++ b/crates/chat-cli/src/cli/chat/parse.rs
@@ -523,7 +523,9 @@ fn fallback<'a, 'b>(
         let fallback = any.parse_next(i)?;
         if let Some(width) = fallback.width() {
             queue_newline_or_advance(&mut o, state, width)?;
-            if fallback != ' ' || state.column != 1 {
+            // When markdown is disabled, preserve all characters including leading spaces
+            // to maintain proper indentation in code blocks
+            if state.markdown_disabled.unwrap_or(false) || fallback != ' ' || state.column != 1 {
                 queue(&mut o, style::Print(fallback))?;
             }
         }
@@ -827,6 +829,12 @@ mod tests {
         markdown_disabled_fallback,
         "+ % @ . ?",
         [style::Print("+ % @ . ?")],
+        true
+    );
+    validate!(
+        markdown_disabled_indentation_preserved,
+        "    if n <= 1:",
+        [style::Print("    if n <= 1:")],
         true
     );
 }


### PR DESCRIPTION
# Fix indentation loss when markdown rendering is disabled

## Problem
When `chat.disableMarkdownRendering` is set to `true`, Python code blocks lose one space per indentation level. Single indentation shows as 3 spaces instead of 4, and double indentation shows as 7 spaces instead of 8.

## Root Cause
The `fallback` function in `parse.rs` was skipping spaces at column 1, which was intended for markdown formatting but caused indentation loss when markdown was disabled.

## Solution
- Modified the condition to preserve all characters (including leading spaces) when markdown is disabled
- Added regression test to prevent future issues
- Maintained backward compatibility when markdown is enabled

> Q is used to get this issue fixed 

## Testing
- ✅ Code compiles successfully
- ✅ New test case `markdown_disabled_indentation_preserved` added
- ✅ Backward compatibility verified

## Before/After
**Before:**
```python
def fibonacci(n):
   if n <= 1:
       return n
   return fibonacci(n-1) + fibonacci(n-2)
```

**After:**
```python
def fibonacci(n):
    if n <= 1:
        return n
    return fibonacci(n-1) + fibonacci(n-2)
```

## Files Changed
- `crates/chat-cli/src/cli/chat/parse.rs` - Fixed indentation logic and added test
