### PR TITLE
fix(knowledge): show platform-accurate valid options in embedding type error

### DIFF
--- a/crates/chat-cli/src/util/knowledge_store.rs
+++ b/crates/chat-cli/src/util/knowledge_store.rs
@@ -328,7 +328,14 @@ impl KnowledgeStore {
                 Some(s) => match EmbeddingType::from_str(s) {
                     Some(et) => Some(et),
                     None => {
-                        return Err(format!("Invalid embedding type '{}'. Valid options are: fast, best", s));
+                        #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+                        let valid = "fast";
+                        #[cfg(not(all(target_os = "linux", target_arch = "aarch64")))]
+                        let valid = "fast, best";
+                        return Err(format!(
+                            "Invalid embedding type '{}'. Valid options are: {}",
+                            s, valid
+                        ));
                     },
                 },
                 None => None,
@@ -623,5 +630,32 @@ mod tests {
 
         // Verify directory structure
         assert!(base_dir.to_string_lossy().contains("knowledge_bases"));
+    }
+
+    /// Regression test for #3139: on Linux ARM64, the error message for an invalid
+    /// embedding type must not list "best" as a valid option since it is unavailable.
+    #[test]
+    fn invalid_embedding_type_error_does_not_mention_best_on_linux_arm() {
+        use semantic_search_client::embedding::EmbeddingType;
+
+        // Simulate what knowledge_store does when from_str returns None
+        let invalid = "best";
+        let result = EmbeddingType::from_str(invalid);
+
+        #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+        {
+            // On Linux ARM64, "best" must not be accepted
+            assert!(result.is_none(), "'best' should not be valid on Linux ARM64");
+            // And the error message must only list "fast"
+            let valid = "fast";
+            let msg = format!("Invalid embedding type '{}'. Valid options are: {}", invalid, valid);
+            assert!(!msg.contains("best"), "error message must not mention 'best' on Linux ARM64");
+        }
+
+        #[cfg(not(all(target_os = "linux", target_arch = "aarch64")))]
+        {
+            // On other platforms, "best" is valid
+            assert!(result.is_some(), "'best' should be valid on this platform");
+        }
     }
 }


### PR DESCRIPTION
## Issue

Closes #3139

## Problem

On Linux ARM64, `EmbeddingType::Best` is not available — the `candle` module is excluded via `#[cfg(not(all(target_os = "linux", target_arch = "aarch64")))]`. When a user passes `--index-type best` on that platform, `from_str` correctly returns `None`, but the error message was misleading:

```
Invalid embedding type 'best'. Valid options are: fast, best
```

`best` is listed as a valid option but is not accepted on that platform, causing user confusion (as reported in the issue).

## Fix

Use `cfg` to build the valid options string at compile time:

```rust
#[cfg(all(target_os = "linux", target_arch = "aarch64"))]
let valid = "fast";
#[cfg(not(all(target_os = "linux", target_arch = "aarch64")))]
let valid = "fast, best";
return Err(format!("Invalid embedding type '{}'. Valid options are: {}", s, valid));
```

On Linux ARM64 the error now reads:
```
Invalid embedding type 'best'. Valid options are: fast
```

## Testing

```bash
# Run the targeted test
cargo test -p chat_cli invalid_embedding_type

# Run the full test suite to check for regressions
cargo test -p chat_cli
```

The test `invalid_embedding_type_error_does_not_mention_best_on_linux_arm` uses `cfg` to assert platform-specific behaviour:
- On Linux ARM64: `EmbeddingType::from_str("best")` returns `None` and the error message does not mention `best`
- On other platforms: `EmbeddingType::from_str("best")` returns `Some` (no change in behaviour)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.