### PR TITLE
fix(schemas): Correct JSON schema reference for transport type

### DIFF
--- a/schemas/agent-v1.json
+++ b/schemas/agent-v1.json
@@ -65,7 +65,7 @@
         "properties": {
           "type": {
             "description": "The type of transport the mcp server is expecting. For http transport, only url (for now) is taken into account",
-            "$ref": "#/$definitions/TransportType",
+            "$ref": "#/definitions/TransportType",
             "default": "stdio"
           },
           "url": {


### PR DESCRIPTION
fix(schemas): Correct JSON schema reference for transport type
Fixes #3127 

*Description of changes:*
- Fixed incorrect JSON schema reference from `#/$definitions` to `#/definitions`
- Ensures proper JSON schema validation for transport type configuration
- Prevents potential parsing or validation errors in agent configuration

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
