### PR TITLE
fix: Restrict profile command to idc users only

### DIFF
--- a/crates/chat-cli/src/auth/builder_id.rs
+++ b/crates/chat-cli/src/auth/builder_id.rs
@@ -611,14 +611,14 @@ impl ResolveIdentity for BearerResolver {
     }
 }
 
-pub async fn is_idc_user(database: &Database) -> Result<bool> {
+pub async fn is_idc_user(database: &Database) -> bool {
     if cfg!(test) {
-        return Ok(false);
+        return false;
     }
     if let Ok(Some(token)) = BuilderIdToken::load(database).await {
-        Ok(token.token_type() == TokenType::IamIdentityCenter)
+        token.token_type() == TokenType::IamIdentityCenter
     } else {
-        Ok(false)
+        false
     }
 }
 

--- a/crates/chat-cli/src/cli/chat/cli/subscribe.rs
+++ b/crates/chat-cli/src/cli/chat/cli/subscribe.rs
@@ -37,10 +37,7 @@ pub struct SubscribeArgs {
 
 impl SubscribeArgs {
     pub async fn execute(self, os: &mut Os, session: &mut ChatSession) -> Result<ChatState, ChatError> {
-        if is_idc_user(&os.database)
-            .await
-            .map_err(|e| ChatError::Custom(e.to_string().into()))?
-        {
+        if is_idc_user(&os.database).await {
             execute!(
                 session.stderr,
                 StyledText::warning_fg(),

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -3737,7 +3737,7 @@ enum ActualSubscriptionStatus {
 //
 // Also, it is currently not possible to subscribe or re-subscribe via console, only IDE/CLI.
 async fn get_subscription_status(os: &mut Os) -> Result<ActualSubscriptionStatus> {
-    if is_idc_user(&os.database).await? {
+    if is_idc_user(&os.database).await {
         return Ok(ActualSubscriptionStatus::Active);
     }
 

--- a/crates/chat-cli/src/cli/user.rs
+++ b/crates/chat-cli/src/cli/user.rs
@@ -339,7 +339,7 @@ pub enum LicenseType {
 }
 
 pub async fn profile(os: &mut Os) -> Result<ExitCode> {
-    if !is_idc_user(&os.database).await? {
+    if !is_idc_user(&os.database).await {
         bail!("This command is only available for IAM Identity Center users");
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated profile command to check user type before calling service
Non-IDC users now receive clear error message: "This command is only available for IAM Identity Center users"
<img width="978" height="76" alt="image" src="https://github.com/user-attachments/assets/4f0b7682-c05f-47d6-a899-95f24364d064" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
