### PR TITLE
feat: adds builtin tool namespace for tool permission

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/hooks.rs
+++ b/crates/chat-cli/src/cli/chat/cli/hooks.rs
@@ -76,7 +76,7 @@ fn hook_matches_tool(hook: &Hook, tool_name: &str) -> bool {
 
                     // Use matches_any_pattern for both MCP and built-in tools
                     let mut patterns = std::collections::HashSet::new();
-                    patterns.insert(pattern.clone());
+                    patterns.insert(pattern.as_str());
                     matches_any_pattern(&patterns, tool_name)
                 },
             }

--- a/crates/chat-cli/src/util/pattern_matching.rs
+++ b/crates/chat-cli/src/util/pattern_matching.rs
@@ -3,10 +3,10 @@ use std::collections::HashSet;
 use globset::Glob;
 
 /// Check if a string matches any pattern in a set of patterns
-pub fn matches_any_pattern(patterns: &HashSet<String>, text: &str) -> bool {
+pub fn matches_any_pattern(patterns: &HashSet<&str>, text: &str) -> bool {
     patterns.iter().any(|pattern| {
         // Exact match first
-        if pattern == text {
+        if *pattern == text {
             return true;
         }
 
@@ -30,7 +30,7 @@ mod tests {
     #[test]
     fn test_exact_match() {
         let mut patterns = HashSet::new();
-        patterns.insert("fs_read".to_string());
+        patterns.insert("fs_read");
 
         assert!(matches_any_pattern(&patterns, "fs_read"));
         assert!(!matches_any_pattern(&patterns, "fs_write"));
@@ -39,7 +39,7 @@ mod tests {
     #[test]
     fn test_wildcard_patterns() {
         let mut patterns = HashSet::new();
-        patterns.insert("fs_*".to_string());
+        patterns.insert("fs_*");
 
         assert!(matches_any_pattern(&patterns, "fs_read"));
         assert!(matches_any_pattern(&patterns, "fs_write"));
@@ -49,7 +49,7 @@ mod tests {
     #[test]
     fn test_mcp_patterns() {
         let mut patterns = HashSet::new();
-        patterns.insert("@mcp-server/*".to_string());
+        patterns.insert("@mcp-server/*");
 
         assert!(matches_any_pattern(&patterns, "@mcp-server/tool1"));
         assert!(matches_any_pattern(&patterns, "@mcp-server/tool2"));
@@ -59,7 +59,7 @@ mod tests {
     #[test]
     fn test_question_mark_wildcard() {
         let mut patterns = HashSet::new();
-        patterns.insert("fs_?ead".to_string());
+        patterns.insert("fs_?ead");
 
         assert!(matches_any_pattern(&patterns, "fs_read"));
         assert!(!matches_any_pattern(&patterns, "fs_write"));

--- a/crates/chat-cli/src/util/tool_permission_checker.rs
+++ b/crates/chat-cli/src/util/tool_permission_checker.rs
@@ -5,21 +5,43 @@ use tracing::debug;
 use crate::util::MCP_SERVER_TOOL_DELIMITER;
 use crate::util::pattern_matching::matches_any_pattern;
 
+const BUILT_IN_PREFIX: &str = "@builtin";
+const BUILT_IN_PREFIX_WITH_SLASH: &str = "@builtin/";
+
 /// Checks if a tool is allowed based on the agent's allowed_tools configuration.
 /// This function handles both native tools and MCP tools with wildcard pattern support.
 pub fn is_tool_in_allowlist(allowed_tools: &HashSet<String>, tool_name: &str, server_name: Option<&str>) -> bool {
-    let filter_patterns = |predicate: fn(&str) -> bool| -> HashSet<String> {
+    let filter_patterns = |predicate: fn(&str) -> bool| -> HashSet<&str> {
         allowed_tools
             .iter()
             .filter(|pattern| predicate(pattern))
-            .cloned()
+            .map(String::as_str)
             .collect()
     };
 
     match server_name {
         // Native tool
         None => {
-            let patterns = filter_patterns(|p| !p.starts_with('@'));
+            for name in allowed_tools {
+                if name
+                    .strip_prefix(BUILT_IN_PREFIX)
+                    .is_some_and(|n| n.is_empty() || n == "/" || n == "/*")
+                {
+                    return true;
+                }
+            }
+
+            let patterns = allowed_tools
+                .iter()
+                .filter_map(|p| {
+                    if !p.starts_with('@') {
+                        Some(p.as_str())
+                    } else {
+                        p.strip_prefix(BUILT_IN_PREFIX_WITH_SLASH)
+                    }
+                })
+                .collect::<HashSet<_>>();
+
             debug!("Native patterns: {:?}", patterns);
             let result = matches_any_pattern(&patterns, tool_name);
             debug!("Native tool '{}' permission check result: {}", tool_name, result);
@@ -78,5 +100,31 @@ mod tests {
         assert!(is_tool_in_allowlist(&allowed, "tool", Some("quip-server")));
         assert!(is_tool_in_allowlist(&allowed, "read_file", Some("git")));
         assert!(!is_tool_in_allowlist(&allowed, "write_file", Some("git")));
+    }
+
+    #[test]
+    fn test_builtin_namespace() {
+        let mut allowed = HashSet::new();
+        allowed.insert("@builtin".to_string());
+        allowed.insert("@builtin/".to_string());
+        allowed.insert("@builtin/*".to_string());
+
+        // @builtin should allow all native tools
+        assert!(is_tool_in_allowlist(&allowed, "fs_read", None));
+
+        // But should not allow MCP tools
+        assert!(!is_tool_in_allowlist(&allowed, "tool", Some("server")));
+
+        allowed.clear();
+        allowed.insert("@builtin/fs_read".to_string());
+
+        assert!(is_tool_in_allowlist(&allowed, "fs_read", None));
+        assert!(!is_tool_in_allowlist(&allowed, "fs_write", None));
+
+        allowed.clear();
+        allowed.insert("@builtin/fs_*".to_string());
+
+        assert!(is_tool_in_allowlist(&allowed, "fs_read", None));
+        assert!(is_tool_in_allowlist(&allowed, "fs_write", None));
     }
 }

--- a/docs/agent-format.md
+++ b/docs/agent-format.md
@@ -212,6 +212,8 @@ The `allowedTools` field supports glob-style wildcard patterns using `*` and `?`
 - **Server pattern**: `"@*-mcp/read_*"` → matches `@git-mcp/read_file`, `@db-mcp/read_data`
 - **Any tool from pattern servers**: `"@git-*/*"` → matches any tool from servers matching `git-*`
 
+Optionally, you can also prefix native tools with the namespace `@builtin`.
+
 ### Examples
 
 ```json
@@ -226,6 +228,7 @@ The `allowedTools` field supports glob-style wildcard patterns using `*` and `?`
     "fs_*",                    // All filesystem tools
     "execute_*",               // All execute tools
     "*_test",                  // Any tool ending in _test
+    @builtin,                // All native tools
     
     // MCP tool wildcards
     "@server/api_*",           // All API tools from server


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
As titled. 

This allows us to specify only the builtin tools in allowTools as such: 
```
  "allowedTools": [
    "@builtin"
  ],
```

I had also made the relevant util function to operate on reference instead to save some allocations. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
