### PR TITLE
Add configurable tool output verbosity

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -677,6 +677,8 @@ pub struct ChatSession {
     prompt_ack_rx: std::sync::mpsc::Receiver<()>,
     /// Additional context to be added to the next user message (e.g., delegate task summaries)
     pending_additional_context: Option<String>,
+    /// Tools used in the current turn (for non-verbose completion messages)
+    tools_used_in_turn: Vec<String>,
 }
 
 impl ChatSession {
@@ -814,6 +816,7 @@ impl ChatSession {
             wrap,
             prompt_ack_rx,
             pending_additional_context: None,
+            tools_used_in_turn: Vec::new(),
         })
     }
 
@@ -2443,6 +2446,14 @@ impl ChatSession {
                 }
             }
 
+            // Determine if we should show detailed output (same logic as print_tool_description)
+            let verbose = os.database
+                .settings
+                .get_bool(Setting::ChatToolOutputVerbose)
+                .unwrap_or(true);
+            // tool.accepted is true if the tool was trusted (allowed without permission)
+            let show_details = verbose || !tool.accepted;
+
             let invoke_result = tool
                 .tool
                 .invoke(
@@ -2450,6 +2461,7 @@ impl ChatSession {
                     &mut self.stdout,
                     &mut self.conversation.file_line_tracker,
                     &self.conversation.agents,
+                    show_details,
                 )
                 .await;
 
@@ -2578,13 +2590,28 @@ impl ChatSession {
                     }
 
                     debug!("tool result output: {:#?}", result);
+                    
+                    // Check verbose setting
+                    let verbose = os.database
+                        .settings
+                        .get_bool(Setting::ChatToolOutputVerbose)
+                        .unwrap_or(true);
+                    
+                    // Build completion message
+                    let completion_msg = if verbose || self.tools_used_in_turn.is_empty() {
+                        format!(" ● Completed in {}s", tool_time)
+                    } else {
+                        let tools = self.tools_used_in_turn.join(", ");
+                        format!(" ● Completed in {}s ({})", tool_time, tools)
+                    };
+                    
                     execute!(
                         self.stdout,
                         style::Print(CONTINUATION_LINE),
                         style::Print("\n"),
                         StyledText::success_fg(),
                         style::SetAttribute(Attribute::Bold),
-                        style::Print(format!(" ● Completed in {}s", tool_time)),
+                        style::Print(completion_msg),
                         StyledText::reset(),
                     )?;
                     if let Some(tag) = checkpoint_tag {
@@ -3137,6 +3164,7 @@ impl ChatSession {
             self.tool_uses.clear();
             self.pending_tool_index = None;
             self.tool_turn_start_time = None;
+            self.tools_used_in_turn.clear();
 
             // Create turn checkpoint if tools were used
             if ExperimentManager::is_enabled(os, ExperimentName::Checkpoint) && !self.conversation.is_in_tangent_mode()
@@ -3450,6 +3478,19 @@ impl ChatSession {
 
     async fn print_tool_description(&mut self, os: &Os, tool_index: usize, trusted: bool) -> Result<(), ChatError> {
         let tool_use = &self.tool_uses[tool_index];
+        let tool_name = tool_use.tool.display_name();
+        
+        // Always track tool usage for completion message
+        self.tools_used_in_turn.push(tool_name.clone());
+        
+        // Determine if we should show detailed output
+        let verbose = os.database
+            .settings
+            .get_bool(Setting::ChatToolOutputVerbose)
+            .unwrap_or(true); // Default to verbose
+        
+        // Show details if: verbose mode is on OR tool requires permission
+        let show_details = verbose || !trusted;
 
         if self.stderr.should_send_structured_event {
             let tool_call_start = ToolCallStart {
@@ -3464,7 +3505,7 @@ impl ChatSession {
                 parent_message_id: None,
             };
             self.stdout.send(Event::ToolCallStart(tool_call_start))?;
-        } else {
+        } else if show_details {
             queue!(
                 self.stdout,
                 StyledText::emphasis_fg(),
@@ -3495,11 +3536,13 @@ impl ChatSession {
             )?;
         }
 
-        tool_use
-            .tool
-            .queue_description(os, &mut self.stdout)
-            .await
-            .map_err(|e| ChatError::Custom(format!("failed to print tool, `{}`: {}", tool_use.name, e).into()))?;
+        if show_details {
+            tool_use
+                .tool
+                .queue_description(os, &mut self.stdout)
+                .await
+                .map_err(|e| ChatError::Custom(format!("failed to print tool, `{}`: {}", tool_use.name, e).into()))?;
+        }
 
         self.stdout.flush()?;
 

--- a/crates/chat-cli/src/cli/chat/tools/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/mod.rs
@@ -149,10 +149,11 @@ impl Tool {
         stdout: &mut impl Write,
         line_tracker: &mut HashMap<String, FileLineTracker>,
         agents: &crate::cli::agent::Agents,
+        show_details: bool,
     ) -> Result<InvokeOutput> {
         let active_agent = agents.get_active();
         match self {
-            Tool::FsRead(fs_read) => fs_read.invoke(os, stdout).await,
+            Tool::FsRead(fs_read) => fs_read.invoke(os, stdout, show_details).await,
             Tool::FsWrite(fs_write) => fs_write.invoke(os, stdout, line_tracker).await,
             Tool::ExecuteCommand(execute_command) => execute_command.invoke(os, stdout).await,
             Tool::UseAws(use_aws) => use_aws.invoke(os, stdout).await,
@@ -475,7 +476,12 @@ pub fn display_purpose(purpose: Option<&String>, updates: &mut impl Write) -> Re
 /// * `updates` - The output to write to
 /// * `is_error` - Whether this is an error message (changes formatting)
 /// * `use_bullet` - Whether to use a bullet point instead of a tick/exclamation
-pub fn queue_function_result(result: &str, updates: &mut impl Write, is_error: bool, use_bullet: bool) -> Result<()> {
+pub fn queue_function_result(result: &str, updates: &mut impl Write, is_error: bool, use_bullet: bool, should_display: bool) -> Result<()> {
+    // Skip output if should_display is false
+    if !should_display {
+        return Ok(());
+    }
+    
     let lines = result.lines().collect::<Vec<_>>();
 
     // Determine symbol and color

--- a/crates/chat-cli/src/database/settings.rs
+++ b/crates/chat-cli/src/database/settings.rs
@@ -91,6 +91,8 @@ pub enum Setting {
     EnabledDelegate,
     #[strum(message = "Specify UI variant to use (string)")]
     UiMode,
+    #[strum(message = "Show detailed tool execution information (boolean)")]
+    ChatToolOutputVerbose,
 }
 
 impl AsRef<str> for Setting {
@@ -133,6 +135,7 @@ impl AsRef<str> for Setting {
             Self::EnabledContextUsageIndicator => "chat.enableContextUsageIndicator",
             Self::EnabledDelegate => "chat.enableDelegate",
             Self::UiMode => "chat.uiMode",
+            Self::ChatToolOutputVerbose => "chat.tool_output_verbose",
         }
     }
 }
@@ -183,6 +186,7 @@ impl TryFrom<&str> for Setting {
             "chat.enableCheckpoint" => Ok(Self::EnabledCheckpoint),
             "chat.enableContextUsageIndicator" => Ok(Self::EnabledContextUsageIndicator),
             "chat.uiMode" => Ok(Self::UiMode),
+            "chat.tool_output_verbose" => Ok(Self::ChatToolOutputVerbose),
             _ => Err(DatabaseError::InvalidSetting(value.to_string())),
         }
     }


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
• Adds configurable tool output verbosity via new setting `chat.tool_output_verbose` (default: true)
• When set to false, hides detailed tool execution output for trusted tools while preserving:
  • Permission prompts for untrusted tools (safety preserved)
  • Completion messages with tool names: `● Completed in 0.99s (fs_read, fs_write)`
  • Structured events for IDE integration
• Implementation changes:
  • Added `ChatToolOutputVerbose` setting to `Setting` enum with full mapping
  • Added `tools_used_in_turn: Vec<String>` field to `ChatSession` to track tools used in current turn
  • Modified print_tool_description() to conditionally display output based on `verbose || !trusted`
  • Enhanced completion message to append tool names when not verbose
  • Added `show_details` parameter to `Tool::invoke()` and propagated through to `queue_function_result()`
  • Updated `fs_read` tool implementations to respect show_details flag (6 call sites)

Tests

Test case: Default behavior (verbose=true)
```
List files in current directory
```
Output shows full tool details:
```
🛠️  Using tool: fs_read (trusted)
 ⋮ 
 ● Reading directory: /path/to/dir with maximum depth of 1
 ✓ Successfully read directory /path/to/dir (32 entries)
 ⋮ 
 ● Completed in 0.99s
```

Test case: Reduced verbosity (verbose=false, trusted tools)
```
List files in current directory
```
Output shows only completion: `● Completed in 0.99s (fs_read)`

Test case: Permission prompts preserved (verbose=false, untrusted tools)
```
Create a test directory
```
Output shows full details with permission prompt:
```
🛠️  Using tool: execute_bash
 ⋮ 
 ● I will run the following shell command: mkdir -p /tmp/test
 ⋮ 
Allow this action? [y/n/t]:
```

Test case: Multiple tools (verbose=false)
```
Read README.md and create a summary
```

Output shows all tools used: `● Completed in 1.5s (fs_read, fs_write)`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.