### PR TITLE
Add maintenance notice and Kiro CLI transition info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Amazon Q CLI
 
+> [!IMPORTANT]
+> This open source project is no longer being actively maintained and will only receive critical security fixes. Amazon Q Developer CLI is now available as [Kiro CLI](https://kiro.dev/cli/), a closed-source product. For the latest features and updates, please use Kiro CLI.
+
 ## Installation
 
 - **macOS**:


### PR DESCRIPTION
This PR adds an important notice to the README informing users that:
- The open source project is no longer being actively maintained
- Only critical security fixes will be provided
- Amazon Q Developer CLI is now available as Kiro CLI (closed-source)
- Links to https://kiro.dev/cli/ for the latest features and updates