### PR TITLE
fix: block dangerous patterns for tool calls

### DIFF
--- a/crates/chat-cli/src/cli/chat/tools/execute/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/execute/mod.rs
@@ -89,7 +89,6 @@ impl ExecuteCommand {
         if !current_cmd.is_empty() {
             all_commands.push(current_cmd);
         }
-        
 
         // Check if each command in the pipe chain starts with a safe command
         for cmd_args in &all_commands {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/amazon-q-developer-cli/issues/2834

*Description of changes:*
Prioritized blocking dangerous patterns for tool calls above allowed commands regex. Removed test for the case where we formerly prioritized allowed commands over blocking dangerous patterns. Added unit tests for blocking dangerous patterns. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
