### PR TITLE
triple backticks hint upon pressing enter with unclosed backticks

### DIFF
--- a/crates/chat-cli/src/cli/feed.json
+++ b/crates/chat-cli/src/cli/feed.json
@@ -21,7 +21,8 @@
           "description": "Right arrow key being disabled - [#3439](https://github.com/aws/amazon-q-developer-cli/pull/3439)"
         }
       ]
-    }{
+    }, 
+    {
       "type": "release",
       "date": "2025-11-12",
       "version": "1.19.5",


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/amazon-q-developer-cli/issues/3271

*Description of changes:*
Made it so that a hint shows up for when someone has unclosed triple backticks. Does not interfere with key presses but does interfere with autocompletion such that the hint won't be part of the autocompletion as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
