### PR TITLE
fix(auth): surface 'No token' dispatch failure as AuthError::NoToken

### DIFF
--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -624,7 +624,70 @@ impl ReasonCode for ChatError {
 
 impl From<ApiClientError> for ChatError {
     fn from(value: ApiClientError) -> Self {
+        // A dispatch failure with "No token" in the error chain means the session has
+        // expired. Surface this as AuthError::NoToken so the handler in handle_chat_error
+        // can display a clear "run `q login`" message instead of an opaque SDK error.
+        // See: #3173
+        if is_no_token_error(&value) {
+            return Self::Auth(crate::auth::AuthError::NoToken);
+        }
         Self::Client(Box::new(value))
+    }
+}
+
+/// Returns true if the error chain contains a "No token" dispatch failure,
+/// which indicates the user's session has expired.
+fn is_no_token_error(err: &ApiClientError) -> bool {
+    use std::error::Error;
+    let mut source: Option<&dyn Error> = Some(err);
+    while let Some(e) = source {
+        if e.to_string().contains("No token") {
+            return true;
+        }
+        source = e.source();
+    }
+    false
+}
+
+#[cfg(test)]
+mod is_no_token_error_tests {
+    use crate::api_client::error::ApiClientError;
+    use crate::auth::AuthError;
+
+    use super::{ChatError, is_no_token_error};
+
+    #[test]
+    fn detects_auth_no_token() {
+        let err = ApiClientError::AuthError(AuthError::NoToken);
+        assert!(is_no_token_error(&err));
+    }
+
+    #[test]
+    fn ignores_unrelated_errors() {
+        let err = ApiClientError::DefaultModelNotFound;
+        assert!(!is_no_token_error(&err));
+    }
+
+    #[test]
+    fn from_api_client_error_converts_no_token_to_auth_error() {
+        let err = ApiClientError::AuthError(AuthError::NoToken);
+        let chat_err = ChatError::from(err);
+        assert!(
+            matches!(chat_err, ChatError::Auth(AuthError::NoToken)),
+            "expected ChatError::Auth(NoToken), got: {:?}",
+            chat_err
+        );
+    }
+
+    #[test]
+    fn from_api_client_error_keeps_other_errors_as_client() {
+        let err = ApiClientError::DefaultModelNotFound;
+        let chat_err = ChatError::from(err);
+        assert!(
+            matches!(chat_err, ChatError::Client(_)),
+            "expected ChatError::Client, got: {:?}",
+            chat_err
+        );
     }
 }
 


### PR DESCRIPTION
## Issue

Closes #3173

## Problem

When a session expires mid-chat, the AWS SDK returns a `DispatchFailure` with `"No token"` in the error chain. This was converted to `ChatError::Client` and displayed as an opaque multi-line error:

```
Amazon Q is having trouble responding right now:
   0: Failed to send the request: dispatch failure (other): No token
   1: dispatch failure (other): No token
   2: dispatch failure
   3: other
   4: No token
```

The handler for `ChatError::Auth(AuthError::NoToken)` already exists and displays a clear, actionable message — but it was never reached because the error was wrapped as `ChatError::Client`.

## Fix

Add `is_no_token_error()` which walks the error source chain to detect the `"No token"` string. In `From<ApiClientError> for ChatError`, check for this condition and convert to `ChatError::Auth(AuthError::NoToken)` so the existing handler is triggered, showing:

```
Authentication Error

Your login session has expired. Please log in again using:

    q login
```

## Testing

```bash
# Run the targeted tests
cargo test -p chat_cli is_no_token_error

# Run the full test suite to check for regressions
cargo test -p chat_cli
```

Four tests cover all cases:
1. `detects_auth_no_token` — `ApiClientError::AuthError(AuthError::NoToken)` is detected
2. `ignores_unrelated_errors` — unrelated errors (e.g. `DefaultModelNotFound`) are not detected
3. `from_api_client_error_converts_no_token_to_auth_error` — `From` conversion produces `ChatError::Auth(AuthError::NoToken)`
4. `from_api_client_error_keeps_other_errors_as_client` — other errors remain as `ChatError::Client`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.