### PR TITLE
fix: prevent delegate tool from bypassing user permission denial

### DIFF
--- a/crates/chat-cli/src/cli/chat/tools/delegate.rs
+++ b/crates/chat-cli/src/cli/chat/tools/delegate.rs
@@ -488,7 +488,10 @@ pub async fn request_user_approval(agent: &str, agents: &Agents, task: &str) -> 
         .ok_or(eyre::eyre!("No agent by the name {agent} found"))?
         .into();
     display_agent_info(agent, task, &config)?;
-    get_user_confirmation()?;
+    
+    if !get_user_confirmation()? {
+        return Err(eyre::eyre!("User declined to proceed with delegation"));
+    }
 
     Ok(())
 }


### PR DESCRIPTION
The delegate tool was not properly checking user approval responses. When get_user_confirmation() returned Ok(false) (user declined), the ? operator would not trigger an error, allowing delegation to proceed despite user denial.

This fix explicitly checks the boolean return value and returns an error when the user declines, preventing unauthorized delegation.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
