### PR TITLE
add support for always inclusion steering files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,6 +1292,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2",
  "shell-color",
  "shell-words",
@@ -5782,6 +5783,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6909,6 +6923,12 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,7 @@ winreg = "0.55.0"
 schemars = "1.0.4"
 jsonschema = "0.30.0"
 rmcp = { version = "0.6.3", features = ["client", "transport-sse-client-reqwest", "reqwest", "transport-streamable-http-client-reqwest", "transport-child-process", "tower", "auth"] }
+serde_yaml = "0.9"
 
 [workspace.lints.rust]
 future_incompatible = "warn"

--- a/crates/chat-cli/Cargo.toml
+++ b/crates/chat-cli/Cargo.toml
@@ -118,6 +118,7 @@ winnow.workspace = true
 schemars.workspace = true
 jsonschema.workspace = true
 rmcp.workspace = true
+serde_yaml.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 nix.workspace = true

--- a/crates/chat-cli/src/cli/agent/mod.rs
+++ b/crates/chat-cli/src/cli/agent/mod.rs
@@ -189,6 +189,7 @@ impl Default for Agent {
                 "file://AGENTS.md",
                 "file://README.md",
                 "file://.amazonq/rules/**/*.md",
+                "file://.kiro/steering/**/*.md",
             ]
             .into_iter()
             .map(Into::into)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Add the steering files path to default agent config resources
- Only include the steering files if it has front matter as always, or not having/having invalid front matter (always is the default)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
