### PR TITLE
fix(mcp): correct environment variable precedence in stdio transport

### DIFF
--- a/crates/chat-cli/src/mcp_client/client.rs
+++ b/crates/chat-cli/src/mcp_client/client.rs
@@ -427,11 +427,14 @@ impl McpClientService {
                 let expanded_cmd = shellexpand::full_with_context(command_as_str, home_dir, context)?;
 
                 let command = Command::new(expanded_cmd.as_ref() as &str).configure(|cmd| {
+                    // Set process environment variables first
+                    cmd.envs(std::env::vars()).args(args);
+
+                    // Then override with custom environment variables from config
                     if let Some(envs) = config_envs {
                         process_env_vars(envs, &os.env);
                         cmd.envs(envs);
                     }
-                    cmd.envs(std::env::vars()).args(args);
 
                     #[cfg(not(windows))]
                     cmd.process_group(0);


### PR DESCRIPTION
- Fix issue where parent process env vars overwrite custom MCP server env vars
- Ensure custom env vars from agent config take precedence over parent env
- Resolves bug introduced in RMCP migration (commit 1813bb77)

Fixes environment variable configuration not taking effect for MCP servers when specified in agent configuration files.

*Issue #, if available:*

*Description of changes:*
I found custom environment variable AWS_PROFILE set for MCP server is not applied to my MCP server after some update of Q CLI. After checking the code, I thought it's a bug introduced during RMCP migration. The change should work the same way as before the RMCP migration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
