### PR TITLE
fix batch-get api prefix in use_aws's READONLY_OPS list

### DIFF
--- a/crates/chat-cli/src/cli/chat/tools/use_aws.rs
+++ b/crates/chat-cli/src/cli/chat/tools/use_aws.rs
@@ -31,7 +31,7 @@ use crate::cli::agent::{
 use crate::os::Os;
 use crate::util::tool_permission_checker::is_tool_in_allowlist;
 
-const READONLY_OPS: [&str; 6] = ["get", "describe", "list", "ls", "search", "batch_get"];
+const READONLY_OPS: [&str; 6] = ["get", "describe", "list", "ls", "search", "batch-get"];
 
 // TODO: we should perhaps composite this struct with an interface that we can use to mock the
 // actual cli with. That will allow us to more thoroughly test it.

--- a/docs/built-in-tools.md
+++ b/docs/built-in-tools.md
@@ -155,7 +155,7 @@ Make AWS CLI API calls with the specified service, operation, and parameters.
 |--------|------|---------|-------------|
 | `allowedServices` | array of strings | `[]` | List of AWS services that can be accessed without prompting |
 | `deniedServices` | array of strings | `[]` | List of AWS services to deny. Deny rules are evaluated before allow rules |
-| `autoAllowReadonly` | boolean | `false` | Whether to automatically allow read-only operations (get, describe, list, ls, search, batch_get) without prompting |
+| `autoAllowReadonly` | boolean | `false` | Whether to automatically allow read-only operations (get, describe, list, ls, search, batch-get) without prompting |
 
 ## Using Tool Settings in Agent Configuration
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/amazon-q-developer-cli/issues/3493

*Description of changes:* update the prefix to match the one I am seeing in the actual tool call (correct: `batch-get`. incorrect: `batch_get`)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
<img width="707" height="482" alt="Screenshot 2025-11-24 at 2 00 02 PM" src="https://github.com/user-attachments/assets/00e776c7-93bb-456a-8114-1a5aaabb5d6a" />
