### PR TITLE
Disable support for '-fls' option in find command for security reasone

### DIFF
--- a/crates/chat-cli/src/cli/chat/tools/execute/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/execute/mod.rs
@@ -113,6 +113,7 @@ impl ExecuteCommand {
                                 || arg.contains("-delete")
                                 || arg.contains("-ok") // includes -okdir
                                 || arg.contains("-fprint") // includes -fprint0 and -fprintf
+                                || arg.contains("-fls")
                         }) =>
                 {
                     return true;
@@ -320,6 +321,7 @@ mod tests {
             ("find important-dir/ -exec rm {} \\;", true),
             ("find . -name '*.c' -execdir gcc -o '{}.out' '{}' \\;", true),
             ("find important-dir/ -delete", true),
+            ("find important-dir/ -fls /etc/passwd", true),
             (
                 "echo y | find . -type f -maxdepth 1 -okdir open -a Calculator {} +",
                 true,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Amazon Q CLI does not properly validates the usage of the `find` command. While the code attempts to block dangerous options like `-exec`, `-ok`, `-delete`, and `-fprint`, it overlooks `-fls`, which can **write arbitrary file listings to attacker-controlled paths**. This can lead to **arbitrary file creation or overwrite** in sensitive directories.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
