### PR TITLE
fix(fs_write): suppress spurious trailing-newline diff lines

### DIFF
--- a/crates/chat-cli/src/cli/chat/tools/fs_write.rs
+++ b/crates/chat-cli/src/cli/chat/tools/fs_write.rs
@@ -641,7 +641,14 @@ fn print_diff(
     new_str: &StylizedFile,
     start_line: usize,
 ) -> Result<()> {
-    let diff = similar::TextDiff::from_lines(&old_str.content, &new_str.content);
+    // Strip at most one trailing newline from both sides before diffing. This prevents a
+    // spurious Delete/Insert pair on the last line when the only difference is whether the
+    // file ends with a newline — a cosmetic artefact caused by write_to_file always appending
+    // one. We strip only a single '\n' so that intentional multi-newline differences are still
+    // shown. See: #923
+    let old_content = old_str.content.strip_suffix('\n').unwrap_or(&old_str.content);
+    let new_content = new_str.content.strip_suffix('\n').unwrap_or(&new_str.content);
+    let diff = similar::TextDiff::from_lines(old_content, new_content);
 
     // First, get the gutter width required for both the old and new lines.
     let (mut max_old_i, mut max_new_i) = (1, 1);
@@ -1576,4 +1583,48 @@ mod tests {
             "after_lines should match the actual line count in the file"
         );
     }
+
+    /// Render `print_diff` to a plain string (no ANSI codes) for assertion.
+    fn diff_output(old: &str, new: &str) -> String {
+        let old = StylizedFile { content: old.to_string(), ..Default::default() };
+        let new = StylizedFile { content: new.to_string(), ..Default::default() };
+        let mut buf = Vec::new();
+        print_diff(&mut buf, &old, &new, 1).unwrap();
+        strip_ansi_escapes::strip_str(String::from_utf8(buf).unwrap())
+    }
+
+    /// Returns the number of lines tagged with `sign` ('+' or '-') in the diff output.
+    fn count_sign(output: &str, sign: char) -> usize {
+        output.lines().filter(|l| l.starts_with(sign)).count()
+    }
+
+    #[test]
+    fn test_print_diff_trailing_newline_only_change_is_not_shown() {
+        // old ends with \n, new does not — only difference is a trailing newline.
+        // write_to_file always appends \n, so this is a common artefact. The diff
+        // should show no additions or deletions. See: #923
+        let output = diff_output("fi\n", "fi");
+        assert_eq!(count_sign(&output, '-'), 0, "no deletions expected:\n{output}");
+        assert_eq!(count_sign(&output, '+'), 0, "no insertions expected:\n{output}");
+    }
+
+    #[test]
+    fn test_print_diff_real_change_is_shown() {
+        // A genuine content change must still appear in the diff.
+        let output = diff_output("old line\n", "new line\n");
+        insta::assert_snapshot!(output, @"
+        - 1   : old line
+        +    1: new line
+        ");
+    }
+
+    #[test]
+    fn test_print_diff_multiple_trailing_newlines_difference_is_shown() {
+        // Intentional multi-newline difference must not be silently swallowed.
+        // old has one trailing \n, new has three — strip_suffix removes only one from each,
+        // leaving new with two extra blank lines that should appear as insertions.
+        let output = diff_output("fi\n", "fi\n\n\n");
+        assert!(count_sign(&output, '+') > 0, "insertions expected for extra newlines:\n{output}");
+    }
+
 }


### PR DESCRIPTION
## Issue

Closes #923

## Problem

When `fs_write` modifies a file, the diff shown to the user always has a spurious last line:

```diff
- 92    : fi
+     92: fi
```

The content is identical — the only difference is a trailing newline. This is a cosmetic artefact caused by `write_to_file` always appending `\n` to file content, while the diff compares the raw strings before normalization.

## Fix

Strip at most **one** trailing newline from both sides before passing to `TextDiff::from_lines`:

```rust
// Before
let diff = similar::TextDiff::from_lines(&old_str.content, &new_str.content);

// After — strip_suffix removes at most one \n, preserving intentional multi-newline differences
let old_content = old_str.content.strip_suffix('\n').unwrap_or(&old_str.content);
let new_content = new_str.content.strip_suffix('\n').unwrap_or(&new_str.content);
let diff = similar::TextDiff::from_lines(old_content, new_content);
```

`strip_suffix` (not `trim_end_matches`) is used deliberately — it removes exactly one trailing newline so that intentional multi-newline differences (e.g. old has 1 trailing newline, new has 3) are still shown.

## Testing

```bash
# Run the three targeted tests
cargo test -p chat_cli test_print_diff

# Run the full test suite to check for regressions
cargo test -p chat_cli
```

Three tests cover all scenarios:
1. `test_print_diff_trailing_newline_only_change_is_not_shown` — the bug case: trailing-newline-only diff produces zero deletions and zero insertions
2. `test_print_diff_real_change_is_shown` — regression guard: a genuine content change still appears (uses `insta::assert_snapshot!` for the exact formatted output)
3. `test_print_diff_multiple_trailing_newlines_difference_is_shown` — edge case: intentional extra newlines are still shown as insertions

Tests use `strip_ansi_escapes` (already in the workspace) to strip terminal color codes before asserting.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.