### PR TITLE
feat: add configurable OAuth redirect uri

### DIFF
--- a/crates/chat-cli/src/cli/chat/tools/custom_tool.rs
+++ b/crates/chat-cli/src/cli/chat/tools/custom_tool.rs
@@ -46,6 +46,15 @@ impl Default for TransportType {
 
 #[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
+pub struct OAuthConfig {
+    /// Custom redirect URI for OAuth flow (e.g., "127.0.0.1:7778")
+    /// If not specified, a random available port will be assigned by the OS
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub redirect_uri: Option<String>,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct CustomToolConfig {
     /// The transport type to use for communication with the MCP server
     #[serde(default)]
@@ -59,6 +68,9 @@ pub struct CustomToolConfig {
     /// Scopes with which oauth is done
     #[serde(default = "get_default_scopes")]
     pub oauth_scopes: Vec<String>,
+    /// OAuth configuration for this server
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oauth: Option<OAuthConfig>,
     /// The command string used to initialize the mcp server
     #[serde(default)]
     pub command: String,

--- a/crates/chat-cli/src/database/settings.rs
+++ b/crates/chat-cli/src/database/settings.rs
@@ -88,8 +88,6 @@ pub enum Setting {
     EnabledCheckpoint,
     #[strum(message = "Enable the delegate tool for subagent management (boolean)")]
     EnabledDelegate,
-    #[strum(message = "Port for OAuth redirect/callback server (number, default: 7777)")]
-    ChatOAuthRedirectPort,
 }
 
 impl AsRef<str> for Setting {
@@ -131,7 +129,6 @@ impl AsRef<str> for Setting {
             Self::EnabledCheckpoint => "chat.enableCheckpoint",
             Self::EnabledContextUsageIndicator => "chat.enableContextUsageIndicator",
             Self::EnabledDelegate => "chat.enableDelegate",
-            Self::ChatOAuthRedirectPort => "chat.oauthRedirectPort",
         }
     }
 }
@@ -181,7 +178,6 @@ impl TryFrom<&str> for Setting {
             "chat.enableTodoList" => Ok(Self::EnabledTodoList),
             "chat.enableCheckpoint" => Ok(Self::EnabledCheckpoint),
             "chat.enableContextUsageIndicator" => Ok(Self::EnabledContextUsageIndicator),
-            "chat.oauthRedirectPort" => Ok(Self::ChatOAuthRedirectPort),
             _ => Err(DatabaseError::InvalidSetting(value.to_string())),
         }
     }

--- a/crates/chat-cli/src/mcp_client/client.rs
+++ b/crates/chat-cli/src/mcp_client/client.rs
@@ -453,11 +453,12 @@ impl McpClientService {
                     url,
                     headers,
                     oauth_scopes: scopes,
+                    oauth,
                     timeout,
                     ..
                 } = &self.config;
 
-                let http_service_builder = HttpServiceBuilder::new(url, os, url, *timeout, scopes, headers, messenger);
+                let http_service_builder = HttpServiceBuilder::new(url, os, url, *timeout, scopes, headers, oauth, messenger);
 
                 let (service, auth_client_wrapper) = http_service_builder.try_build(&self).await?;
 

--- a/crates/chat-cli/src/mcp_client/oauth_util.rs
+++ b/crates/chat-cli/src/mcp_client/oauth_util.rs
@@ -56,7 +56,6 @@ use tracing::{
 use url::Url;
 
 use super::messenger::Messenger;
-use crate::database::settings::Setting;
 use crate::os::Os;
 use crate::util::directories::{
     DirectoryError,
@@ -197,6 +196,7 @@ pub struct HttpServiceBuilder<'a> {
     pub timeout: u64,
     pub scopes: &'a [String],
     pub headers: &'a HashMap<String, String>,
+    pub oauth_config: &'a Option<crate::cli::chat::tools::custom_tool::OAuthConfig>,
     pub messenger: &'a dyn Messenger,
 }
 
@@ -208,6 +208,7 @@ impl<'a> HttpServiceBuilder<'a> {
         timeout: u64,
         scopes: &'a [String],
         headers: &'a HashMap<String, String>,
+        oauth_config: &'a Option<crate::cli::chat::tools::custom_tool::OAuthConfig>,
         messenger: &'a dyn Messenger,
     ) -> Self {
         Self {
@@ -217,6 +218,7 @@ impl<'a> HttpServiceBuilder<'a> {
             timeout,
             scopes,
             headers,
+            oauth_config,
             messenger,
         }
     }
@@ -232,6 +234,7 @@ impl<'a> HttpServiceBuilder<'a> {
             timeout,
             scopes,
             headers,
+            oauth_config,
             messenger,
         } = self;
 
@@ -293,6 +296,7 @@ impl<'a> HttpServiceBuilder<'a> {
                                     cred_full_path.clone(),
                                     reg_full_path.clone(),
                                     scopes,
+                                    oauth_config,
                                     messenger,
                                     os,
                                 )
@@ -454,6 +458,7 @@ async fn get_auth_manager(
     cred_full_path: PathBuf,
     reg_full_path: PathBuf,
     scopes: &[String],
+    oauth_config: &Option<crate::cli::chat::tools::custom_tool::OAuthConfig>,
     messenger: &dyn Messenger,
     os: &Os,
 ) -> Result<AuthorizationManager, OauthUtilError> {
@@ -477,7 +482,7 @@ async fn get_auth_manager(
         _ => {
             info!("Error reading cached credentials");
             debug!("## mcp: cache read failed. constructing auth manager from scratch");
-            let (am, redirect_uri) = get_auth_manager_impl(oauth_state, scopes, messenger, os).await?;
+            let (am, redirect_uri) = get_auth_manager_impl(oauth_state, scopes, oauth_config, messenger, os).await?;
 
             // Client registration is done in [start_authorization]
             // If we have gotten past that point that means we have the info to persist the
@@ -512,15 +517,19 @@ async fn get_auth_manager(
 async fn get_auth_manager_impl(
     mut oauth_state: OAuthState,
     scopes: &[String],
+    oauth_config: &Option<crate::cli::chat::tools::custom_tool::OAuthConfig>,
     messenger: &dyn Messenger,
-    os: &Os,
+    _os: &Os,
 ) -> Result<(AuthorizationManager, String), OauthUtilError> {
-    // Get port from settings, default to 7777 if not configured
-    let port = os
-        .database
-        .settings
-        .get_int(Setting::ChatOAuthRedirectPort)
-        .map_or(7777, |p| p as u16);
+    // Get port from per-server oauth config, or use 0 for random port assignment
+    let port = oauth_config
+        .as_ref()
+        .and_then(|cfg| cfg.redirect_uri.as_ref())
+        .and_then(|uri| {
+            // Parse port from redirect_uri like "127.0.0.1:7778" or ":7778"
+            uri.split(':').last().and_then(|p| p.parse::<u16>().ok())
+        })
+        .unwrap_or(0); // Port 0 = OS assigns random available port
 
     let socket_addr = SocketAddr::from(([127, 0, 0, 1], port));
     let cancellation_token = tokio_util::sync::CancellationToken::new();

--- a/schemas/agent-v1.json
+++ b/schemas/agent-v1.json
@@ -94,6 +94,22 @@
               "offline_access"
             ]
           },
+          "oauth": {
+            "description": "OAuth configuration for this server",
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "redirectUri": {
+                "description": "Custom redirect URI for OAuth flow (e.g., \"127.0.0.1:7778\"). If not specified, a random available port will be assigned by the OS",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          },
           "command": {
             "description": "The command string used to initialize the mcp server",
             "type": "string",


### PR DESCRIPTION
Add support for custom redirect URI to support multiple remote MCP servers and requirement where an MCP server may require a hardcoded port. When not assigned in the mcp configuration, the current experience is preserved (randomly assigned port)

*Issue #, if available:* Request to be able to specify port/have dedicated port for `redirect_uri` since currently it was randomly assigned and this cannot be supported by the OAuth provider.

*Description of changes:*

Adds ability to specify a default OAuth redirect uri, per mcp server (similar to [Gemini CLI](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md#oauth-configuration-properties))

Example configuration

```

{

  "mcpServers": {

    "stripe": {

      "type": "http",

      "url": "https://mcp.stripe.com",

      "oauth": {

        "redirectUri": "127.0.0.1:7777"

      }

    },

    "vercel": {

      "type": "http",

      "url": "https://mcp.vercel.com",

      "oauth": {

        "redirectUri": "127.0.0.1:7778"

      }

    }

  }

}

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
