### PR TITLE
Fix: non-interactive output incorrectly sent to stderr instead of stdout

### DIFF
--- a/crates/chat-cli-ui/src/conduit.rs
+++ b/crates/chat-cli-ui/src/conduit.rs
@@ -298,7 +298,7 @@ impl std::io::Write for ControlEnd<DestinationStdout> {
             if byte == &10 || byte == &13 {
                 if self.current_event.is_none() {
                     self.current_event
-                        .replace(Event::LegacyPassThrough(LegacyPassThroughOutput::Stderr(
+                        .replace(Event::LegacyPassThrough(LegacyPassThroughOutput::Stdout(
                             Default::default(),
                         )));
                 }
@@ -323,7 +323,7 @@ impl std::io::Write for ControlEnd<DestinationStdout> {
         if start < end {
             if self.current_event.is_none() {
                 self.current_event
-                    .replace(Event::LegacyPassThrough(LegacyPassThroughOutput::Stderr(
+                    .replace(Event::LegacyPassThrough(LegacyPassThroughOutput::Stdout(
                         Default::default(),
                     )));
             }


### PR DESCRIPTION
*Issue #, if available:*
Solves an internal TT related to non-interactive output redirection

*Description of changes:*
This PR fixes an issue introduced in the refactor of the legacy conduit system where
`ControlEnd<DestinationStdout>` was incorrectly initializing `LegacyPassThroughOutput::Stderr`,
causing non-interactive model output to be written to `stderr` instead of `stdout`.
https://github.com/aws/amazon-q-developer-cli/pull/3112/files#diff-a668f28dd7d3f5a5cf37bc315f83d6a5b4f05005651a607c6ec0858770358a31R301-R302


Verified output stream behavior via `q chat --no-interactive "how are you?" 2>/dev/null` — output now correctly appears on stdout.
`> I'm doing well, thanks for asking! I'm here and ready to help you with AWS services, development tasks, or any technical questions you might  have. What can I assist you with today?`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
