### PR TITLE
fix: make q settings delete functionality user friendly

### DIFF
--- a/crates/chat-cli/src/cli/settings.rs
+++ b/crates/chat-cli/src/cli/settings.rs
@@ -89,7 +89,13 @@ impl SettingsArgs {
             None => {
                 let Some(key) = &self.key else {
                     if self.delete {
-                        return Err(eyre::eyre!("the argument {} requires a {}\n Usage: q settings {} {}", "'--delete'".yellow(), "<KEY>".green(), "--delete".yellow(), "<KEY>".green()));
+                        return Err(eyre::eyre!(
+                            "the argument {} requires a {}\n Usage: q settings {} {}",
+                            "'--delete'".yellow(),
+                            "<KEY>".green(),
+                            "--delete".yellow(),
+                            "<KEY>".green()
+                        ));
                     }
                     return Ok(ExitCode::SUCCESS);
                 };


### PR DESCRIPTION
*Issue #, if available:*: N/A

*Description of changes:*
* When you user `q settings --help`, the delete option help says "Delete a value" when it should be `delete a key` as delete does not take value.
* Going by Usage as mentioned in `q settings --help`, when you type out `q settings -d chat.defaultAgent "some-value"` The error message shown is confusing and contradictory. It prints out two contradicting statement. As seen below 
```
dev-dsk-fast-chownira-2c-402b637c % q settings --delete chat.defaultAgent my-preferred-agent
error: the argument '--delete' cannot be used with '[VALUE]'

Usage: q settings --delete <KEY> [VALUE] <--- this contradicts above

For more information, try '--help'.

```
* Fixed both the above problems, now by mistake if user uses value in delete , it will print a user friendly correcting message
```
dev-dsk-fast-chownira-2c-402b637c % cargo run --bin chat_cli -- settings -d chat.defaultAgent "some-val"
   Compiling chat_cli v1.16.3 (/local/home/chownira/AmazonQ/amazon-q-developer-cli/crates/chat-cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 43.75s
     Running `target/debug/chat_cli settings -d chat.defaultAgent some-val`
error: the argument '--delete' cannot be used with '[VALUE]'
 Usage: q settings --delete chat.defaultAgent

``` 
## testing
Wrote a unit test and 
Ran
* cargo test
* cargo clippy
* cargo +nightly fmt

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
