### PR TITLE
feat: Add /tangent compact command

### DIFF
--- a/docs/tangent-mode.md
+++ b/docs/tangent-mode.md
@@ -39,6 +39,13 @@ Use `/tangent tail` to preserve the last conversation entry (question + answer):
 Restored conversation from checkpoint (↯) with last conversation entry preserved.
 ```
 
+### Exit Tangent Mode with Compact
+Use `/tangent compact` to summarize the tangent conversation into the main conversation:
+```
+↯ > /tangent compact
+Restored conversation from checkpoint (↯) with last tangent conversation summarized.
+```
+
 ## Usage Examples
 
 ### Example 1: Exploring Alternatives


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/amazon-q-developer-cli/issues/3079

*Description of changes:*
Implements the `/tangent compact` command that allows users to exit tangent mode while preserving a summarized version of the tangent conversation in the main conversation thread. This feature is an alternative to `tail` which only keeps the last question and answer in the context.

Also added visual feedback messages following the style of what is currently implemented for `/compact`, and description of the new feature on the tangent documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
