### PR TITLE
fix: removes outdated semantic_search folder migration

### DIFF
--- a/crates/chat-cli/src/util/knowledge_store.rs
+++ b/crates/chat-cli/src/util/knowledge_store.rs
@@ -162,25 +162,6 @@ impl KnowledgeStore {
             .and_then(|name| name.to_str())
             .unwrap_or(DEFAULT_AGENT_NAME);
 
-        // Migrate from legacy ~/.semantic_search
-        let old_flat_dir = dirs::home_dir()
-            .unwrap_or_else(|| PathBuf::from("."))
-            .join(".semantic_search");
-
-        if old_flat_dir.exists() && !agent_dir.exists() {
-            if let Some(parent) = agent_dir.parent() {
-                std::fs::create_dir_all(parent).ok();
-            }
-            if std::fs::rename(&old_flat_dir, agent_dir).is_ok() {
-                println!(
-                    "✅ Migrated knowledge base from {} to {}",
-                    old_flat_dir.display(),
-                    agent_dir.display()
-                );
-                return true;
-            }
-        }
-
         // Migrate from knowledge_bases root - get file list first to avoid recursion
         if let Some(kb_root) = agent_dir.parent() {
             if kb_root.exists() {


### PR DESCRIPTION
Remove legacy ~/.semantic_search migration logic that was causing compatibility issues for users. The migration was outdated and causing problems during knowledge base initialization.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
