### PR TITLE
chore (mcp): upgrades rmcp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5364,9 +5364,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534fd1cd0601e798ac30545ff2b7f4a62c6f14edd4aaed1cc5eb1e85f69f09af"
+checksum = "583d060e99feb3a3683fb48a1e4bf5f8d4a50951f429726f330ee5ff548837f8"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5393,9 +5393,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba777eb0e5f53a757e36f0e287441da0ab766564ba7201600eeb92a4753022e"
+checksum = "421d8b0ba302f479214889486f9550e63feca3af310f1190efcf6e2016802693"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ winreg = "0.55.0"
 schemars = "1.0.4"
 jsonschema = "0.30.0"
 zip = "2.2.0"
-rmcp = { version = "0.7.0", features = ["client", "transport-sse-client-reqwest", "reqwest", "transport-streamable-http-client-reqwest", "transport-child-process", "tower", "auth"] }
+rmcp = { version = "0.8.0", features = ["client", "transport-sse-client-reqwest", "reqwest", "transport-streamable-http-client-reqwest", "transport-child-process", "tower", "auth"] }
 
 [workspace.lints.rust]
 future_incompatible = "warn"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Upgrades RMCP to 0.8.0.
The major change we are looking to include is the refinement for dynamic client registry url discovery: https://github.com/modelcontextprotocol/rust-sdk/pull/459

This is needed because some service endpoints (e.g. datadog) is failing DCR because oauth manager was not producing the correct registry url. 
I have verified that this fixes it. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
