### PR TITLE
fix: display aliased tool names in UI (#2564)

### DIFF
--- a/crates/chat-cli/src/cli/chat/tool_manager.rs
+++ b/crates/chat-cli/src/cli/chat/tool_manager.rs
@@ -916,6 +916,7 @@ impl ToolManager {
 
                 Tool::Custom(CustomTool {
                     name: tool_name.to_owned(),
+                    display_name: Some(name.to_owned()),
                     server_name: server_name.to_owned(),
                     client: running_service.clone(),
                     params: value.args.as_object().cloned(),

--- a/crates/chat-cli/src/cli/chat/tools/custom_tool.rs
+++ b/crates/chat-cli/src/cli/chat/tools/custom_tool.rs
@@ -109,6 +109,9 @@ pub struct CustomTool {
     /// Actual tool name as recognized by its MCP server. This differs from the tool names as they
     /// are seen by the model since they are not prefixed by its MCP server name.
     pub name: String,
+    /// Display name for the tool (may be an alias). Used for UI display purposes.
+    /// If None, falls back to using `name`.
+    pub display_name: Option<String>,
     /// The name of the MCP (Model Context Protocol) server that hosts this tool.
     /// This is used to identify which server instance the tool belongs to and is
     /// prefixed to the tool name when presented to the model for disambiguation.

--- a/crates/chat-cli/src/cli/chat/tools/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/mod.rs
@@ -114,7 +114,13 @@ impl Tool {
             #[cfg(not(windows))]
             Tool::ExecuteCommand(_) => "execute_bash",
             Tool::UseAws(_) => "use_aws",
-            Tool::Custom(custom_tool) => &custom_tool.name,
+            Tool::Custom(custom_tool) => {
+                return custom_tool
+                    .display_name
+                    .as_deref()
+                    .unwrap_or(&custom_tool.name)
+                    .to_owned();
+            },
             Tool::GhIssue(_) => "gh_issue",
             Tool::Introspect(_) => "introspect",
             Tool::Knowledge(_) => "knowledge",


### PR DESCRIPTION
Fixes #2564

## Problem
The `toolAliases` feature works functionally (tools execute correctly), but the UI displays original tool names instead of the configured aliases.

**Before:**
```
🛠️  Using tool: getConfluencePage from mcp server atlassian_slalom
```

**After:**
```
🛠️  Using tool: getSlalomPage from mcp server atlassian_slalom
```

## Solution
Added a `display_name` field to `CustomTool` to separate display concerns from MCP invocation:
- `name` field: Original tool name (sent to MCP server)
- `display_name` field: Aliased name (shown in UI)
- `display_name()` method: Uses alias if present, falls back to original name

## Testing
- ✅ All existing tests pass (327 passed, 0 failed)
- ✅ Clippy clean (no new warnings)
- ✅ Code formatted with `cargo +nightly fmt`
- ✅ Manually tested with multi-instance MCP agent
- ✅ Verified: UI shows alias, MCP receives original name, tools execute correctly

## Changes
- `crates/chat-cli/src/cli/chat/tools/custom_tool.rs`: Add `display_name` field
- `crates/chat-cli/src/cli/chat/tools/mod.rs`: Update `display_name()` to use alias
- `crates/chat-cli/src/cli/chat/tool_manager.rs`: Set `display_name` when creating CustomTool

**Impact:** Cosmetic fix only, fully backward compatible (Optional field with fallback)