### PR TITLE
fix: opaque error when session expires

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -832,6 +832,26 @@ impl ChatSession {
         }
 
         let (context, report, display_err_message) = match err {
+            ChatError::Auth(AuthError::NoToken) => {
+                execute!(
+                    self.stderr,
+                    style::SetAttribute(Attribute::Bold),
+                    StyledText::error_fg(),
+                    style::Print("Authentication Error\n"),
+                    StyledText::reset_attributes(),
+                    StyledText::reset(),
+                    style::Print("\nYour login session has expired. Please log in again using:\n\n"),
+                    StyledText::success_fg(),
+                    style::Print("    q login\n\n"),
+                    StyledText::reset(),
+                )?;
+
+                self.conversation
+                    .append_transcript("Authentication expired - please log in again".to_string());
+
+                self.inner = Some(ChatState::Exit);
+                return Ok(());
+            },
             ChatError::Interrupted { tool_uses: ref inter } => {
                 execute!(self.stderr, style::Print("\n\n"))?;
 


### PR DESCRIPTION
*Issue #, if available:*
#3173

*Description of changes:*
Improves the error message when a user's authentication session expires during an active chat session.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
