### PR TITLE
Fix knowledge migration moving agent directories

### DIFF
--- a/crates/chat-cli/src/util/knowledge_store.rs
+++ b/crates/chat-cli/src/util/knowledge_store.rs
@@ -169,9 +169,14 @@ impl KnowledgeStore {
                     let files_to_migrate: Vec<_> = entries
                         .flatten()
                         .filter(|entry| {
+                            let path = entry.path();
                             let name = entry.file_name();
                             let name_str = name.to_string_lossy();
-                            name_str != current_agent_id && name_str != DEFAULT_AGENT_NAME && !name_str.starts_with('.')
+                            // Only migrate FILES, not directories (to avoid moving other agent directories)
+                            path.is_file()
+                                && name_str != current_agent_id
+                                && name_str != DEFAULT_AGENT_NAME
+                                && !name_str.starts_with('.')
                         })
                         .collect();
 


### PR DESCRIPTION
Fixes #3148

## Problem
The `migrate_legacy_knowledge_base` function was incorrectly moving other agent directories into the current agent's directory when running `/knowledge show`. This created nested directory structures like:
```
~/.aws/amazonq/knowledge_bases/
  agent_a/
    agent_b/  <-- Wrong! Agent B nested inside Agent A
```

## Root Cause
The migration logic didn't distinguish between files and directories when filtering entries in the knowledge_bases root. It was treating other agent directories as "legacy files" to migrate.

## Solution
Added a check to ensure only FILES are migrated from the root directory, leaving other agent directories untouched.

## Testing
- Verified the filter now checks `path.is_file()` before migrating
- Other agent directories will no longer be moved into the current agent's directory