### PR TITLE
Rename agent schema description from q chat to kiro-cli

### DIFF
--- a/crates/agent/src/agent/agent_config/definitions.rs
+++ b/crates/agent/src/agent/agent_config/definitions.rs
@@ -91,7 +91,7 @@ impl AgentConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-#[schemars(description = "An Agent is a declarative way of configuring a given instance of q chat.")]
+#[schemars(description = "An Agent is a declarative way of configuring a given instance of kiro-cli.")]
 pub struct AgentConfigV2025_08_22 {
     #[serde(rename = "$schema", default = "default_schema")]
     pub schema: String,

--- a/crates/chat-cli/src/cli/agent/mod.rs
+++ b/crates/chat-cli/src/cli/agent/mod.rs
@@ -101,7 +101,7 @@ pub enum AgentConfigError {
     InvalidFileUri { uri: String },
 }
 
-/// An [Agent] is a declarative way of configuring a given instance of q chat. Currently, it is
+/// An [Agent] is a declarative way of configuring a given instance of kiro-cli. Currently, it is
 /// impacting q chat in via influenicng [ContextManager] and [ToolManager].
 /// Changes made to [ContextManager] and [ToolManager] do not persist across sessions.
 ///
@@ -127,7 +127,7 @@ pub enum AgentConfigError {
 /// "warm".
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[schemars(description = "An Agent is a declarative way of configuring a given instance of q chat.")]
+#[schemars(description = "An Agent is a declarative way of configuring a given instance of kiro-cli.")]
 pub struct Agent {
     #[serde(rename = "$schema", default = "default_schema")]
     pub schema: String,

--- a/schemas/agent-v1.json
+++ b/schemas/agent-v1.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Agent",
-  "description": "An Agent is a declarative way of configuring a given instance of q chat.",
+  "description": "An Agent is a declarative way of configuring a given instance of kiro-cli.",
   "type": "object",
   "definitions": {
     "hookCommands": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated the agent schema description to say "kiro-cli" instead of "q chat"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
