### PR TITLE
Fix AuthProfile deserialization for social login profiles

### DIFF
--- a/crates/chat-cli/src/database/mod.rs
+++ b/crates/chat-cli/src/database/mod.rs
@@ -86,6 +86,7 @@ pub struct CredentialsJson {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AuthProfile {
     pub arn: String,
+    #[serde(alias = "profileName")]
     pub profile_name: String,
 }
 
@@ -667,6 +668,20 @@ mod tests {
         println!("duration: {:?}", now.elapsed() / 100);
 
         store.delete_secret(key).await.unwrap();
+    }
+
+    #[test]
+    fn test_auth_profile_deserialization_snake_case() {
+        let json = r#"{"arn":"arn:aws:codewhisperer:us-east-1:123456:profile/TEST","profile_name":"TestProfile"}"#;
+        let profile: AuthProfile = serde_json::from_str(json).unwrap();
+        assert_eq!(profile.profile_name, "TestProfile");
+    }
+
+    #[test]
+    fn test_auth_profile_deserialization_camel_case() {
+        let json = r#"{"arn":"arn:aws:codewhisperer:us-east-1:123456:profile/TEST","profileName":"TestProfile"}"#;
+        let profile: AuthProfile = serde_json::from_str(json).unwrap();
+        assert_eq!(profile.profile_name, "TestProfile");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Adds `#[serde(alias = "profileName")]` to `AuthProfile.profile_name` so it deserializes correctly from both snake_case and camelCase JSON
- Adds unit tests for both deserialization formats

## Problem

The wrapper binary (`q_cli`/`fig_auth`) writes the auth profile to the database with camelCase:
```json
{"arn":"...","profileName":"Social_Default_Profile"}
```

But `AuthProfile` in `chat-cli` expects snake_case (`profile_name`), causing `get_auth_profile()` to fail with:
```
Failed to get auth profile: missing field `profile_name` at line 1 column 114
```

This results in `profileArn` being `None`, which triggers the lazy `ListAvailableProfiles` fallback. When that also fails (returns empty for social auth tokens), users see:
```
profileArn is required but no profiles are available. Please log in and select a profile.
```

Debug log (`KIRO_LOG_LEVEL=debug KIRO_CHAT_LOG_FILE=/tmp/debug.log`) confirms this:
```
ERROR chat_cli::api_client: 350: Failed to get auth profile: missing field `profile_name` at line 1 column 114
INFO  chat_cli::api_client: 194: profileArn missing, attempting lazy resolution via list_available_profiles
```

## Verification

Running the chat binary directly after manually fixing the JSON to `"profile_name"` confirms chat works. The `#[serde(alias)]` fix makes this automatic.

## Test plan

- [ ] Unit tests pass for both `profile_name` and `profileName` JSON formats
- [ ] Social/Google login users can send chat messages without the profileArn error
- [ ] Builder ID and IAM Identity Center login flows remain unaffected

Fixes #3703