### PR TITLE
feat: Unify show and status commands for knowledge

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/knowledge.rs
+++ b/crates/chat-cli/src/cli/chat/cli/knowledge.rs
@@ -7,10 +7,7 @@ use crossterm::style::{
     Color,
 };
 use eyre::Result;
-use semantic_search_client::{
-    OperationStatus,
-    SystemStatus,
-};
+use semantic_search_client::SystemStatus;
 
 use crate::cli::chat::tools::sanitize_path_tool_arg;
 use crate::cli::chat::{
@@ -25,10 +22,15 @@ use crate::util::knowledge_store::KnowledgeStore;
 /// Knowledge base management commands
 #[derive(Clone, Debug, PartialEq, Eq, Subcommand)]
 pub enum KnowledgeSubcommand {
-    /// Display the knowledge base contents
+    /// Display the knowledge base contents and background operations
     Show,
     /// Add a file or directory to knowledge base
     Add {
+        /// Name for the knowledge base entry
+        #[arg(long, short = 'n')]
+        name: String,
+        /// Path to file or directory to add
+        #[arg(long, short = 'p')]
         path: String,
         /// Include patterns (e.g., `**/*.ts`, `**/*.md`)
         #[arg(long, action = clap::ArgAction::Append)]
@@ -47,8 +49,6 @@ pub enum KnowledgeSubcommand {
     Update { path: String },
     /// Remove all knowledge base entries
     Clear,
-    /// Show background operation status
-    Status,
     /// Cancel a background operation
     Cancel {
         /// Operation ID to cancel (optional - cancels most recent if not provided)
@@ -116,15 +116,15 @@ impl KnowledgeSubcommand {
                 }
             },
             KnowledgeSubcommand::Add {
+                name,
                 path,
                 include,
                 exclude,
                 index_type,
-            } => Self::handle_add(os, session, path, include, exclude, index_type).await,
+            } => Self::handle_add(os, session, name, path, include, exclude, index_type).await,
             KnowledgeSubcommand::Remove { path } => Self::handle_remove(os, session, path).await,
             KnowledgeSubcommand::Update { path } => Self::handle_update(os, session, path).await,
             KnowledgeSubcommand::Clear => Self::handle_clear(os, session).await,
-            KnowledgeSubcommand::Status => Self::handle_status(os, session).await,
             KnowledgeSubcommand::Cancel { operation_id } => {
                 Self::handle_cancel(os, session, operation_id.as_deref()).await
             },
@@ -148,16 +148,33 @@ impl KnowledgeSubcommand {
                 Ok(store) => {
                     let store = store.lock().await;
                     let contexts = store.get_all().await.unwrap_or_default();
+                    let status_data = store.get_status_data().await.ok();
 
-                    if contexts.is_empty() {
+                    // Show contexts if any exist
+                    if !contexts.is_empty() {
+                        Self::format_knowledge_entries_with_indent(session, &contexts, "    ")?;
+                    }
+
+                    // Show operations if any exist
+                    if let Some(status) = &status_data {
+                        if !status.operations.is_empty() {
+                            let formatted_status = Self::format_status_display(status);
+                            if !formatted_status.is_empty() {
+                                queue!(session.stderr, style::Print(format!("{}\n", formatted_status)))?;
+                            }
+                        }
+                    }
+
+                    // Only show <none> if both contexts and operations are empty
+                    if contexts.is_empty()
+                        && (status_data.is_none() || status_data.as_ref().unwrap().operations.is_empty())
+                    {
                         queue!(
                             session.stderr,
                             style::SetForegroundColor(Color::DarkGrey),
                             style::Print("    <none>\n\n"),
                             style::SetForegroundColor(Color::Reset)
                         )?;
-                    } else {
-                        Self::format_knowledge_entries_with_indent(session, &contexts, "    ")?;
                     }
                 },
                 Err(_) => {
@@ -194,14 +211,16 @@ impl KnowledgeSubcommand {
                 style::Print("\n")
             )?;
 
-            // Description line with original description
-            queue!(
-                session.stderr,
-                style::Print(format!("{}   ", indent)),
-                style::SetForegroundColor(Color::Grey),
-                style::Print(format!("{}\n", ctx.description)),
-                style::SetForegroundColor(Color::Reset)
-            )?;
+            // Path line if available (matching operation format)
+            if let Some(source_path) = &ctx.source_path {
+                queue!(
+                    session.stderr,
+                    style::Print(format!("{}   ", indent)),
+                    style::SetForegroundColor(Color::Grey),
+                    style::Print(format!("{}\n", source_path)),
+                    style::SetForegroundColor(Color::Reset)
+                )?;
+            }
 
             // Stats line with improved colors
             queue!(
@@ -237,6 +256,7 @@ impl KnowledgeSubcommand {
     async fn handle_add(
         os: &Os,
         session: &mut ChatSession,
+        name: &str,
         path: &str,
         include_patterns: &[String],
         exclude_patterns: &[String],
@@ -276,7 +296,7 @@ impl KnowledgeSubcommand {
                     .with_exclude_patterns(exclude)
                     .with_embedding_type(embedding_type_resolved);
 
-                match store.add(path, &sanitized_path.clone(), options).await {
+                match store.add(name, &sanitized_path.clone(), options).await {
                     Ok(message) => OperationResult::Info(message),
                     Err(e) => {
                         if e.contains("Invalid include pattern") || e.contains("Invalid exclude pattern") {
@@ -396,116 +416,52 @@ impl KnowledgeSubcommand {
         }
     }
 
-    /// Handle status operation
-    async fn handle_status(os: &Os, session: &ChatSession) -> OperationResult {
-        let agent = Self::get_agent(session);
-        let async_knowledge_store = match KnowledgeStore::get_async_instance(os, agent).await {
-            Ok(store) => store,
-            Err(e) => return OperationResult::Error(format!("Error accessing knowledge base directory: {}", e)),
-        };
-        let store = async_knowledge_store.lock().await;
-
-        match store.get_status_data().await {
-            Ok(status_data) => {
-                let formatted_status = Self::format_status_display(&status_data);
-                OperationResult::Info(formatted_status)
-            },
-            Err(e) => OperationResult::Error(format!("Failed to get status: {}", e)),
-        }
-    }
-
     /// Format status data for display (UI rendering responsibility)
     fn format_status_display(status: &SystemStatus) -> String {
-        let mut status_lines = Vec::new();
-
-        // Show knowledge base summary
-        status_lines.push(format!(
-            "📚 Total knowledge base entries: {} ({} persistent, {} volatile)",
-            status.total_contexts, status.persistent_contexts, status.volatile_contexts
-        ));
-
         if status.operations.is_empty() {
-            status_lines.push("✅ No active operations".to_string());
-            return status_lines.join("\n");
+            return String::new(); // No operations, no output
         }
 
-        status_lines.push("📊 Active Operations:".to_string());
-        status_lines.push(format!(
-            "  📈 Queue Status: {} active, {} waiting (max {} concurrent)",
-            status.active_count, status.waiting_count, status.max_concurrent
-        ));
-
+        let mut output = String::new();
         for op in &status.operations {
-            let formatted_operation = Self::format_operation_display(op);
-            status_lines.push(formatted_operation);
-        }
+            let operation_desc = op.operation_type.display_name();
 
-        status_lines.join("\n")
-    }
+            // Main entry line with operation name and ID (like knowledge entries)
+            output.push_str(&format!("    🔄 {} ({})\n", operation_desc, &op.short_id));
 
-    /// Format a single operation for display
-    fn format_operation_display(op: &OperationStatus) -> String {
-        let elapsed = op.started_at.elapsed().unwrap_or_default();
+            // Description/path line (indented like knowledge entries)
+            // Use actual path from operation type if available, otherwise use message
+            let description = match &op.operation_type {
+                semantic_search_client::OperationType::Indexing { path, .. } => path.clone(),
+                semantic_search_client::OperationType::Clearing => op.message.clone(),
+            };
+            output.push_str(&format!("       {}\n", description));
 
-        let (status_icon, status_info) = if op.is_cancelled {
-            ("🛑", "Cancelled".to_string())
-        } else if op.is_failed {
-            ("❌", op.message.clone())
-        } else if op.is_waiting {
-            ("⏳", op.message.clone())
-        } else if Self::should_show_progress_bar(op.current, op.total) {
-            ("🔄", Self::create_progress_bar(op.current, op.total, &op.message))
-        } else {
-            ("🔄", op.message.clone())
-        };
-
-        let operation_desc = op.operation_type.display_name();
-
-        // Format with conditional elapsed time and ETA
-        if op.is_cancelled || op.is_failed {
-            format!(
-                "  {} {} | {}\n    {}",
-                status_icon, op.short_id, operation_desc, status_info
-            )
-        } else {
-            let mut time_info = format!("Elapsed: {}s", elapsed.as_secs());
-
-            if let Some(eta) = op.eta {
-                time_info.push_str(&format!(" | ETA: {}s", eta.as_secs()));
+            // Status/progress line with ETA if available
+            if op.is_cancelled {
+                output.push_str("       Cancelled\n");
+            } else if op.is_failed {
+                output.push_str("       Failed\n");
+            } else if op.is_waiting {
+                output.push_str("       Waiting\n");
+            } else if Self::should_show_progress_bar(op.current, op.total) {
+                let percentage = (op.current as f64 / op.total as f64 * 100.0) as u8;
+                if let Some(eta) = op.eta {
+                    output.push_str(&format!("       {}% • ETA: {}s\n", percentage, eta.as_secs()));
+                } else {
+                    output.push_str(&format!("       {}%\n", percentage));
+                }
+            } else {
+                output.push_str("       In progress\n");
             }
-
-            format!(
-                "  {} {} | {}\n    {} | {}",
-                status_icon, op.short_id, operation_desc, status_info, time_info
-            )
         }
+
+        output.trim_end().to_string() // Remove trailing newline
     }
 
     /// Check if progress bar should be shown
     fn should_show_progress_bar(current: u64, total: u64) -> bool {
         total > 0 && current <= total
-    }
-
-    /// Create progress bar display
-    fn create_progress_bar(current: u64, total: u64, message: &str) -> String {
-        if total == 0 {
-            return message.to_string();
-        }
-
-        let percentage = (current as f64 / total as f64 * 100.0) as u8;
-        let filled = (current as f64 / total as f64 * 30.0) as usize;
-        let empty = 30 - filled;
-
-        let mut bar = String::new();
-        bar.push_str(&"█".repeat(filled));
-        if filled < 30 && current < total {
-            bar.push('▓');
-            bar.push_str(&"░".repeat(empty.saturating_sub(1)));
-        } else {
-            bar.push_str(&"░".repeat(empty));
-        }
-
-        format!("{} {}% ({}/{}) {}", bar, percentage, current, total, message)
     }
 
     /// Handle cancel operation
@@ -583,7 +539,6 @@ impl KnowledgeSubcommand {
             KnowledgeSubcommand::Remove { .. } => "remove",
             KnowledgeSubcommand::Update { .. } => "update",
             KnowledgeSubcommand::Clear => "clear",
-            KnowledgeSubcommand::Status => "status",
             KnowledgeSubcommand::Cancel { .. } => "cancel",
         }
     }
@@ -595,7 +550,7 @@ mod tests {
 
     use super::*;
 
-    #[derive(Parser)]
+    #[derive(Parser, Debug)]
     #[command(name = "test")]
     struct TestCli {
         #[command(subcommand)]
@@ -608,6 +563,9 @@ mod tests {
         let result = TestCli::try_parse_from([
             "test",
             "add",
+            "--name",
+            "my-project",
+            "--path",
             "/some/path",
             "--include",
             "*.rs",
@@ -623,9 +581,14 @@ mod tests {
         let cli = result.unwrap();
 
         if let KnowledgeSubcommand::Add {
-            path, include, exclude, ..
+            name,
+            path,
+            include,
+            exclude,
+            ..
         } = cli.knowledge
         {
+            assert_eq!(name, "my-project");
             assert_eq!(path, "/some/path");
             assert_eq!(include, vec!["*.rs", "**/*.md"]);
             assert_eq!(exclude, vec!["node_modules/**", "target/**"]);
@@ -650,14 +613,19 @@ mod tests {
     #[test]
     fn test_empty_patterns_allowed() {
         // Test that commands work without any patterns
-        let result = TestCli::try_parse_from(["test", "add", "/some/path"]);
+        let result = TestCli::try_parse_from(["test", "add", "--name", "my-project", "--path", "/some/path"]);
         assert!(result.is_ok());
 
         let cli = result.unwrap();
         if let KnowledgeSubcommand::Add {
-            path, include, exclude, ..
+            name,
+            path,
+            include,
+            exclude,
+            ..
         } = cli.knowledge
         {
+            assert_eq!(name, "my-project");
             assert_eq!(path, "/some/path");
             assert!(include.is_empty());
             assert!(exclude.is_empty());
@@ -672,6 +640,9 @@ mod tests {
         let result = TestCli::try_parse_from([
             "test",
             "add",
+            "--name",
+            "my-project",
+            "--path",
             "/some/path",
             "--include",
             "*.rs",
@@ -692,11 +663,30 @@ mod tests {
     }
 
     #[test]
+    fn test_add_command_with_name_and_path() {
+        // Test that add command accepts both name and path parameters
+        let result = TestCli::try_parse_from(["test", "add", "--name", "my-project", "--path", "/path/to/project"]);
+
+        assert!(result.is_ok());
+        let cli = result.unwrap();
+
+        if let KnowledgeSubcommand::Add { name, path, .. } = cli.knowledge {
+            assert_eq!(name, "my-project");
+            assert_eq!(path, "/path/to/project");
+        } else {
+            panic!("Expected Add subcommand");
+        }
+    }
+
+    #[test]
     fn test_multiple_exclude_patterns() {
         // Test multiple exclude patterns
         let result = TestCli::try_parse_from([
             "test",
             "add",
+            "--name",
+            "my-project",
+            "--path",
             "/some/path",
             "--exclude",
             "node_modules/**",

--- a/crates/chat-cli/src/cli/chat/tools/knowledge.rs
+++ b/crates/chat-cli/src/cli/chat/tools/knowledge.rs
@@ -36,8 +36,6 @@ pub enum Knowledge {
     Search(KnowledgeSearch),
     Update(KnowledgeUpdate),
     Show,
-    /// Show background operation status
-    Status,
     /// Cancel a background operation
     Cancel(KnowledgeCancel),
 }
@@ -148,7 +146,6 @@ impl Knowledge {
             },
             Knowledge::Search(_) => Ok(()),
             Knowledge::Show => Ok(()),
-            Knowledge::Status => Ok(()),
             Knowledge::Cancel(_) => Ok(()),
         }
     }
@@ -297,10 +294,10 @@ impl Knowledge {
                 }
             },
             Knowledge::Show => {
-                queue!(updates, style::Print("Showing all knowledge base entries"),)?;
-            },
-            Knowledge::Status => {
-                queue!(updates, style::Print("Checking background operation status"),)?;
+                queue!(
+                    updates,
+                    style::Print("Showing all knowledge base entries and background operations"),
+                )?;
             },
             Knowledge::Cancel(cancel) => {
                 queue!(
@@ -449,13 +446,19 @@ impl Knowledge {
                 }
             },
             Knowledge::Show => {
-                let contexts = store.get_all().await;
-                match contexts {
-                    Ok(contexts) => {
+                // Get both contexts and status data
+                let contexts_result = store.get_all().await;
+                let status_result = store.get_status_data().await;
+
+                match (contexts_result, status_result) {
+                    (Ok(contexts), Ok(status_data)) => {
+                        let mut output = String::new();
+
+                        // Add contexts section
                         if contexts.is_empty() {
-                            "No knowledge base entries found".to_string()
+                            output.push_str("No knowledge base entries found\n");
                         } else {
-                            let mut output = String::from("Knowledge base entries:\n");
+                            output.push_str("Knowledge base entries:\n");
                             for context in contexts {
                                 output.push_str(&format!("- ID: {}\n  Name: {}\n  Description: {}\n  Persistent: {}\n  Created: {}\n  Last Updated: {}\n  Items: {}\n\n",
                                     context.id,
@@ -467,19 +470,48 @@ impl Knowledge {
                                     context.item_count
                                 ));
                             }
-                            output
                         }
+
+                        // Add status section
+                        output.push('\n');
+                        output.push_str(&Self::format_status_display(&status_data));
+
+                        output
                     },
-                    Err(e) => format!("Failed to get knowledge base entries: {}", e),
-                }
-            },
-            Knowledge::Status => {
-                match store.get_status_data().await {
-                    Ok(status_data) => {
-                        // Format the status data for display (same logic as knowledge command)
-                        Self::format_status_display(&status_data)
+                    (Ok(contexts), Err(e)) => {
+                        // Show contexts but note status error
+                        let mut output = String::new();
+                        if contexts.is_empty() {
+                            output.push_str("No knowledge base entries found\n");
+                        } else {
+                            output.push_str("Knowledge base entries:\n");
+                            for context in contexts {
+                                output.push_str(&format!("- ID: {}\n  Name: {}\n  Description: {}\n  Persistent: {}\n  Created: {}\n  Last Updated: {}\n  Items: {}\n\n",
+                                    context.id,
+                                    context.name,
+                                    context.description,
+                                    context.persistent,
+                                    context.created_at.format("%Y-%m-%d %H:%M:%S"),
+                                    context.updated_at.format("%Y-%m-%d %H:%M:%S"),
+                                    context.item_count
+                                ));
+                            }
+                        }
+                        output.push_str(&format!("\nStatus unavailable: {}", e));
+                        output
                     },
-                    Err(e) => format!("Failed to get status: {}", e),
+                    (Err(e), Ok(status_data)) => {
+                        // Show status but note contexts error
+                        let mut output = format!("Contexts unavailable: {}\n\n", e);
+                        output.push_str(&Self::format_status_display(&status_data));
+                        output
+                    },
+                    (Err(contexts_err), Err(status_err)) => {
+                        format!(
+                            "Failed to get contexts: {}\nFailed to get status: {}",
+                            contexts_err, status_err
+                        )
+                    },
                 }
             },
             Knowledge::Cancel(cancel) => store
@@ -506,72 +538,44 @@ impl Knowledge {
 
     /// Format status data for display (UI rendering responsibility)
     fn format_status_display(status: &semantic_search_client::SystemStatus) -> String {
-        let mut status_lines = Vec::new();
-
-        // Show context summary
-        status_lines.push(format!(
-            "Total contexts: {} ({} persistent, {} volatile)",
-            status.total_contexts, status.persistent_contexts, status.volatile_contexts
-        ));
-
         if status.operations.is_empty() {
-            status_lines.push("No active operations".to_string());
-            return status_lines.join("\n");
+            return "No active operations".to_string();
         }
 
-        status_lines.push("Active Operations:".to_string());
-        status_lines.push(format!(
-            "Queue Status: {} active, {} waiting (max {} concurrent)",
-            status.active_count, status.waiting_count, status.max_concurrent
-        ));
-
+        let mut output = String::new();
         for op in &status.operations {
-            let formatted_operation = Self::format_operation_display(op);
-            status_lines.push(formatted_operation);
-        }
+            let operation_desc = op.operation_type.display_name();
 
-        status_lines.join("\n")
-    }
+            // Main entry line with operation name and ID (like knowledge entries)
+            output.push_str(&format!("🔄 {} ({})\n", operation_desc, &op.short_id));
 
-    /// Format a single operation for display (LLM-friendly data format)
-    fn format_operation_display(op: &semantic_search_client::OperationStatus) -> String {
-        let elapsed = op.started_at.elapsed().unwrap_or_default();
+            // Description/path line (indented like knowledge entries)
+            // Use actual path from operation type if available, otherwise use message
+            let description = match &op.operation_type {
+                semantic_search_client::OperationType::Indexing { path, .. } => path.clone(),
+                semantic_search_client::OperationType::Clearing => op.message.clone(),
+            };
+            output.push_str(&format!("   {}\n", description));
 
-        let status_info = if op.is_cancelled {
-            "Status: Cancelled".to_string()
-        } else if op.is_failed {
-            format!("Status: Failed - {}", op.message)
-        } else if op.is_waiting {
-            format!("Status: Waiting - {}", op.message)
-        } else if op.total > 0 {
-            let percentage = (op.current as f64 / op.total as f64 * 100.0) as u8;
-            format!(
-                "Status: In Progress - {}% ({}/{}) - {}",
-                percentage, op.current, op.total, op.message
-            )
-        } else {
-            format!("Status: In Progress - {}", op.message)
-        };
-
-        let operation_desc = op.operation_type.display_name();
-
-        // Format with conditional elapsed time and ETA
-        if op.is_cancelled || op.is_failed {
-            format!(
-                "Operation ID: {} | Type: {} | {}",
-                op.short_id, operation_desc, status_info
-            )
-        } else {
-            let mut time_info = format!("Elapsed: {}s", elapsed.as_secs());
-
-            if let Some(eta) = op.eta {
-                time_info.push_str(&format!(" | ETA: {}s", eta.as_secs()));
+            // Status/progress line with ETA if available
+            if op.is_cancelled {
+                output.push_str("   Cancelled\n");
+            } else if op.is_failed {
+                output.push_str("   Failed\n");
+            } else if op.is_waiting {
+                output.push_str("   Waiting\n");
+            } else if op.total > 0 {
+                let percentage = (op.current as f64 / op.total as f64 * 100.0) as u8;
+                if let Some(eta) = op.eta {
+                    output.push_str(&format!("   {}% • ETA: {}s\n", percentage, eta.as_secs()));
+                } else {
+                    output.push_str(&format!("   {}%\n", percentage));
+                }
+            } else {
+                output.push_str("   In progress\n");
             }
-
-            format!(
-                "Operation ID: {} | Type: {} | {} | {}",
-                op.short_id, operation_desc, status_info, time_info
-            )
         }
+
+        output.trim_end().to_string() // Remove trailing newline
     }
 }

--- a/docs/knowledge-management.md
+++ b/docs/knowledge-management.md
@@ -17,23 +17,34 @@ The knowledge feature is experimental and disabled by default. Enable it with:
 
 Once enabled, you can use `/knowledge` commands within your chat session:
 
-`/knowledge add myproject /path/to/project`
-`/knowledge show`
+```bash
+/knowledge add --name myproject --path /path/to/project
+/knowledge show
+```
 
 ## Commands
 
 #### `/knowledge show`
 
-Display all entries in your knowledge base with detailed information including creation dates, item counts, and persistence status.
+Display all entries in your knowledge base with detailed information including creation dates, item counts, and persistence status. Also shows any active background indexing operations with progress and ETA information.
 
-#### `/knowledge add <name> <path> [--include pattern] [--exclude pattern] [--index-type Fast|Best]`
+This unified command replaces the previous separate `/knowledge status` command, providing a complete view of both your stored knowledge and ongoing operations in one place.
+
+#### `/knowledge add --name <name> --path <path> [--include pattern] [--exclude pattern] [--index-type Fast|Best]`
 
 Add files or directories to your knowledge base. The system will recursively index all supported files in directories.
 
-`/knowledge add "project-docs" /path/to/documentation`
-`/knowledge add "config-files" /path/to/config.json`
-`/knowledge add "fast-search" /path/to/logs --index-type Fast`
-`/knowledge add "semantic-search" /path/to/docs --index-type Best`
+**Required Parameters:**
+- `--name` or `-n`: A descriptive name for the knowledge entry
+- `--path` or `-p`: Path to the file or directory to index
+
+**Examples:**
+```bash
+/knowledge add --name "project-docs" --path /path/to/documentation
+/knowledge add -n "config-files" -p /path/to/config.json
+/knowledge add --name "fast-search" --path /path/to/logs --index-type Fast
+/knowledge add -n "semantic-search" -p /path/to/docs --index-type Best
+```
 
 **Index Types**
 
@@ -144,10 +155,6 @@ Remove all entries from your knowledge base. This action requires confirmation a
 You'll be prompted to confirm:
 
 > ⚠️ This will remove ALL knowledge base entries. Are you sure? (y/N):
-
-#### `/knowledge status`
-
-View the status of background indexing operations, including progress and queue information.
 
 #### `/knowledge cancel [operation_id]`
 
@@ -274,7 +281,7 @@ Organizing Your Knowledge Base
 
 - Add project directories rather than individual files when possible
 - Use include/exclude patterns to avoid indexing build artifacts: `--exclude "target/**" --exclude "node_modules/**"`
-- Use /knowledge status to monitor indexing progress for large directories
+- Use /knowledge show to monitor indexing progress for large directories
 - Consider breaking very large projects into logical sub-directories
 
 #### Pattern Filtering Best Practices
@@ -314,7 +321,7 @@ If your files aren't appearing in search results:
 1. **Check patterns**: Ensure your include patterns match the files you want
 2. **Verify exclude patterns**: Make sure exclude patterns aren't filtering out desired files
 3. **Check file types**: Ensure your files have supported extensions
-4. **Monitor status**: Use /knowledge status to check if indexing is still in progress
+4. **Monitor progress**: Use /knowledge show to check if indexing is still in progress
 5. **Verify paths**: Ensure the paths you added actually exist and are accessible
 6. **Check for errors**: Look for error messages in the CLI output
 
@@ -322,7 +329,7 @@ If your files aren't appearing in search results:
 
 If searches aren't returning expected results:
 
-1. **Wait for indexing**: Use /knowledge status to ensure indexing is complete
+1. **Wait for indexing**: Use /knowledge show to ensure indexing is complete
 2. **Try different queries**: Use various phrasings and keywords
 3. **Verify content**: Use /knowledge show to confirm your content was added
 4. **Check file types**: Unsupported file types won't have searchable content
@@ -331,7 +338,7 @@ If searches aren't returning expected results:
 
 If operations are slow:
 
-1. **Check queue status**: Use /knowledge status to see operation queue
+1. **Check operations**: Use /knowledge show to see operation progress and queue
 2. **Cancel if needed**: Use /knowledge cancel to stop problematic operations
 3. **Add smaller chunks**: Consider adding subdirectories instead of entire large projects
 4. **Use better patterns**: Exclude unnecessary files with exclude patterns


### PR DESCRIPTION
- Unifies /knowledge status and /knowledge show
- Adds --path and --name args for consistency
- Add short flags: -n for --name, -p for --path
- Update documentation to reflect show/status unification and new flags

Usage examples:
/knowledge add -n myproject -p /path/to/project
/knowledge add --name docs --path /path/to/docs
/knowledge show  # Now shows both entries and operations

*Description of changes:*

<img width="438" height="195" alt="image" src="https://github.com/user-attachments/assets/8b3a5a01-6f9c-4930-88cb-97c4cc2f0826" />

Simplified UX.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
