### PR TITLE
fix: save convo with context

### DIFF
--- a/crates/chat-cli/src/cli/chat/context.rs
+++ b/crates/chat-cli/src/cli/chat/context.rs
@@ -41,8 +41,7 @@ impl Serialize for ContextFilePath {
         S: Serializer,
     {
         match self {
-            ContextFilePath::Agent(path) => path.serialize(serializer),
-            ContextFilePath::Session(_) => Err(serde::ser::Error::custom("Session paths are not serialized")),
+            ContextFilePath::Agent(path) | ContextFilePath::Session(path) => path.serialize(serializer),
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/amazon-q-developer-cli/issues/2652
https://github.com/aws/amazon-q-developer-cli/issues/2912

*Description of changes:*
As titled. 
Note that when loading convo with saved context, we are going to do the following:
- Examine to see if file path is in the current agent's permanent scope
- If it is NOT present, move it to the current agent's session paths 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
