### PR TITLE
refactor: dynamically generate command list

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/mod.rs
+++ b/crates/chat-cli/src/cli/chat/cli/mod.rs
@@ -123,7 +123,7 @@ pub enum SlashCommand {
     )]
     Checkpoint(CheckpointSubcommand),
     /// View, manage, and resume to-do lists
-    #[command(subcommand)]
+    #[command(subcommand, hide = true)]
     Todos(TodoSubcommand),
     /// Paste an image from clipboard
     Paste(PasteArgs),


### PR DESCRIPTION
*Issue #, if available:*
#3185 

*Description of changes:*
Replace static `COMMANDS` array with dynamic generation to automatically sync available commands with SlashCommand
enum definition. This prevents inconsistencies like #3185 where unimplemented commands (e.g., `/hooks help`) appeared in the command list.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
