### PR TITLE
chore: Fixed ToolUse UX for MCP Tools

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -3471,15 +3471,6 @@ impl ChatSession {
                 parent_message_id: None,
             };
             self.stdout.send(Event::ToolCallStart(tool_call_start))?;
-        } else if let Tool::Custom(ref tool) = tool_use.tool {
-            queue!(
-                self.stdout,
-                StyledText::reset(),
-                style::Print(" from mcp server "),
-                StyledText::emphasis_fg(),
-                style::Print(&tool.server_name),
-                StyledText::reset(),
-            )?;
         }
 
         tool_use

--- a/crates/chat-cli/src/cli/chat/tools/custom_tool.rs
+++ b/crates/chat-cli/src/cli/chat/tools/custom_tool.rs
@@ -150,7 +150,7 @@ impl CustomTool {
         queue!(
             output,
             style::Print("Running "),
-            StyledText::success_fg(),
+            StyledText::brand_fg(),
             style::Print(&self.name),
             StyledText::reset(),
         )?;

--- a/crates/chat-cli/src/cli/chat/tools/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/mod.rs
@@ -214,14 +214,27 @@ impl Tool {
                 queue,
                 style,
             };
-            queue!(
-                output,
-                StyledText::secondary_fg(),
-                style::Print(" (using tool: "),
-                style::Print(self.display_name()),
-                style::Print(")"),
-                StyledText::reset(),
-            )?;
+            if let Tool::Custom(tool) = self {
+                queue!(
+                    output,
+                    StyledText::secondary_fg(),
+                    style::Print(" (from mcp server: "),
+                    style::Print(&tool.server_name),
+                    style::Print(", using tool: "),
+                    style::Print(self.display_name()),
+                    style::Print(")"),
+                    StyledText::reset(),
+                )?;
+            } else {
+                queue!(
+                    output,
+                    StyledText::secondary_fg(),
+                    style::Print(" (using tool: "),
+                    style::Print(self.display_name()),
+                    style::Print(")"),
+                    StyledText::reset(),
+                )?;
+            }
         };
 
         Ok(())


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

<img width="718" height="120" alt="image" src="https://github.com/user-attachments/assets/cb0eba6a-5425-422e-835e-0d283d3c115c" />

Updates ToolUse UX for MCP toolls to match new color schema and behavior.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
