### PR TITLE
fix: install cross using --locked

### DIFF
--- a/build-config/buildspec-linux.yml
+++ b/build-config/buildspec-linux.yml
@@ -22,7 +22,7 @@ phases:
       - . "$HOME/.cargo/env"
       - rustup toolchain install `cat rust-toolchain.toml | grep channel | cut -d '=' -f2 | tr -d ' "'`
       # Install cross only if the musl env var is set and not null
-      - if [ ! -z "${AMAZON_Q_BUILD_MUSL:+x}" ]; then cargo install cross --git https://github.com/cross-rs/cross; fi
+      - if [ ! -z "${AMAZON_Q_BUILD_MUSL:+x}" ]; then cargo install cross --git https://github.com/cross-rs/cross --locked; fi
       # Install python/node via mise (https://mise.jdx.dev/continuous-integration.html)
       - curl --retry 5 --proto '=https' --tlsv1.2 -sSf https://mise.run | sh
       - mise install


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Installing `cross` in CI is failing because it is trying to use a version of `home` that requires rustc 1.88.0, but CI requires 1.87.0. `cross` lockfile still uses a compatible version of `home`, hence installing with `--locked`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
