### PR TITLE
fix:bug(checkpoint): fix crashes when truncating checkpoint message 

### DIFF
--- a/crates/chat-cli/src/cli/chat/checkpoint.rs
+++ b/crates/chat-cli/src/cli/chat/checkpoint.rs
@@ -28,6 +28,7 @@ use serde::{
 use tracing::debug;
 
 use crate::cli::ConversationState;
+use super::util::truncate_safe;
 use crate::cli::chat::conversation::HistoryEntry;
 use crate::os::Os;
 
@@ -370,7 +371,7 @@ pub fn truncate_message(s: &str, max_len: usize) -> String {
         return s.to_string();
     }
 
-    let truncated = &s[..max_len];
+    let truncated = truncate_safe(s, max_len);
     if let Some(pos) = truncated.rfind(' ') {
         format!("{}...", &truncated[..pos])
     } else {


### PR DESCRIPTION
*Issue #, if available: https://github.com/aws/amazon-q-developer-cli/issues/3136*

*Description of changes:*

When using checkpoint features, the user’s prompt is truncated through the `truncate_message` function. This function trims the prompt with a substring if its length is too long (length: 60).

However, in the case of multibyte characters such as those in CJK languages, **if a character is cut across a UTF-8 boundary, a panic occurs and the program terminates.**

**This PR removes such crashes and fixes the truncate_message** so that it works correctly.



*Screen Capture*

![checkpoint-crash](https://github.com/user-attachments/assets/aee474a9-b4b5-4e42-904a-f24160a66720)

