### PR TITLE
Rahulrajaram compaction fixes

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/usage/usage_data_provider.rs
+++ b/crates/chat-cli/src/cli/chat/cli/usage/usage_data_provider.rs
@@ -18,7 +18,7 @@ pub(super) async fn get_detailed_usage_data(
 
     let state = session
         .conversation
-        .backend_conversation_state(os, true, &mut std::io::stderr())
+        .backend_conversation_state(os, true, &mut std::io::stderr(), tokio::sync::broadcast::channel(1).1)
         .await?;
 
     let data = state.calculate_conversation_size();

--- a/crates/chat-cli/src/cli/chat/context.rs
+++ b/crates/chat-cli/src/cli/chat/context.rs
@@ -250,12 +250,13 @@ impl ContextManager {
         os: &crate::os::Os,
         prompt: Option<&str>,
         tool_context: Option<crate::cli::chat::cli::hooks::ToolContext>,
+        ctrlc_rx: tokio::sync::broadcast::Receiver<()>,
     ) -> Result<Vec<((HookTrigger, Hook), HookOutput)>, ChatError> {
         let mut hooks = self.hooks.clone();
         hooks.retain(|t, _| *t == trigger);
         let cwd = os.env.current_dir()?.to_string_lossy().to_string();
         self.hook_executor
-            .run_hooks(hooks, output, &cwd, prompt, tool_context)
+            .run_hooks(hooks, output, &cwd, prompt, tool_context, ctrlc_rx)
             .await
     }
 }

--- a/crates/chat-cli/src/cli/chat/conversation_overflow_test.rs
+++ b/crates/chat-cli/src/cli/chat/conversation_overflow_test.rs
@@ -1,0 +1,159 @@
+#[cfg(test)]
+mod overflow_tests {
+    use std::collections::{HashMap, VecDeque};
+    use crate::api_client::model::Tool;
+    use crate::cli::chat::consts::MAX_CONVERSATION_STATE_HISTORY_LEN;
+    use crate::cli::chat::conversation::{HistoryEntry, enforce_conversation_invariants};
+    use crate::cli::chat::message::{AssistantMessage, UserMessage};
+    use crate::cli::chat::tools::ToolOrigin;
+
+    fn create_history_entry(content: &str) -> HistoryEntry {
+        HistoryEntry {
+            user: UserMessage::new_prompt(content.to_string(), None),
+            assistant: AssistantMessage::new_response(None, content.to_string()),
+            request_metadata: None,
+        }
+    }
+
+    #[test]
+    fn test_overflow_at_boundary() {
+        let mut history = VecDeque::new();
+        let mut next_message = None;
+        let tools: HashMap<ToolOrigin, Vec<Tool>> = HashMap::new();
+
+        // Create exactly 5000 history entries (10000 messages when flattened)
+        for i in 0..5000 {
+            history.push_back(create_history_entry(&format!("msg{}", i)));
+        }
+
+        let (start, end) = enforce_conversation_invariants(&mut history, &mut next_message, &tools);
+        let valid_history_len = end - start;
+        let total_messages = valid_history_len * 2;
+
+        // BUG: This should fail but doesn't - we're at exactly the limit
+        assert!(
+            total_messages <= MAX_CONVERSATION_STATE_HISTORY_LEN,
+            "Expected total messages {} to be <= {}, but overflow detection didn't trigger",
+            total_messages,
+            MAX_CONVERSATION_STATE_HISTORY_LEN
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "Expected overflow detection to trigger")]
+    fn test_overflow_one_past_boundary() {
+        let mut history = VecDeque::new();
+        let mut next_message = None;
+        let tools: HashMap<ToolOrigin, Vec<Tool>> = HashMap::new();
+
+        // Create 5001 history entries (10002 messages when flattened)
+        for i in 0..5001 {
+            history.push_back(create_history_entry(&format!("msg{}", i)));
+        }
+
+        let (start, end) = enforce_conversation_invariants(&mut history, &mut next_message, &tools);
+        let valid_history_len = end - start;
+        let total_messages = valid_history_len * 2;
+
+        // BUG: This WILL overflow (10002 > 10000) but trimming happens too late
+        if total_messages > MAX_CONVERSATION_STATE_HISTORY_LEN {
+            panic!("Expected overflow detection to trigger before sending {} messages (limit: {})",
+                   total_messages, MAX_CONVERSATION_STATE_HISTORY_LEN);
+        }
+    }
+
+    #[test]
+    fn test_overflow_with_context_buffer() {
+        let mut history = VecDeque::new();
+        let mut next_message = None;
+        let tools: HashMap<ToolOrigin, Vec<Tool>> = HashMap::new();
+
+        // Create 4998 entries (9996 messages) - should be safe with 6-message buffer
+        for i in 0..4998 {
+            history.push_back(create_history_entry(&format!("msg{}", i)));
+        }
+
+        let (start, end) = enforce_conversation_invariants(&mut history, &mut next_message, &tools);
+        let valid_history_len = end - start;
+        let total_messages = valid_history_len * 2;
+
+        // With 6 context messages, total would be 9996 + 6 = 10002 (OVERFLOW!)
+        let total_with_context = total_messages + 6;
+        assert!(
+            total_with_context <= MAX_CONVERSATION_STATE_HISTORY_LEN,
+            "BUG: Total messages with context {} exceeds limit {} - trimming should have occurred earlier",
+            total_with_context,
+            MAX_CONVERSATION_STATE_HISTORY_LEN
+        );
+    }
+
+    #[test]
+    fn test_trimming_threshold() {
+        let mut history = VecDeque::new();
+        let mut next_message = None;
+        let tools: HashMap<ToolOrigin, Vec<Tool>> = HashMap::new();
+
+        // Test the exact threshold where trimming should occur
+        // Current buggy condition: (history.len() * 2) > MAX_CONVERSATION_STATE_HISTORY_LEN - 6
+        // This means: history.len() > 4997
+        
+        // At 4997 entries: 4997 * 2 = 9994, which is NOT > 9994, so no trimming
+        for i in 0..4997 {
+            history.push_back(create_history_entry(&format!("msg{}", i)));
+        }
+        
+        let initial_len = history.len();
+        let (start, end) = enforce_conversation_invariants(&mut history, &mut next_message, &tools);
+        let trimmed = start > 0;
+        
+        assert!(
+            !trimmed,
+            "BUG: At {} entries (9994 messages), trimming should not occur yet, but it did",
+            initial_len
+        );
+
+        // At 4998 entries: 4998 * 2 = 9996, which IS > 9994, so trimming occurs
+        history.push_back(create_history_entry("msg4997"));
+        let (start, end) = enforce_conversation_invariants(&mut history, &mut next_message, &tools);
+        let trimmed = start > 0;
+        
+        assert!(
+            trimmed,
+            "At 4998 entries (9996 messages), trimming should occur"
+        );
+        
+        // But by now we've already exceeded the safe limit with context messages!
+        let valid_history_len = end - start;
+        let total_with_context = (valid_history_len * 2) + 6;
+        assert!(
+            total_with_context <= MAX_CONVERSATION_STATE_HISTORY_LEN,
+            "BUG: After trimming, total {} still exceeds limit {}",
+            total_with_context,
+            MAX_CONVERSATION_STATE_HISTORY_LEN
+        );
+    }
+
+    #[test]
+    fn test_proactive_trimming_needed() {
+        // This test demonstrates what the threshold SHOULD be
+        let safe_threshold = (MAX_CONVERSATION_STATE_HISTORY_LEN - 100) / 2; // Leave 100 message buffer
+        
+        let mut history = VecDeque::new();
+        let mut next_message = None;
+        let tools: HashMap<ToolOrigin, Vec<Tool>> = HashMap::new();
+
+        // Fill to the safe threshold
+        for i in 0..safe_threshold {
+            history.push_back(create_history_entry(&format!("msg{}", i)));
+        }
+
+        let total_messages = history.len() * 2;
+        let buffer_remaining = MAX_CONVERSATION_STATE_HISTORY_LEN - total_messages;
+        
+        assert!(
+            buffer_remaining >= 100,
+            "Safe threshold should leave at least 100 messages of buffer, but only {} remaining",
+            buffer_remaining
+        );
+    }
+}

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -22,6 +22,8 @@ mod parser;
 mod prompt;
 mod prompt_parser;
 pub mod server_messenger;
+#[cfg(test)]
+mod test_blocking;
 use crate::cli::chat::checkpoint::CHECKPOINT_MESSAGE_MAX_LENGTH;
 use crate::constants::ui_text;
 #[cfg(unix)]
@@ -783,6 +785,7 @@ impl ChatSession {
             loop {
                 match ctrl_c().await {
                     Ok(_) => {
+                        warn!("🔴 CTRL+C SIGNAL RECEIVED - broadcasting to {} subscribers", ctrlc_tx.receiver_count());
                         let _ = ctrlc_tx
                             .send(())
                             .map_err(|err| error!(?err, "failed to send ctrlc to broadcast channel"));
@@ -827,6 +830,7 @@ impl ChatSession {
         let mut ctrl_c_stream = self.ctrlc_rx.resubscribe();
         let result = match self.inner.take().expect("state must always be Some") {
             ChatState::PromptUser { skip_printing_tools } => {
+                warn!("🟡 Entering PromptUser state");
                 match (self.interactive, self.tool_uses.is_empty()) {
                     (false, true) => {
                         self.inner = Some(ChatState::Exit);
@@ -843,7 +847,10 @@ impl ChatSession {
             ChatState::HandleInput { input } => {
                 tokio::select! {
                     res = self.handle_input(os, input) => res,
-                    Ok(_) = ctrl_c_stream.recv() => Err(ChatError::Interrupted { tool_uses: Some(self.tool_uses.clone()) })
+                    Ok(_) = ctrl_c_stream.recv() => {
+                        warn!("🔴 CTRL+C caught in HandleInput state");
+                        Err(ChatError::Interrupted { tool_uses: Some(self.tool_uses.clone()) })
+                    }
                 }
             },
             ChatState::CompactHistory {
@@ -858,7 +865,10 @@ impl ChatSession {
                 let tool_uses_clone = self.tool_uses.clone();
                 tokio::select! {
                     res = self.tool_use_execute(os) => res,
-                    Ok(_) = ctrl_c_stream.recv() => Err(ChatError::Interrupted { tool_uses: Some(tool_uses_clone) })
+                    Ok(_) = ctrl_c_stream.recv() => {
+                        warn!("🔴 CTRL+C caught in ExecuteTools state");
+                        Err(ChatError::Interrupted { tool_uses: Some(tool_uses_clone) })
+                    }
                 }
             },
             ChatState::ValidateTools { tool_uses } => {
@@ -874,6 +884,7 @@ impl ChatSession {
                 tokio::select! {
                     res = self.handle_response(os, conversation_state, request_metadata_clone) => res,
                     Ok(_) = ctrl_c_stream.recv() => {
+                        warn!("🔴 CTRL+C caught in HandleResponseStream state");
                         debug!(?request_metadata, "ctrlc received");
                         // Wait for handle_response to finish handling the ctrlc.
                         tokio::time::sleep(Duration::from_millis(5)).await;
@@ -949,7 +960,7 @@ impl ChatSession {
                             .abandon_tool_use(tool_uses, "The user interrupted the tool execution.".to_string());
                         let _ = self
                             .conversation
-                            .as_sendable_conversation_state(os, &mut self.stderr, false)
+                            .as_sendable_conversation_state(os, &mut self.stderr, false, self.ctrlc_rx.resubscribe())
                             .await?;
                         self.conversation.push_assistant_message(
                             os,
@@ -1767,7 +1778,7 @@ impl ChatSession {
         if should_retry {
             Ok(ChatState::HandleResponseStream(
                 self.conversation
-                    .as_sendable_conversation_state(os, &mut self.stderr, false)
+                    .as_sendable_conversation_state(os, &mut self.stderr, false, self.ctrlc_rx.resubscribe())
                     .await?,
             ))
         } else {
@@ -2347,7 +2358,7 @@ impl ChatSession {
 
             let conv_state = self
                 .conversation
-                .as_sendable_conversation_state(os, &mut self.stderr, true)
+                .as_sendable_conversation_state(os, &mut self.stderr, true, self.ctrlc_rx.resubscribe())
                 .await?;
             self.send_tool_use_telemetry(os).await;
 
@@ -2767,6 +2778,7 @@ impl ChatSession {
                             os,
                             None,
                             Some(tool_context),
+                            self.ctrlc_rx.resubscribe(),
                         )
                         .await;
                 }
@@ -2797,7 +2809,7 @@ impl ChatSession {
         self.send_tool_use_telemetry(os).await;
         return Ok(ChatState::HandleResponseStream(
             self.conversation
-                .as_sendable_conversation_state(os, &mut self.stderr, false)
+                .as_sendable_conversation_state(os, &mut self.stderr, false, self.ctrlc_rx.resubscribe())
                 .await?,
         ));
     }
@@ -2974,7 +2986,7 @@ impl ChatSession {
                             self.send_tool_use_telemetry(os).await;
                             return Ok(ChatState::HandleResponseStream(
                                 self.conversation
-                                    .as_sendable_conversation_state(os, &mut self.stderr, false)
+                                    .as_sendable_conversation_state(os, &mut self.stderr, false, self.ctrlc_rx.resubscribe())
                                     .await?,
                             ));
                         },
@@ -3011,7 +3023,7 @@ impl ChatSession {
                             self.send_tool_use_telemetry(os).await;
                             return Ok(ChatState::HandleResponseStream(
                                 self.conversation
-                                    .as_sendable_conversation_state(os, &mut self.stderr, false)
+                                    .as_sendable_conversation_state(os, &mut self.stderr, false, self.ctrlc_rx.resubscribe())
                                     .await?,
                             ));
                         },
@@ -3061,7 +3073,7 @@ impl ChatSession {
                             self.send_tool_use_telemetry(os).await;
                             return Ok(ChatState::HandleResponseStream(
                                 self.conversation
-                                    .as_sendable_conversation_state(os, &mut self.stderr, false)
+                                    .as_sendable_conversation_state(os, &mut self.stderr, false, self.ctrlc_rx.resubscribe())
                                     .await?,
                             ));
                         },
@@ -3266,6 +3278,7 @@ impl ChatSession {
                         os,
                         None,
                         None,
+                        self.ctrlc_rx.resubscribe(),
                     )
                     .await;
             }
@@ -3376,7 +3389,7 @@ impl ChatSession {
 
             return Ok(ChatState::HandleResponseStream(
                 self.conversation
-                    .as_sendable_conversation_state(os, &mut self.stderr, false)
+                    .as_sendable_conversation_state(os, &mut self.stderr, false, self.ctrlc_rx.resubscribe())
                     .await?,
             ));
         }
@@ -3403,6 +3416,7 @@ impl ChatSession {
                         os,
                         None, // prompt
                         Some(tool_context),
+                        self.ctrlc_rx.resubscribe(),
                     )
                     .await?;
 
@@ -3447,7 +3461,7 @@ impl ChatSession {
             self.conversation.add_tool_results(tool_results);
             return Ok(ChatState::HandleResponseStream(
                 self.conversation
-                    .as_sendable_conversation_state(os, &mut self.stderr, false)
+                    .as_sendable_conversation_state(os, &mut self.stderr, false, self.ctrlc_rx.resubscribe())
                     .await?,
             ));
         }
@@ -3482,7 +3496,7 @@ impl ChatSession {
 
         Ok(ChatState::HandleResponseStream(
             self.conversation
-                .as_sendable_conversation_state(os, &mut self.stderr, true)
+                .as_sendable_conversation_state(os, &mut self.stderr, true, self.ctrlc_rx.resubscribe())
                 .await?,
         ))
     }
@@ -3571,16 +3585,20 @@ impl ChatSession {
 
     /// Helper function to read user input with a prompt and Ctrl+C handling
     fn read_user_input(&mut self, prompt: &str, exit_on_single_ctrl_c: bool) -> Option<String> {
+        warn!("🟢 Entering read_user_input, about to call rustyline");
         let mut ctrl_c = false;
         loop {
+            warn!("🟢 Calling input_source.read_line()...");
             match (self.input_source.read_line(Some(prompt)), ctrl_c) {
                 (Ok(Some(line)), _) => {
+                    warn!("🟢 Got input: {:?}", line);
                     if line.trim().is_empty() {
                         continue; // Reprompt if the input is empty
                     }
                     return Some(line);
                 },
                 (Ok(None), false) => {
+                    warn!("🟢 Got None (Ctrl+C or Ctrl+D), ctrl_c={}", ctrl_c);
                     if exit_on_single_ctrl_c {
                         return None;
                     }
@@ -3594,8 +3612,14 @@ impl ChatSession {
                     .unwrap_or_default();
                     ctrl_c = true;
                 },
-                (Ok(None), true) => return None, // Exit if Ctrl+C was pressed twice
-                (Err(_), _) => return None,
+                (Ok(None), true) => {
+                    warn!("🟢 Got None again, exiting");
+                    return None;
+                },
+                (Err(e), _) => {
+                    warn!("🟢 Got error: {:?}", e);
+                    return None;
+                },
             }
         }
     }

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -2112,13 +2112,13 @@ impl ChatSession {
             }
         }
 
-        self.conversation.append_user_transcript(&user_input);
         Ok(ChatState::HandleInput { input: user_input })
     }
 
     async fn handle_input(&mut self, os: &mut Os, mut user_input: String) -> Result<ChatState, ChatError> {
         queue!(self.stderr, style::Print('\n'))?;
         user_input = sanitize_unicode_tags(&user_input);
+        self.conversation.append_user_transcript(&user_input);
         let input = user_input.trim();
 
         // handle image path

--- a/crates/chat-cli/src/cli/chat/test_blocking.rs
+++ b/crates/chat-cli/src/cli/chat/test_blocking.rs
@@ -1,0 +1,138 @@
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
+    use tokio::sync::broadcast;
+
+    /// This test demonstrates that blocking operations prevent tokio::select! from processing
+    /// Ctrl+C signals. This simulates the issue where rustyline::readline() blocks the runtime.
+    #[tokio::test]
+    async fn test_blocking_prevents_ctrlc_handling() {
+        let (ctrlc_tx, mut ctrlc_rx) = broadcast::channel::<()>(1);
+        let hang_detected = Arc::new(AtomicBool::new(false));
+        let hang_detected_clone = hang_detected.clone();
+
+        // Spawn a task that simulates the blocking readline call
+        let blocking_task = tokio::spawn(async move {
+            tokio::select! {
+                // This simulates a blocking operation like rustyline::readline()
+                _ = tokio::task::spawn_blocking(|| {
+                    // Block for 2 seconds to simulate readline waiting for input
+                    std::thread::sleep(Duration::from_secs(2));
+                }) => {
+                    // If we get here, the blocking operation completed
+                },
+                // This should fire when Ctrl+C is pressed
+                Ok(_) = ctrlc_rx.recv() => {
+                    // If we get here, Ctrl+C was processed successfully
+                    hang_detected_clone.store(true, Ordering::SeqCst);
+                },
+            }
+        });
+
+        // Wait a bit for the task to start blocking
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Simulate Ctrl+C being pressed
+        let _ = ctrlc_tx.send(());
+
+        // Wait a bit to see if the signal was processed
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // The hang_detected flag should be true if Ctrl+C was handled
+        // With spawn_blocking, this should work correctly
+        assert!(
+            hang_detected.load(Ordering::SeqCst),
+            "Ctrl+C should be processed even during blocking operations when using spawn_blocking"
+        );
+
+        // Clean up
+        blocking_task.abort();
+    }
+
+    /// This test simulates the run_hooks scenario where async operations
+    /// complete without Ctrl+C handling - demonstrates the bug
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_hooks_without_ctrlc_handling() {
+        let (ctrlc_tx, _ctrlc_rx) = broadcast::channel::<()>(1);
+        let hook_completed = Arc::new(AtomicBool::new(false));
+        let hook_completed_clone = hook_completed.clone();
+        
+        // Simulate hook execution that takes time but has NO Ctrl+C handling
+        let hook_task = tokio::spawn(async move {
+            // Simulate a hook that takes 1 second
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            hook_completed_clone.store(true, Ordering::SeqCst);
+        });
+        
+        // Simulate Ctrl+C being pressed immediately
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let _ = ctrlc_tx.send(());
+        
+        // Wait a bit to see if hook responds to Ctrl+C (it won't)
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        
+        // Hook should still be running because it doesn't check for Ctrl+C
+        assert!(
+            !hook_completed.load(Ordering::SeqCst),
+            "Hook should still be running - doesn't respond to Ctrl+C"
+        );
+        
+        // Wait for hook to actually complete
+        let _ = hook_task.await;
+        
+        // Now it should be done
+        assert!(
+            hook_completed.load(Ordering::SeqCst),
+            "Hook eventually completes but ignored Ctrl+C - this is the bug"
+        );
+    }
+
+    /// This test shows the CORRECT pattern - hooks WITH Ctrl+C handling
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_hooks_with_ctrlc_handling() {
+        let (ctrlc_tx, mut ctrlc_rx) = broadcast::channel::<()>(1);
+        
+        // Simulate hook execution WITH Ctrl+C handling
+        let hook_task = tokio::spawn(async move {
+            let mut futures = vec![];
+            for _ in 0..3 {
+                futures.push(tokio::spawn(async {
+                    tokio::time::sleep(Duration::from_secs(2)).await;
+                    "hook result"
+                }));
+            }
+            
+            // Wait for hooks WITH tokio::select! for Ctrl+C
+            tokio::select! {
+                _ = async {
+                    for fut in futures {
+                        let _ = fut.await;
+                    }
+                } => {},
+                Ok(_) = ctrlc_rx.recv() => {
+                    // Ctrl+C received, cancel hooks
+                    return Err("Cancelled by Ctrl+C");
+                }
+            }
+            Ok("Completed")
+        });
+        
+        // Simulate Ctrl+C being pressed while hooks are running
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let _ = ctrlc_tx.send(());
+        
+        // Hook task should complete quickly because it handles Ctrl+C
+        let result = tokio::time::timeout(Duration::from_millis(500), hook_task).await;
+        
+        assert!(
+            result.is_ok(),
+            "Hook execution should complete quickly when Ctrl+C is handled"
+        );
+        assert!(
+            result.unwrap().unwrap().is_err(),
+            "Hook should return error indicating cancellation"
+        );
+    }
+}


### PR DESCRIPTION
## Fix: Conversation overflow, terminal responsiveness, and transcript accuracy

### Changes

1. Conversation overflow with token-based compaction

  - Fixed bug where message count was used instead of token count, causing overflow errors with large tool outputs
  - Track cumulative token usage (input + output) from backend MetadataEvent
  - Trigger proactive compaction at 98% of context window based on actual tokens
  - Add MetadataEvent support to ChatResponseStream

2. Ctrl+C handling during hook execution

  - CLI no longer freezes during "Thinking..." state when hooks are running
  - Hooks now respond immediately to Ctrl+C instead of waiting for 30s timeout
  - Uses tokio::select! to monitor both hook completion and Ctrl+C signals

3. Transcript sanitization

  - Fixed bug where hidden unicode characters appeared in transcript but not in messages sent to LLM
  - Moved transcript append to after sanitization step

4. ANSI escape codes in /clear command

  - Replaced StyledText helpers with direct crossterm commands for consistent rendering across terminals