### PR TITLE
fix: allow diagnostic without auth

### DIFF
--- a/crates/chat-cli/src/cli/agent/root_command_args.rs
+++ b/crates/chat-cli/src/cli/agent/root_command_args.rs
@@ -81,10 +81,16 @@ pub struct AgentArgs {
 impl AgentArgs {
     pub async fn execute(self, os: &mut Os) -> Result<ExitCode> {
         let mut stderr = std::io::stderr();
-        let mcp_enabled = match os.client.is_mcp_enabled().await {
-            Ok(enabled) => enabled,
-            Err(err) => {
-                tracing::warn!(?err, "Failed to check MCP configuration, defaulting to enabled");
+        let mcp_enabled = match os.client.as_ref() {
+            Some(client) => match client.is_mcp_enabled().await {
+                Ok(enabled) => enabled,
+                Err(err) => {
+                    tracing::warn!(?err, "Failed to check MCP configuration, defaulting to enabled");
+                    true
+                },
+            },
+            None => {
+                tracing::debug!("API client not available, defaulting MCP to enabled");
                 true
             },
         };

--- a/crates/chat-cli/src/cli/chat/cli/model.rs
+++ b/crates/chat-cli/src/cli/chat/cli/model.rs
@@ -174,7 +174,7 @@ pub async fn get_available_models(os: &Os) -> Result<(Vec<ModelInfo>, ModelInfo)
     let endpoint = Endpoint::configured_value(&os.database);
     let region = endpoint.region().as_ref();
 
-    match os.client.get_available_models(region).await {
+    match os.client.as_ref().unwrap().get_available_models(region).await {
         Ok(api_res) => {
             let models: Vec<ModelInfo> = api_res.models.iter().map(ModelInfo::from_api_model).collect();
             let default_model = ModelInfo::from_api_model(&api_res.default_model);

--- a/crates/chat-cli/src/cli/chat/cli/subscribe.rs
+++ b/crates/chat-cli/src/cli/chat/cli/subscribe.rs
@@ -162,7 +162,7 @@ async fn upgrade_to_pro(os: &mut Os, session: &mut ChatSession) -> Result<(), Ch
     }
 
     // Create a subscription token and open the webpage
-    let r = os.client.create_subscription_token().await?;
+    let r = os.client.as_ref().unwrap().create_subscription_token().await?;
 
     let url = with_spinner(&mut session.stderr, "Preparing to upgrade...", || async move {
         r.encoded_verification_url()

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -297,7 +297,7 @@ impl ChatArgs {
         info!(?conversation_id, "Generated new conversation id");
 
         // Check MCP status once at the beginning of the session
-        let mcp_enabled = match os.client.is_mcp_enabled().await {
+        let mcp_enabled = match os.client.as_ref().unwrap().is_mcp_enabled().await {
             Ok(enabled) => enabled,
             Err(err) => {
                 tracing::warn!(?err, "Failed to check MCP configuration, defaulting to enabled");
@@ -1222,8 +1222,13 @@ impl ChatSession {
         request_metadata_lock: Arc<Mutex<Option<RequestMetadata>>>,
         message_meta_tags: Option<Vec<MessageMetaTag>>,
     ) -> Result<SendMessageStream, ChatError> {
-        match SendMessageStream::send_message(&os.client, conversation_state, request_metadata_lock, message_meta_tags)
-            .await
+        match SendMessageStream::send_message(
+            os.client.as_ref().unwrap(),
+            conversation_state,
+            request_metadata_lock,
+            message_meta_tags,
+        )
+        .await
         {
             Ok(res) => Ok(res),
             Err(err) => {
@@ -3329,7 +3334,7 @@ impl ChatSession {
     }
 
     async fn retry_model_overload(&mut self, os: &mut Os) -> Result<ChatState, ChatError> {
-        os.client.invalidate_model_cache().await;
+        os.client.as_ref().unwrap().invalidate_model_cache().await;
         match select_model(os, self).await {
             Ok(Some(_)) => (),
             Ok(None) => {
@@ -3752,7 +3757,7 @@ async fn get_subscription_status(os: &mut Os) -> Result<ActualSubscriptionStatus
         return Ok(ActualSubscriptionStatus::Active);
     }
 
-    match os.client.create_subscription_token().await {
+    match os.client.as_ref().unwrap().create_subscription_token().await {
         Ok(response) => match response.status() {
             SubscriptionStatus::Active => Ok(ActualSubscriptionStatus::Expiring),
             SubscriptionStatus::Inactive => Ok(ActualSubscriptionStatus::None),
@@ -3892,7 +3897,7 @@ mod tests {
     #[tokio::test]
     async fn test_flow() {
         let mut os = Os::new().await.unwrap();
-        os.client.set_mock_output(serde_json::json!([
+        os.client.as_mut().unwrap().set_mock_output(serde_json::json!([
             [
                 "Sure, I'll create a file for you",
                 {
@@ -3945,7 +3950,7 @@ mod tests {
     #[tokio::test]
     async fn test_flow_tool_permissions() {
         let mut os = Os::new().await.unwrap();
-        os.client.set_mock_output(serde_json::json!([
+        os.client.as_mut().unwrap().set_mock_output(serde_json::json!([
             [
                 "Ok",
                 {
@@ -4092,7 +4097,7 @@ mod tests {
     async fn test_flow_multiple_tools() {
         // let _ = tracing_subscriber::fmt::try_init();
         let mut os = Os::new().await.unwrap();
-        os.client.set_mock_output(serde_json::json!([
+        os.client.as_mut().unwrap().set_mock_output(serde_json::json!([
             [
                 "Sure, I'll create a file for you",
                 {
@@ -4186,7 +4191,7 @@ mod tests {
     async fn test_flow_tools_trust_all() {
         // let _ = tracing_subscriber::fmt::try_init();
         let mut os = Os::new().await.unwrap();
-        os.client.set_mock_output(serde_json::json!([
+        os.client.as_mut().unwrap().set_mock_output(serde_json::json!([
             [
                 "Sure, I'll create a file for you",
                 {
@@ -4273,7 +4278,10 @@ mod tests {
     #[cfg(unix)]
     async fn test_subscribe_flow() {
         let mut os = Os::new().await.unwrap();
-        os.client.set_mock_output(serde_json::Value::Array(vec![]));
+        os.client
+            .as_mut()
+            .unwrap()
+            .set_mock_output(serde_json::Value::Array(vec![]));
         let agents = get_test_agents(&os).await;
 
         let tool_manager = ToolManager::default();
@@ -4315,7 +4323,7 @@ mod tests {
         };
 
         let mut os = Os::new().await.unwrap();
-        os.client.set_mock_output(serde_json::json!([
+        os.client.as_mut().unwrap().set_mock_output(serde_json::json!([
             [
                 "I'll read that file for you",
                 {
@@ -4463,7 +4471,7 @@ mod tests {
         os.fs.write("/sensitive.txt", "classified information").await.unwrap();
 
         // Mock LLM responses: first tries fs_read, gets blocked, then responds to error
-        os.client.set_mock_output(serde_json::json!([
+        os.client.as_mut().unwrap().set_mock_output(serde_json::json!([
             [
                 "I'll read that file for you",
                 {

--- a/crates/chat-cli/src/cli/mcp.rs
+++ b/crates/chat-cli/src/cli/mcp.rs
@@ -435,10 +435,16 @@ impl StatusArgs {
 async fn get_mcp_server_configs(os: &mut Os) -> Result<BTreeMap<Scope, Vec<(String, Option<McpServerConfig>, bool)>>> {
     let mut results = BTreeMap::new();
     let mut stderr = std::io::stderr();
-    let mcp_enabled = match os.client.is_mcp_enabled().await {
-        Ok(enabled) => enabled,
-        Err(err) => {
-            tracing::warn!(?err, "Failed to check MCP configuration, defaulting to enabled");
+    let mcp_enabled = match os.client.as_ref() {
+        Some(client) => match client.is_mcp_enabled().await {
+            Ok(enabled) => enabled,
+            Err(err) => {
+                tracing::warn!(?err, "Failed to check MCP configuration, defaulting to enabled");
+                true
+            },
+        },
+        None => {
+            tracing::debug!("API client not available, defaulting MCP to enabled");
             true
         },
     };


### PR DESCRIPTION
*Issue #, if available:*
#3199

*Description of changes:*
This PR allows the `diagnostic` command (and other commands that don't require authentication) to run without being logged in.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
