### PR TITLE
fix: flush stdout after queue_description to display tool information

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -3269,6 +3269,8 @@ impl ChatSession {
             .await
             .map_err(|e| ChatError::Custom(format!("failed to print tool, `{}`: {}", tool_use.name, e).into()))?;
 
+        self.stdout.flush()?;
+
         Ok(())
     }
 


### PR DESCRIPTION
## Description
Fixes #3155 - Tool descriptions (e.g., file paths) were not displayed in permission prompts.

## Problem
When Q requests permission to use a tool, the tool description was not visible to users:

**Before:**
```
🛠️  Using tool: fs_read
 ⋮ 
 ● 
Allow this action? [y/n/t]:
```

**After:**
```
🛠️  Using tool: fs_read
 ⋮ 
 ● Reading file: /tmp/foo.txt, all lines
Allow this action? [y/n/t]:
```

## Root Cause
The `queue!` macro buffers output and requires an explicit `flush()` to display content. The `print_tool_description()` method was missing a `flush()` call after `queue_description()`.

## Changes
- Added `self.stdout.flush()?` in `print_tool_description()` method
- File: `crates/chat-cli/src/cli/chat/mod.rs`
- Lines: +2


## Checklist
- [x] Code follows the project's style guidelines
- [x] Changes have been tested locally
- [x] No breaking changes introduced
