### PR TITLE
fix: make command/url conditionally required based on MCP server type

### DIFF
--- a/schemas/agent-v1.json
+++ b/schemas/agent-v1.json
@@ -146,9 +146,20 @@
             "default": false
           }
         },
-        "required": [
-          "command"
-        ]
+        "if": {
+          "properties": {
+            "type": {
+              "const": "http"
+            }
+          },
+          "required": ["type"]
+        },
+        "then": {
+          "required": ["url"]
+        },
+        "else": {
+          "required": ["command"]
+        }
       },
       "default": {}
     },


### PR DESCRIPTION
### Summary
Fixes #3346. Improves the MCP server configuration schema to conditionally require fields based on the transport type.

### Problem
The previous schema required the command field for all MCP servers. However, http type MCP servers need a url field instead of command. This caused 
incorrect validation for HTTP-based MCP server configurations.

### Changes
• Introduced JSON Schema if-then-else syntax in schemas/agent-v1.json
• When type: "http", the url field is required
• Otherwise (for stdio), the command field is required

### Impact
• Only affects agent configuration schema validation logic
• No impact on existing valid configurations
• Invalid configurations will now be detected more accurately

#### Before

<img width="1669" height="641" alt="スクリーンショット 2025-11-03 午後10 43 23" src="https://github.com/user-attachments/assets/18511b9f-5a0d-4372-85b6-a7baf919f6bc" />


#### After

<img width="1694" height="557" alt="スクリーンショット 2025-11-03 午後9 48 21" src="https://github.com/user-attachments/assets/4bc960ea-05b9-49e0-8f55-34c442cdff5b" />

[Tool used](https://www.jsonschemavalidator.net/)