### PR TITLE
In non-interactive mode, request alternative method on tool rejection

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -752,6 +752,8 @@ impl ChatSession {
                         return Ok(());
                     },
                     (false, false) => {
+                        // This should be unreachable now - tools are rejected in the permission loop
+                        error!("Reached PromptUser with pending tools in non-interactive mode");
                         return Err(ChatError::NonInteractiveToolApproval);
                     },
                     _ => (),
@@ -2198,6 +2200,9 @@ impl ChatSession {
             self.conversation.enter_tangent_mode();
         }
 
+        // Initialize tool_results to collect errors for rejected tools
+        let mut tool_results: Vec<ToolUseResult> = vec![];
+
         // Verify tools have permissions.
         for i in 0..self.tool_uses.len() {
             let tool = &mut self.tool_uses[i];
@@ -2283,6 +2288,30 @@ impl ChatSession {
                 continue;
             }
 
+            // Handle non-interactive mode - reject tool and continue
+            if !self.interactive {
+                let error_message = format!(
+                    "Tool '{}' requires approval but --no-interactive was specified. \
+                    This tool is not trusted. Please try an alternative approach.",
+                    tool.name
+                );
+                
+                tool_results.push(ToolUseResult {
+                    tool_use_id: tool.id.clone(),
+                    content: vec![ToolUseResultBlock::Text(error_message)],
+                    status: ToolResultStatus::Error,
+                });
+                
+                self.tool_use_telemetry_events
+                    .entry(tool.id.clone())
+                    .and_modify(|ev| {
+                        ev.is_trusted = false;
+                        ev.is_accepted = false;
+                    });
+                
+                continue;
+            }
+
             self.pending_tool_index = Some(i);
 
             return Ok(ChatState::PromptUser {
@@ -2292,10 +2321,14 @@ impl ChatSession {
 
         // All tools are allowed now
         // Execute the requested tools.
-        let mut tool_results = vec![];
         let mut image_blocks: Vec<RichImageBlock> = Vec::new();
 
         for tool in &self.tool_uses {
+            // Skip tools that weren't accepted (already have error results)
+            if !tool.accepted {
+                continue;
+            }
+
             let tool_start = std::time::Instant::now();
             let mut tool_telemetry = self.tool_use_telemetry_events.entry(tool.id.clone());
             tool_telemetry = tool_telemetry.and_modify(|ev| {


### PR DESCRIPTION
*Issue #, if available:* #1958

*Description of changes:*

This is a proof-of-concept proposal to improve the user experience when running in non-interactive mode without trusting all tools. Existing behavior is to fail and stop the ensure session when an untrusted tool call is attempted. When running in interactive mode, the agent+model are able to find workarounds in some cases -- perhaps a trusted tool can be used instead. This change handles denied tool calls by asking the model to try an alternative approach intead of stopping the session.

This is meant to be a dirt simple version of @swapneils suggestion from #1958, that makes no distinction between "partially trusted" and untrusted tools. If the tool execution is denied, whatever the reason, the model is asked to try an alternative approach.

**This is meant as a proposal, and needs refinement, but I'm posting it now to see what people think about the general approach**. Possible issues with this simple implementation include:

- Maybe this is just a bad idea entirely, for reasons I don't yet understand, and it is important that untrusted tools always fail in non-interactive mode.
- This could be behind an opt-in flag, kind of an alternative to `trust-all-tools`.
- May not handle specifically `denied` tools correctly (I have simply not tested this case)
- Unclear how reasonable the UX actually is. I'm not sure under what conditions in more complicated real world sessions Q will actually end up *successfully* trying another approach.
- We probably need to do something to prevent infinite looping on attempts that will never work, such as ping-ponging between two denied tools.
- I haven't added any automated tests. Of course, it didn't break any existing tests either :) But it would be nice to have some coverage of this behavior if feasible.

### Testing

Agent config used:
```json
{
  "$schema": "https://raw.githubusercontent.com/aws/amazon-q-developer-cli/refs/heads/main/schemas/agent-v1.json",
  "name": "find-only",
  "description": "Agent for finding.",
  "prompt": "You are an agent that can only use find.",
  "mcpServers": {},
  "tools": [
    "fs_read",
    "execute_bash"
  ],
  "toolAliases": {},
  "allowedTools": [],
  "resources": [],
  "hooks": {},
  "toolsSettings": {
    "execute_bash": {
      "allowedCommands": ["find .*"]
    }
  },
  "useLegacyMcpJson": false
}
```

Without this change:
```
% q chat --no-interactive --agent find-only "read and display the file SECURITY.md with the cat command"

... <banner etc.> ...

🤖 You are chatting with claude-sonnet-4.5

🛠️  Using tool: execute_bash
 ⋮ 
 ● I will run the following shell command: cat SECURITY.md
 ⋮ 
 ↳ Purpose: Display the contents of SECURITY.md

error: Tool approval required but --no-interactive was specified. Use --trust-all-tools to automatically approve tools.
```

With this change:

```
% cargo run --bin chat_cli -- chat --no-interactive --agent find-only "read and display the file SECURITY.md with the cat command"                                                                        

... <banner etc.> ...   

🤖 You are chatting with claude-sonnet-4.5

🛠️  Using tool: execute_bash
 ⋮ 
 ● I will run the following shell command: cat SECURITY.md
 ⋮ 
 ↳ Purpose: Display the contents of SECURITY.md


> I cannot execute bash commands in this mode. Let me read the file using the available file reading tool:


🛠️  Using tool: fs_read (trusted)
 ⋮ 
 ● Reading file: SECURITY.md, all lines
 ✓ Successfully read 520 bytes from SECURITY.md
 ⋮ 
 ● Completed in 0.0s


> Here's the content of SECURITY.md:

# Reporting Security Issues

We take all security reports seriously. When we receive such reports, we will investigate and subsequently address any potential vulnerabilities as quickly as possible. If you discover a potential security issue in this project, please notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/) or directly via email to [AWS Security](mailto:aws-security@amazon.com). Please do not create a public GitHub issue in this project.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
