### PR TITLE
fix: removes color from spinner

### DIFF
--- a/crates/chat-cli/src/cli/chat/custom_spinner.rs
+++ b/crates/chat-cli/src/cli/chat/custom_spinner.rs
@@ -26,7 +26,7 @@ impl Spinners {
         pb.set_style(
             ProgressStyle::default_spinner()
                 .tick_chars(SPINNER_CHARS)
-                .template("{spinner:.green} {msg}")
+                .template("{spinner} {msg}")
                 .unwrap(),
         );
         pb.set_message(message);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
As titled.
This was added by accident.
It was also outputting partial ANSI codes sometimes. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
