### PR TITLE
 [Issue #3263] feat: persist login method choice and default to previous selection

### DIFF
--- a/crates/chat-cli/src/database/mod.rs
+++ b/crates/chat-cli/src/database/mod.rs
@@ -58,6 +58,7 @@ const CLIENT_ID_KEY: &str = "telemetryClientId";
 const CODEWHISPERER_PROFILE_KEY: &str = "api.codewhisperer.profile";
 const START_URL_KEY: &str = "auth.idc.start-url";
 const IDC_REGION_KEY: &str = "auth.idc.region";
+const LOGIN_METHOD_KEY: &str = "auth.login-method";
 // We include this key to remove for backwards compatibility
 const CUSTOMIZATION_STATE_KEY: &str = "api.selectedCustomization";
 const PROFILE_MIGRATION_KEY: &str = "profile.Migrated";
@@ -322,6 +323,16 @@ impl Database {
     pub fn set_idc_region(&mut self, region: String) -> Result<usize, DatabaseError> {
         // Annoyingly, this is encoded as a JSON string on older clients
         self.set_json_entry(Table::State, IDC_REGION_KEY, region)
+    }
+
+    /// Get the last used login method.
+    pub fn get_login_method(&self) -> Result<Option<String>, DatabaseError> {
+        self.get_json_entry::<String>(Table::State, LOGIN_METHOD_KEY)
+    }
+
+    /// Set the last used login method.
+    pub fn set_login_method(&mut self, method: String) -> Result<usize, DatabaseError> {
+        self.set_json_entry(Table::State, LOGIN_METHOD_KEY, method)
     }
 
     /// Get if user has already completed a migration

--- a/crates/chat-cli/src/util/mod.rs
+++ b/crates/chat-cli/src/util/mod.rs
@@ -59,7 +59,7 @@ impl std::fmt::Display for UnknownDesktopErrContext {
     }
 }
 
-pub fn choose(prompt: impl Display, options: &[impl ToString]) -> Result<Option<usize>> {
+pub fn choose(prompt: impl Display, options: &[impl ToString], default: usize) -> Result<Option<usize>> {
     if options.is_empty() {
         bail!("no options passed to choose")
     }
@@ -71,7 +71,7 @@ pub fn choose(prompt: impl Display, options: &[impl ToString]) -> Result<Option<
 
     match Select::with_theme(&dialoguer_theme())
         .items(options)
-        .default(0)
+        .default(default)
         .with_prompt(prompt.to_string())
         .interact_opt()
     {


### PR DESCRIPTION
Issue #, if available: Completes https://github.com/aws/amazon-q-developer-cli/issues/3263

Description of changes:

    Add database methods to store/retrieve last used login method
    Update login flow to use stored preference as default selection
    Update choose utility function for custom default options
    Improves UX by remembering user's login method preference

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.