### PR TITLE
Modify /subscribe to redirect to kiro.dev

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/subscribe.rs
+++ b/crates/chat-cli/src/cli/chat/cli/subscribe.rs
@@ -25,7 +25,7 @@ const DEFAULT_SUBSCRIPTION_DOMAIN: &str = "app.kiro.dev";
 
 fn get_subscription_url() -> String {
     let domain = env::var("KIRO_SUBSCRIPTION_DOMAIN").unwrap_or_else(|_| DEFAULT_SUBSCRIPTION_DOMAIN.to_string());
-    format!("https://{}/account/usage", domain)
+    format!("https://{domain}/account/usage")
 }
 
 /// Arguments for the subscribe command to manage Developer Pro subscriptions

--- a/crates/chat-cli/src/constants.rs
+++ b/crates/chat-cli/src/constants.rs
@@ -172,15 +172,7 @@ pub mod ui_text {
 pub mod subscription_text {
     use super::PRODUCT_NAME;
 
-    /// Title for subscription upgrade dialog
-    pub fn subscribe_title() -> String {
-        format!("Subscribe to {PRODUCT_NAME} Pro")
-    }
 
-    /// Subscription upgrade information text
-    pub const SUBSCRIBE_INFO: &str = "During the upgrade, you'll be asked to link your Builder ID to the AWS account that will be billed the monthly subscription fee.
-
-Need help? Visit our subscription support page> https://docs.aws.amazon.com/console/amazonq/upgrade-builder-id";
 
     /// Message for IDC users about subscription management
     pub fn idc_subscription_message() -> String {


### PR DESCRIPTION
Changing /subscribe to support new usecases/
1. Social/Free BID - Redirect to kiro.dev
2. Enterprise - Keep the current flow
3. Paid BID - Keep the current flow