### PR TITLE
docs: add TESTING.md with testing conventions for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,11 @@ GitHub provides additional document on [forking a repository](https://help.githu
 
 Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.
 
+## Writing Tests
+
+Please include tests with your changes. See [TESTING.md](TESTING.md) for
+conventions on when to use standard assertions vs snapshot testing with `insta`.
+
 ## Code of Conduct
 
 This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,165 @@
+# Testing Guide
+
+This document covers testing conventions for the `chat-cli` crate, including when to use
+standard assertions vs snapshot testing with [`insta`](https://insta.rs).
+
+## Quick Reference
+
+| Situation | Use |
+|-----------|-----|
+| Numeric / boolean / enum result | `assert_eq!` / `assert!` |
+| Short, stable string | `assert_eq!` |
+| Formatted / multi-line string output | `insta::assert_snapshot!` |
+| Complex struct | `insta::assert_debug_snapshot!` |
+| Output contains ANSI escape codes | Strip first → then `insta` or `assert_eq!` |
+
+---
+
+## Standard Assertions
+
+Use `assert_eq!` and `assert!` for simple, deterministic values where the expected result
+is obvious and stable:
+
+```rust
+// Numeric
+assert_eq!(lines_added, 3);
+assert_eq!(count_sign(&output, '-'), 0);
+
+// Boolean / Result
+assert!(result.is_ok());
+assert!(path.exists());
+
+// Enum variant
+assert!(matches!(fw, FsWrite::Create { .. }));
+
+// Short stable string
+assert_eq!(sanitize_path(&os, "~/file.txt"), "/home/user/file.txt");
+```
+
+Avoid using `assert_eq!` for long or formatted strings — they are fragile and hard to read
+when they fail.
+
+---
+
+## Snapshot Testing with insta
+
+`insta` is already a workspace dependency. Use it when the output is a complex or formatted
+string that would be tedious and brittle to hardcode manually.
+
+### Setup
+
+Install the review CLI once:
+
+```bash
+cargo install cargo-insta
+```
+
+### Inline snapshots (recommended)
+
+For short-to-medium output, store the expected value directly in source using `@"..."`:
+
+```rust
+insta::assert_snapshot!(output, @"
+- 1   : old line
++    1: new line
+");
+```
+
+This keeps the expected value visible in the same file as the test, making PR reviews easier.
+
+### Named / auto-named snapshots
+
+For larger output, let `insta` store the snapshot in a separate `.snap` file:
+
+```rust
+// Auto-named (uses test function name)
+insta::assert_snapshot!(output);
+
+// Explicitly named
+insta::assert_snapshot!("my_snapshot", output);
+```
+
+Snapshot files are committed to the repository alongside the test.
+
+### Workflow
+
+1. Write the test without an expected value:
+
+   ```rust
+   insta::assert_snapshot!(output);
+   ```
+
+2. Run the tests — they will fail but record the actual output:
+
+   ```bash
+   cargo test -p chat_cli
+   ```
+
+3. Review and accept the recorded output:
+
+   ```bash
+   cargo insta review   # interactive: inspect each snapshot
+   # or
+   cargo insta accept   # accept all pending snapshots at once
+   ```
+
+4. Re-run the tests — they should now pass:
+
+   ```bash
+   cargo test -p chat_cli
+   ```
+
+5. When output changes in the future, `cargo insta review` shows a before/after diff.
+   Decide whether the change is intentional or a regression.
+
+### Other snapshot variants
+
+```rust
+// Debug output of any type that implements Debug
+insta::assert_debug_snapshot!(parsed_tool_use);
+
+// JSON (requires the "json" feature, already enabled in workspace)
+insta::assert_json_snapshot!(api_response);
+```
+
+---
+
+## Handling ANSI Escape Codes
+
+Terminal rendering functions (e.g. `print_diff`) embed ANSI color codes in their output.
+Asserting directly on that output will fail because lines start with escape sequences, not
+the visible characters.
+
+Strip ANSI codes before asserting. The `strip_ansi_escapes` crate is already used in the
+codebase:
+
+```rust
+// In your test helper
+fn render(old: &str, new: &str) -> String {
+    let mut buf = Vec::new();
+    print_diff(&mut buf, &make_file(old), &make_file(new), 1).unwrap();
+    strip_ansi_escapes::strip_str(String::from_utf8(buf).unwrap())
+}
+
+#[test]
+fn test_real_change_is_shown() {
+    let output = render("old line\n", "new line\n");
+    insta::assert_snapshot!(output, @"
+    - 1   : old line
+    +    1: new line
+    ");
+}
+```
+
+---
+
+## Real Example: `print_diff` in `fs_write.rs`
+
+The tests added in [#3717](https://github.com/aws/amazon-q-developer-cli/pull/3717) demonstrate
+this pattern in practice:
+
+- `count_sign()` + `assert_eq!` for simple numeric assertions (zero deletions, non-zero insertions)
+- `insta::assert_snapshot!` for the exact formatted output of a real change
+- `strip_ansi_escapes` to make the output assertable
+
+See `crates/chat-cli/src/cli/chat/tools/fs_write.rs` tests module for the full implementation.

--- a/TESTING.md
+++ b/TESTING.md
@@ -3,6 +3,31 @@
 This document covers testing conventions for the `chat-cli` crate, including when to use
 standard assertions vs snapshot testing with [`insta`](https://insta.rs).
 
+## Table of Contents
+
+1. [Core Principle](#core-principle)
+2. [Quick Reference](#quick-reference)
+3. [Standard Assertions](#standard-assertions)
+4. [Snapshot Testing with insta](#snapshot-testing-with-insta)
+5. [Handling ANSI Escape Codes](#handling-ansi-escape-codes)
+6. [Real Examples from This Codebase](#real-examples-from-this-codebase)
+7. [Anti-Patterns to Avoid](#anti-patterns-to-avoid)
+
+---
+
+## Core Principle
+
+The choice between `assert_eq!` and `insta` is not a matter of preference — it depends on
+**the nature of the output being tested**:
+
+```
+Simple & deterministic output   →  assert_eq! / assert!
+Complex / long string output    →  insta::assert_snapshot!
+Output that may change over time →  insta (with review workflow)
+```
+
+---
+
 ## Quick Reference
 
 | Situation | Use |
@@ -11,14 +36,18 @@ standard assertions vs snapshot testing with [`insta`](https://insta.rs).
 | Short, stable string | `assert_eq!` |
 | Formatted / multi-line string output | `insta::assert_snapshot!` |
 | Complex struct | `insta::assert_debug_snapshot!` |
+| JSON response | `insta::assert_json_snapshot!` |
 | Output contains ANSI escape codes | Strip first → then `insta` or `assert_eq!` |
+| Output that may change over time | `insta` (with review workflow) |
 
 ---
 
 ## Standard Assertions
 
 Use `assert_eq!` and `assert!` for simple, deterministic values where the expected result
-is obvious and stable:
+is obvious and stable.
+
+### ✅ Correct usage
 
 ```rust
 // Numeric
@@ -34,6 +63,25 @@ assert!(matches!(fw, FsWrite::Create { .. }));
 
 // Short stable string
 assert_eq!(sanitize_path(&os, "~/file.txt"), "/home/user/file.txt");
+
+// Condition without caring about exact value
+assert!(count_sign(&output, '+') > 0);
+```
+
+### ❌ Do not use assert_eq! for these
+
+```rust
+// Long formatted string — fragile and hard to read on failure
+assert_eq!(
+    output,
+    "- 1   : old line\n+    1: new line\n\n"
+);
+
+// Output containing ANSI escape codes — will never match visible text
+assert_eq!(rendered, "\u{1b}[38;5;9m- 1   : old line\u{1b}[0m\n");
+
+// Long JSON or structured text
+assert_eq!(json_output, "{\"key\": \"value\", \"nested\": {...}}");
 ```
 
 Avoid using `assert_eq!` for long or formatted strings — they are fragile and hard to read
@@ -48,15 +96,48 @@ string that would be tedious and brittle to hardcode manually.
 
 ### Setup
 
-Install the review CLI once:
+`insta` as a library is already declared in the workspace:
+
+```toml
+# Cargo.toml (workspace root)
+insta = "1.43.1"
+
+# crates/chat-cli/Cargo.toml
+[dev-dependencies]
+insta.workspace = true
+```
+
+Install the review CLI once before writing snapshot tests:
 
 ```bash
 cargo install cargo-insta
+
+# Verify
+cargo insta --version
+# cargo-insta 1.47.2
 ```
 
-### Inline snapshots (recommended)
+> **Important:** Check `Cargo.toml` for existing dependencies before adding new ones.
+> `strip_ansi_escapes` is also already available in the workspace — no need to add it.
 
-For short-to-medium output, store the expected value directly in source using `@"..."`:
+### Three modes
+
+```rust
+// 1. Inline snapshot — value stored directly in source code (recommended)
+insta::assert_snapshot!(output, @"expected value here");
+
+// 2. Auto-named — stored in a separate .snap file, named after the test function
+insta::assert_snapshot!(output);
+
+// 3. Explicitly named — stored in a separate .snap file with a custom name
+insta::assert_snapshot!("my_snapshot_name", output);
+```
+
+**Recommendation for this codebase:** use **inline snapshots** (`@"..."`) for short-to-medium
+output. The expected value is visible in the same file as the test, making PR reviews easier
+without needing to open separate `.snap` files.
+
+### Inline snapshots (recommended)
 
 ```rust
 insta::assert_snapshot!(output, @"
@@ -64,8 +145,6 @@ insta::assert_snapshot!(output, @"
 +    1: new line
 ");
 ```
-
-This keeps the expected value visible in the same file as the test, making PR reviews easier.
 
 ### Named / auto-named snapshots
 
@@ -81,37 +160,6 @@ insta::assert_snapshot!("my_snapshot", output);
 
 Snapshot files are committed to the repository alongside the test.
 
-### Workflow
-
-1. Write the test without an expected value:
-
-   ```rust
-   insta::assert_snapshot!(output);
-   ```
-
-2. Run the tests — they will fail but record the actual output:
-
-   ```bash
-   cargo test -p chat_cli
-   ```
-
-3. Review and accept the recorded output:
-
-   ```bash
-   cargo insta review   # interactive: inspect each snapshot
-   # or
-   cargo insta accept   # accept all pending snapshots at once
-   ```
-
-4. Re-run the tests — they should now pass:
-
-   ```bash
-   cargo test -p chat_cli
-   ```
-
-5. When output changes in the future, `cargo insta review` shows a before/after diff.
-   Decide whether the change is intentional or a regression.
-
 ### Other snapshot variants
 
 ```rust
@@ -122,44 +170,227 @@ insta::assert_debug_snapshot!(parsed_tool_use);
 insta::assert_json_snapshot!(api_response);
 ```
 
+### Workflow
+
+**Step 1:** Write the test without an expected value:
+
+```rust
+#[test]
+fn test_diff_output() {
+    let output = diff_output("old line\n", "new line\n");
+    insta::assert_snapshot!(output);  // no value yet
+}
+```
+
+**Step 2:** Run the tests — they will fail but record the actual output as pending:
+
+```bash
+cargo test -p chat_cli test_diff_output
+# FAILED — but snapshot is saved as pending
+```
+
+**Step 3:** Review the recorded output interactively:
+
+```bash
+cargo insta review
+```
+
+This opens an interactive prompt:
+
+```
+Snapshot: diff_output
+Source: crates/chat-cli/src/cli/chat/tools/fs_write.rs:1615
+────────────────────────────────────────────────────────
+Expression: output
+────────────────────────────────────────────────────────
+New snapshot:
+- 1   : old line
++    1: new line
+
+Accept? [y/n/s(kip)]
+```
+
+**Step 4:** Accept the snapshot:
+
+```bash
+# Press 'y' in the interactive review, or accept all at once:
+cargo insta accept
+```
+
+After accepting, the source file is updated automatically with the inline value:
+
+```rust
+insta::assert_snapshot!(output, @"
+- 1   : old line
++    1: new line
+");
+```
+
+**Step 5:** Re-run the tests — they should now pass:
+
+```bash
+cargo test -p chat_cli test_diff_output
+# ok
+```
+
+**When output changes in the future:**
+
+```bash
+cargo insta test -p chat_cli  # run all tests with insta
+cargo insta review             # review changes: regression or intentional?
+```
+
 ---
 
 ## Handling ANSI Escape Codes
 
 Terminal rendering functions (e.g. `print_diff`) embed ANSI color codes in their output.
 Asserting directly on that output will fail because lines start with escape sequences, not
-the visible characters.
+the visible characters:
+
+```
+\u{1b}[38;5;9m- 1   : old line\u{1b}[0m
+```
+
+The line above starts with `\u{1b}[38;5;9m` (a red color code), not `-`. Any assertion
+checking for `starts_with('-')` will silently fail.
 
 Strip ANSI codes before asserting. The `strip_ansi_escapes` crate is already used in the
-codebase:
+codebase — no need to add a new dependency:
 
 ```rust
-// In your test helper
-fn render(old: &str, new: &str) -> String {
+fn diff_output(old: &str, new: &str) -> String {
+    let old = StylizedFile { content: old.to_string(), ..Default::default() };
+    let new = StylizedFile { content: new.to_string(), ..Default::default() };
     let mut buf = Vec::new();
-    print_diff(&mut buf, &make_file(old), &make_file(new), 1).unwrap();
+    print_diff(&mut buf, &old, &new, 1).unwrap();
+    // strip_ansi_escapes is already in the workspace — check Cargo.toml before adding deps
     strip_ansi_escapes::strip_str(String::from_utf8(buf).unwrap())
-}
-
-#[test]
-fn test_real_change_is_shown() {
-    let output = render("old line\n", "new line\n");
-    insta::assert_snapshot!(output, @"
-    - 1   : old line
-    +    1: new line
-    ");
 }
 ```
 
 ---
 
-## Real Example: `print_diff` in `fs_write.rs`
+## Real Examples from This Codebase
 
-The tests added in [#3717](https://github.com/aws/amazon-q-developer-cli/pull/3717) demonstrate
-this pattern in practice:
+### Case 1: Testing `print_diff` in `fs_write.rs`
 
-- `count_sign()` + `assert_eq!` for simple numeric assertions (zero deletions, non-zero insertions)
-- `insta::assert_snapshot!` for the exact formatted output of a real change
-- `strip_ansi_escapes` to make the output assertable
+`print_diff` is a private function that renders a colored terminal diff. It embeds ANSI
+codes and produces multi-line formatted output — a perfect case for combining both approaches.
 
-See `crates/chat-cli/src/cli/chat/tools/fs_write.rs` tests module for the full implementation.
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Renders print_diff to a plain string with ANSI codes stripped.
+    fn diff_output(old: &str, new: &str) -> String {
+        let old = StylizedFile { content: old.to_string(), ..Default::default() };
+        let new = StylizedFile { content: new.to_string(), ..Default::default() };
+        let mut buf = Vec::new();
+        print_diff(&mut buf, &old, &new, 1).unwrap();
+        strip_ansi_escapes::strip_str(String::from_utf8(buf).unwrap())
+    }
+
+    /// Counts lines starting with the given sign character.
+    fn count_sign(output: &str, sign: char) -> usize {
+        output.lines().filter(|l| l.starts_with(sign)).count()
+    }
+
+    #[test]
+    fn test_trailing_newline_only_change_is_not_shown() {
+        // assert_eq! is sufficient — result is a simple number
+        let output = diff_output("fi\n", "fi");
+        assert_eq!(count_sign(&output, '-'), 0);
+        assert_eq!(count_sign(&output, '+'), 0);
+    }
+
+    #[test]
+    fn test_real_change_is_shown() {
+        // insta is appropriate — output is a formatted string with line numbers
+        let output = diff_output("old line\n", "new line\n");
+        insta::assert_snapshot!(output, @"
+        - 1   : old line
+        +    1: new line
+        ");
+    }
+
+    #[test]
+    fn test_multiple_trailing_newlines_difference_is_shown() {
+        // assert! is sufficient — we only need to know insertions exist
+        let output = diff_output("fi\n", "fi\n\n\n");
+        assert!(count_sign(&output, '+') > 0);
+    }
+}
+```
+
+**Pattern used:**
+- `assert_eq!` for numeric results from `count_sign`
+- `insta::assert_snapshot!` for the exact formatted string output
+- `assert!` for simple boolean conditions
+
+### Case 2: Testing `sanitize_path_tool_arg` in `tools/mod.rs`
+
+```rust
+#[tokio::test]
+async fn test_tilde_path_expansion() {
+    let os = Os::new().await.unwrap();
+
+    // assert_eq! is appropriate — output is a deterministic path derived from os.env.home()
+    let actual = sanitize_path_tool_arg(&os, "~");
+    assert_eq!(actual, os.fs.chroot_path(&expected_home), "tilde should expand");
+
+    let actual = sanitize_path_tool_arg(&os, "~/hello");
+    assert_eq!(actual, os.fs.chroot_path(&expected_home.join("hello")));
+}
+```
+
+`assert_eq!` is correct here because the output is a path that can be computed
+deterministically from `os.env.home()` — no formatting, no ANSI, no variability.
+
+---
+
+## Anti-Patterns to Avoid
+
+### ❌ Hardcoding ANSI escape codes
+
+```rust
+// Don't
+assert_eq!(output, "\u{1b}[38;5;9m- 1   : old\u{1b}[0m\n");
+
+// Do
+let clean = strip_ansi_escapes::strip_str(&output);
+insta::assert_snapshot!(clean, @"- 1   : old");
+```
+
+### ❌ Using insta for simple values
+
+```rust
+// Overkill
+insta::assert_snapshot!(count.to_string(), @"3");
+
+// Sufficient
+assert_eq!(count, 3);
+```
+
+### ❌ Manually writing snapshot values
+
+```rust
+// Don't guess — you will get whitespace or escaping wrong
+insta::assert_snapshot!(output, @"- 1   : old line\n+    1: new line\n\n");
+
+// Let insta record the actual output, then review and accept
+insta::assert_snapshot!(output);  // run first, review, then accept
+```
+
+### ❌ Not installing cargo-insta before writing snapshot tests
+
+```bash
+# Check for insta in the workspace before starting
+grep insta Cargo.toml
+# If present → install the CLI tool
+cargo install cargo-insta
+```
+
+Skipping this leads to workarounds like hardcoding strings or modifying test helpers
+unnecessarily — both of which were avoidable mistakes documented here for reference.


### PR DESCRIPTION
## Motivation

The codebase has `insta` as a workspace dependency but its usage is minimal (3 occurrences across the entire codebase) and completely undocumented. There is currently no guidance for contributors on:

- When to use `assert_eq!`/`assert!` vs `insta` snapshot testing
- How to run the `cargo insta` review workflow
- How to handle ANSI escape codes in terminal output tests (a common pitfall when testing rendering functions like `print_diff`)

This gap leads to either fragile hardcoded strings or missing tests for rendered output entirely.

## Changes

- Add `TESTING.md` at the repo root with:
  - Quick reference table for choosing the right assertion style
  - Standard assertion examples with guidance on when they are appropriate
  - Full `cargo-insta` workflow: write → run → review → accept
  - Pattern for stripping ANSI escape codes before asserting
  - Real example referencing the pattern introduced in PR #3717
- Add a one-line pointer in `CONTRIBUTING.md` → `TESTING.md`

## Notes

- `docs/` was intentionally left unchanged — all existing files there are user-facing feature documentation, not contributor guides
- `TESTING.md` follows the same root-level convention as `CONTRIBUTING.md`, `SECURITY.md`, and `CODE_OF_CONDUCT.md`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.