### PR TITLE
fix: add OS-aware guidance to execute_bash tool for correct cross-platform commands

### DIFF
--- a/crates/chat-cli/src/cli/chat/message.rs
+++ b/crates/chat-cli/src/cli/chat/message.rs
@@ -15,6 +15,11 @@ use tracing::{
     warn,
 };
 
+use crate::util::system_info::{
+    in_wsl,
+    os_version,
+};
+
 use super::consts::{
     MAX_CURRENT_WORKING_DIRECTORY_LEN,
     MAX_USER_MESSAGE_SIZE,
@@ -540,8 +545,21 @@ impl From<ToolUse> for AssistantToolUse {
 }
 
 pub fn build_env_state() -> EnvState {
+    // Build a detailed OS description using system_info
+    let os_description = match os_version() {
+        Some(version) => {
+            let base = version.to_string();
+            if in_wsl() {
+                format!("{} (WSL - Windows Subsystem for Linux)", base)
+            } else {
+                base
+            }
+        },
+        None => env::consts::OS.into(),
+    };
+
     let mut env_state = EnvState {
-        operating_system: Some(env::consts::OS.into()),
+        operating_system: Some(os_description),
         ..Default::default()
     };
 

--- a/crates/chat-cli/src/cli/chat/tools/tool_index.json
+++ b/crates/chat-cli/src/cli/chat/tools/tool_index.json
@@ -24,13 +24,13 @@
   },
   "execute_bash": {
     "name": "execute_bash",
-    "description": "Execute the specified bash command.",
+    "description": "Execute the specified shell command.\n\nIMPORTANT: Always check the 'operating_system' field in the user's environment context before generating commands.\n\nOS-specific guidance:\n- Windows: Use PowerShell syntax (Get-ChildItem instead of ls, Get-Content instead of cat, New-Item instead of touch, Remove-Item instead of rm, Copy-Item instead of cp, Move-Item instead of mv). Use backslashes for paths or forward slashes. Use $env:VAR for environment variables.\n- Linux/macOS: Use bash/POSIX syntax (ls, cat, touch, rm, cp, mv). Use forward slashes for paths. Use $VAR for environment variables.\n- WSL: The environment is Linux but may interact with Windows paths via /mnt/c/.\n\nNever assume Linux commands will work on Windows or vice versa. When the OS is unclear, ask the user to confirm.",
     "input_schema": {
       "type": "object",
       "properties": {
         "command": {
           "type": "string",
-          "description": "Bash command to execute"
+          "description": "Shell command to execute. Must use syntax appropriate for the user's operating system."
         },
         "summary": {
           "type": "string",


### PR DESCRIPTION
## Summary

This PR fixes an issue where the LLM generates Linux/bash commands when running on Windows instances. The root cause was that while the OS information was being sent to the LLM, the `execute_bash` tool description didn't instruct the LLM to check or use this information.

## Changes

### 1. Enhanced `execute_bash` Tool Description (`tool_index.json`)
- Added explicit instruction to check the `operating_system` field before generating commands
- Added OS-specific command guidance:
  - **Windows**: Use PowerShell syntax (Get-ChildItem, Get-Content, New-Item, etc.)
  - **Linux/macOS**: Use bash/POSIX syntax (ls, cat, touch, etc.)
  - **WSL**: Linux environment with Windows path access via `/mnt/c/`
- Updated command parameter description to emphasize OS-appropriate syntax

### 2. Enhanced OS Information in `build_env_state()` (`message.rs`)
- Now uses the existing `os_version()` function from `system_info` module
- Provides detailed OS descriptions instead of simple strings:
  - Before: `"windows"`, `"linux"`, `"macos"`
  - After: `"Windows 11 (or newer) - build 22631"`, `"Linux 5.15.0 - Ubuntu 22.04 LTS"`, `"macOS 14.5.0 (23F79)"`
- Added WSL detection to append `"(WSL - Windows Subsystem for Linux)"` suffix

## Testing

- `cargo build -p chat_cli` - Success
- `cargo test -p chat_cli message` - All 7 tests pass
- JSON validation - Valid

## Impact

The LLM will now:
1. Be explicitly instructed to check the OS before generating shell commands
2. Receive more detailed OS information to make better decisions
3. Generate PowerShell commands for Windows and bash commands for Linux/macOS