### PR TITLE
chore: remove max limit on conversation length

### DIFF
--- a/crates/chat-cli/src/cli/chat/consts.rs
+++ b/crates/chat-cli/src/cli/chat/consts.rs
@@ -3,7 +3,7 @@
 pub const MAX_CURRENT_WORKING_DIRECTORY_LEN: usize = 256;
 
 /// Limit to send the number of messages as part of chat.
-pub const MAX_CONVERSATION_STATE_HISTORY_LEN: usize = 10000;
+pub const MAX_CONVERSATION_STATE_HISTORY_LEN: usize = 2000;
 
 /// Actual service limit is 800_000
 pub const MAX_TOOL_RESPONSE_SIZE: usize = 400_000;

--- a/crates/chat-cli/src/cli/chat/consts.rs
+++ b/crates/chat-cli/src/cli/chat/consts.rs
@@ -3,7 +3,7 @@
 pub const MAX_CURRENT_WORKING_DIRECTORY_LEN: usize = 256;
 
 /// Limit to send the number of messages as part of chat.
-pub const MAX_CONVERSATION_STATE_HISTORY_LEN: usize = 2000;
+pub const MAX_CONVERSATION_STATE_HISTORY_LEN: usize = 10000;
 
 /// Actual service limit is 800_000
 pub const MAX_TOOL_RESPONSE_SIZE: usize = 400_000;

--- a/crates/chat-cli/src/cli/chat/consts.rs
+++ b/crates/chat-cli/src/cli/chat/consts.rs
@@ -3,7 +3,7 @@
 pub const MAX_CURRENT_WORKING_DIRECTORY_LEN: usize = 256;
 
 /// Limit to send the number of messages as part of chat.
-pub const MAX_CONVERSATION_STATE_HISTORY_LEN: usize = 250;
+pub const MAX_CONVERSATION_STATE_HISTORY_LEN: usize = 10000;
 
 /// Actual service limit is 800_000
 pub const MAX_TOOL_RESPONSE_SIZE: usize = 400_000;

--- a/crates/chat-cli/src/cli/chat/conversation.rs
+++ b/crates/chat-cli/src/cli/chat/conversation.rs
@@ -199,7 +199,7 @@ impl ConversationState {
             next_message: None,
             history: VecDeque::new(),
             valid_history_range: Default::default(),
-            transcript: VecDeque::with_capacity(MAX_CONVERSATION_STATE_HISTORY_LEN),
+            transcript: VecDeque::new(),
             tools: format_tool_spec(tool_config),
             context_manager,
             tool_manager,
@@ -1385,7 +1385,7 @@ mod tests {
         // First, build a large conversation history. We need to ensure that the order is always
         // User -> Assistant -> User -> Assistant ...and so on.
         conversation.set_next_user_message("start".to_string()).await;
-        for i in 0..=(MAX_CONVERSATION_STATE_HISTORY_LEN + 100) {
+        for i in 0..=200 {
             let s = conversation
                 .as_sendable_conversation_state(&os, &mut vec![], true)
                 .await
@@ -1415,7 +1415,7 @@ mod tests {
         )
         .await;
         conversation.set_next_user_message("start".to_string()).await;
-        for i in 0..=(MAX_CONVERSATION_STATE_HISTORY_LEN + 100) {
+        for i in 0..=200 {
             let s = conversation
                 .as_sendable_conversation_state(&os, &mut vec![], true)
                 .await
@@ -1451,7 +1451,7 @@ mod tests {
         )
         .await;
         conversation.set_next_user_message("start".to_string()).await;
-        for i in 0..=(MAX_CONVERSATION_STATE_HISTORY_LEN + 100) {
+        for i in 0..=200 {
             let s = conversation
                 .as_sendable_conversation_state(&os, &mut vec![], true)
                 .await
@@ -1511,7 +1511,7 @@ mod tests {
         // First, build a large conversation history. We need to ensure that the order is always
         // User -> Assistant -> User -> Assistant ...and so on.
         conversation.set_next_user_message("start".to_string()).await;
-        for i in 0..=(MAX_CONVERSATION_STATE_HISTORY_LEN + 100) {
+        for i in 0..=200 {
             let s = conversation
                 .as_sendable_conversation_state(&os, &mut vec![], true)
                 .await


### PR DESCRIPTION
*Description of changes:*
- The back-end limit on the maximum support conversation length has been removed, so we are instead relying on the current context window overflow logic to be used for managing conversation context length.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
