### PR TITLE
fix(agent): Parse EDITOR environment variable to agent edit/create co…

### DIFF
--- a/crates/chat-cli/src/cli/agent/root_command_args.rs
+++ b/crates/chat-cli/src/cli/agent/root_command_args.rs
@@ -116,13 +116,8 @@ impl AgentArgs {
             Some(AgentSubcommands::Create { name, directory, from }) => {
                 let mut agents = Agents::load(os, None, true, &mut stderr, mcp_enabled).await.0;
                 let path_with_file_name = create_agent(os, &mut agents, name.clone(), directory, from).await?;
-                let editor_cmd = std::env::var("EDITOR").unwrap_or_else(|_| "vi".to_string());
-                let mut cmd = std::process::Command::new(editor_cmd);
 
-                let status = cmd.arg(&path_with_file_name).status()?;
-                if !status.success() {
-                    bail!("Editor process did not exit with success");
-                }
+                crate::util::editor::launch_editor(&path_with_file_name)?;
 
                 let Ok(content) = os.fs.read(&path_with_file_name).await else {
                     bail!(
@@ -148,13 +143,8 @@ impl AgentArgs {
                 let _agents = Agents::load(os, None, true, &mut stderr, mcp_enabled).await.0;
                 let (_agent, path_with_file_name) = Agent::get_agent_by_name(os, &name).await?;
 
-                let editor_cmd = std::env::var("EDITOR").unwrap_or_else(|_| "vi".to_string());
-                let mut cmd = std::process::Command::new(editor_cmd);
 
-                let status = cmd.arg(&path_with_file_name).status()?;
-                if !status.success() {
-                    bail!("Editor process did not exit with success");
-                }
+                crate::util::editor::launch_editor(&path_with_file_name)?;
 
                 let Ok(content) = os.fs.read(&path_with_file_name).await else {
                     bail!(

--- a/crates/chat-cli/src/cli/chat/cli/profile.rs
+++ b/crates/chat-cli/src/cli/chat/cli/profile.rs
@@ -195,13 +195,9 @@ impl AgentSubcommand {
                 let path_with_file_name = create_agent(os, &mut agents, name.clone(), directory, from)
                     .await
                     .map_err(|e| ChatError::Custom(Cow::Owned(e.to_string())))?;
-                let editor_cmd = std::env::var("EDITOR").unwrap_or_else(|_| "vi".to_string());
-                let mut cmd = std::process::Command::new(editor_cmd);
 
-                let status = cmd.arg(&path_with_file_name).status()?;
-                if !status.success() {
-                    return Err(ChatError::Custom("Editor process did not exit with success".into()));
-                }
+                crate::util::editor::launch_editor(&path_with_file_name)
+                    .map_err(|e| ChatError::Custom(Cow::Owned(e.to_string())))?;
 
                 let new_agent = Agent::load(
                     os,
@@ -253,13 +249,9 @@ impl AgentSubcommand {
                     .await
                     .map_err(|e| ChatError::Custom(Cow::Owned(e.to_string())))?;
 
-                let editor_cmd = std::env::var("EDITOR").unwrap_or_else(|_| "vi".to_string());
-                let mut cmd = std::process::Command::new(editor_cmd);
 
-                let status = cmd.arg(&path_with_file_name).status()?;
-                if !status.success() {
-                    return Err(ChatError::Custom("Editor process did not exit with success".into()));
-                }
+                crate::util::editor::launch_editor(&path_with_file_name)
+                    .map_err(|e| ChatError::Custom(Cow::Owned(e.to_string())))?;
 
                 let updated_agent = Agent::load(
                     os,

--- a/crates/chat-cli/src/util/editor.rs
+++ b/crates/chat-cli/src/util/editor.rs
@@ -1,0 +1,40 @@
+use std::path::Path;
+use std::process::Command;
+
+/// Launch the user's preferred editor with the given file path.
+///
+/// This function properly parses the EDITOR environment variable to handle
+/// editors that require arguments (e.g., "emacsclient -nw").
+///
+/// # Arguments
+/// * `file_path` - Path to the file to open in the editor
+///
+/// # Returns
+/// * `Ok(())` if the editor was launched successfully and exited with success
+/// * `Err` if the editor failed to launch or exited with an error
+pub fn launch_editor(file_path: &Path) -> eyre::Result<()> {
+    let editor_cmd = std::env::var("EDITOR").unwrap_or_else(|_| "vi".to_string());
+
+    // Parse the editor command to handle arguments
+    let mut parts = shlex::split(&editor_cmd)
+        .ok_or_else(|| eyre::eyre!("Failed to parse EDITOR command"))?;
+
+    if parts.is_empty() {
+        eyre::bail!("EDITOR environment variable is empty");
+    }
+
+    let editor_bin = parts.remove(0);
+
+    let mut cmd = Command::new(editor_bin);
+    for arg in parts {
+        cmd.arg(arg);
+    }
+
+    let status = cmd.arg(file_path).status()?;
+
+    if !status.success() {
+        eyre::bail!("Editor process did not exit with success");
+    }
+
+    Ok(())
+}

--- a/crates/chat-cli/src/util/mod.rs
+++ b/crates/chat-cli/src/util/mod.rs
@@ -1,5 +1,6 @@
 pub mod consts;
 pub mod directories;
+pub mod editor;
 pub mod knowledge_store;
 pub mod open;
 pub mod pattern_matching;


### PR DESCRIPTION
…mmands

Fix bug where 'q agent edit', '/agent edit', 'q agent create' and '/agent create' commands failed when EDITOR contained arguments (e.g., 'emacsclient -nw'). The commands were passing the entire string to Command::new() which expects only the executable name.

Now using shlex::split() to properly parse the command and arguments, matching the implementation in the /editor chat command.

🤖 Assisted by Amazon Q Developer

*Issue #, if available:* #3103  https://github.com/aws/amazon-q-developer-cli/issues/3103

*Description of changes:*
Fix bug where \`q agent edit\`, \`/agent edit\`, \`q agent create\` and \`/agent create\` commands failed when EDITOR environment variable contained arguments (e.g., \`emacsclient -nw\`).

The commands were passing the entire EDITOR string to \`Command::new()\` which expects only the executable name, not a command with arguments.

## Solution
- Created \`util::editor::launch_editor()\` helper function that properly parses EDITOR using \`shlex::split()\`
- Updated all 4 locations (agent create/edit in both CLI and chat session contexts) to use the shared helper

## Testing
- Tested with \`EDITOR=\"emacsclient -nw\"\` - commands now work correctly


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
