### PR TITLE
feat: Allow users to run postToolUse hooks only after a complete turn

### DIFF
--- a/crates/chat-cli/src/cli/agent/hook.rs
+++ b/crates/chat-cli/src/cli/agent/hook.rs
@@ -68,7 +68,7 @@ pub struct Hook {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub matcher: Option<String>,
 
-    /// If true, PostToolUse hooks are deferred until turn completion
+    /// If true, the hook is deferred until turn completion
     #[serde(default)]
     pub only_when_turn_complete: bool,
 

--- a/crates/chat-cli/src/cli/agent/hook.rs
+++ b/crates/chat-cli/src/cli/agent/hook.rs
@@ -69,7 +69,7 @@ pub struct Hook {
     pub matcher: Option<String>,
 
     /// If true, PostToolUse hooks are deferred until turn completion
-    #[serde(default = "Hook::default_only_when_turn_complete")]
+    #[serde(default)]
     pub only_when_turn_complete: bool,
 
     #[schemars(skip)]
@@ -85,7 +85,7 @@ impl Hook {
             max_output_size: Self::default_max_output_size(),
             cache_ttl_seconds: Self::default_cache_ttl_seconds(),
             matcher: None,
-            only_when_turn_complete: Self::default_only_when_turn_complete(),
+            only_when_turn_complete: false,
             source,
         }
     }
@@ -100,10 +100,6 @@ impl Hook {
 
     fn default_cache_ttl_seconds() -> u64 {
         DEFAULT_CACHE_TTL_SECONDS
-    }
-
-    fn default_only_when_turn_complete() -> bool {
-        false
     }
 }
 

--- a/crates/chat-cli/src/cli/agent/legacy/hooks.rs
+++ b/crates/chat-cli/src/cli/agent/legacy/hooks.rs
@@ -81,6 +81,7 @@ impl From<LegacyHook> for Option<Hook> {
             max_output_size: value.max_output_size,
             cache_ttl_seconds: value.cache_ttl_seconds,
             matcher: None,
+            only_when_turn_complete: false,
             source: Default::default(),
         })
     }

--- a/crates/chat-cli/src/cli/chat/cli/hooks.rs
+++ b/crates/chat-cli/src/cli/chat/cli/hooks.rs
@@ -84,7 +84,7 @@ fn hook_matches_tool(hook: &Hook, tool_name: &str) -> bool {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct ToolContext {
     pub tool_name: String,
     pub tool_input: serde_json::Value,

--- a/docs/agent-format.md
+++ b/docs/agent-format.md
@@ -286,7 +286,8 @@ For detailed information about hook behavior, input/output formats, and examples
     "postToolUse": [
       {
         "matcher": "fs_write",
-        "command": "cargo fmt --all"
+        "command": "cargo fmt --all",
+        "only_when_turn_complete": true
       }
     ]
   }
@@ -296,6 +297,7 @@ For detailed information about hook behavior, input/output formats, and examples
 Each hook is defined with:
 - `command` (required): The command to execute
 - `matcher` (optional): Pattern to match tool names for `preToolUse` and `postToolUse` hooks. See [built-in tools documentation](./built-in-tools.md) for available tool names.
+- `only_when_turn_complete` (optional): For `postToolUse` hooks only. If true, defers execution until all tools in the turn complete. Defaults to false.
 
 Available hook triggers:
 - `agentSpawn`: Triggered when the agent is initialized.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -150,6 +150,44 @@ rather than after each individual tool.
 }
 ```
 
+When deferred, the hook receives an array of all hook events that triggered it during the turn. This allows you to parse and process multiple tool executions however you prefer - whether that's running once per unique directory, processing all modified files, or any other custom logic.
+
+**Deferred Hook Event**
+```json
+{
+  "hook_event_name": "postToolUse",
+  "cwd": "/current/working/directory",
+  "hook_events": [
+    {
+      "tool_name": "fs_write",
+      "cwd": "/project1",
+      "tool_input": {
+        "command": "create",
+        "path": "/project1/src/main.rs",
+        "file_text": "fn main() {}"
+      },
+      "tool_response": {
+        "success": true,
+        "result": [""]
+      }
+    },
+    {
+      "tool_name": "fs_write", 
+      "cwd": "/project2",
+      "tool_input": {
+        "command": "create",
+        "path": "/project2/lib.rs",
+        "file_text": "pub fn hello() {}"
+      },
+      "tool_response": {
+        "success": true,
+        "result": [""]
+      }
+    }
+  ]
+}
+```
+
 ### MCP Example
 
 For MCP tools, the tool name includes the full namespaced format including the MCP Server name:

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -133,6 +133,23 @@ Runs after tool execution with access to tool results.
 - **0**: Hook succeeded.
 - **Other**: Show STDERR warning to user. Tool already ran.
 
+**Deferred Execution:**
+PostToolUse hooks can be deferred until turn completion by setting `only_when_turn_complete: true`. 
+This is useful for formatting, cleanup tasks or for running tests that should run only once after all tools complete, 
+rather than after each individual tool.
+
+```json
+{
+  "postToolUse": [
+    {
+      "matcher": "fs_write",
+      "command": "cargo fmt --all",
+      "only_when_turn_complete": true
+    }
+  ]
+}
+```
+
 ### MCP Example
 
 For MCP tools, the tool name includes the full namespaced format including the MCP Server name:


### PR DESCRIPTION
*Issue #, if available:* #3034

*Description of changes:*
See #2875 for the initial implementation. Sometimes, the Agents run the tools several times in a particular turn (e.g. when writing code, they don't write the whole thing at once, especially when dealing with already existing files).

With this feature, you can set your hook to only run at the end of the turn, allowing you to only run e.g. formatting/tests when the whole file is written.

Tested locally, it's working as intended - only after doing all the fs_write did it do the formatting (I used the example currently in the hooks.md that runs `cargo fmt` after it's done).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
