### PR TITLE
fix(todo): improve validation error messages to help model self-correct

### DIFF
--- a/crates/chat-cli/src/cli/chat/tools/todo.rs
+++ b/crates/chat-cli/src/cli/chat/tools/todo.rs
@@ -414,7 +414,11 @@ impl TodoList {
                 }
                 for i in completed_indices.iter() {
                     if *i >= state.tasks.len() {
-                        bail!("Index {i} is out of bounds for length {}, ", state.tasks.len());
+                        bail!(
+                            "Index {i} is out of bounds — valid indices are 0..{} (current list has {} tasks)",
+                            state.tasks.len(),
+                            state.tasks.len()
+                        );
                     }
                 }
             },
@@ -428,15 +432,23 @@ impl TodoList {
                 if new_tasks.iter().any(|task| task.trim().is_empty()) {
                     bail!("New tasks cannot be empty");
                 } else if has_duplicates(insert_indices) {
-                    bail!("Insertion indices must be unique")
+                    bail!("Insertion indices must be unique — each task must have a distinct index")
                 } else if new_tasks.len() != insert_indices.len() {
-                    bail!("Must provide an index for every new task");
+                    bail!(
+                        "Must provide an index for every new task — got {} tasks but {} indices",
+                        new_tasks.len(),
+                        insert_indices.len()
+                    );
                 } else if new_description.is_some() && new_description.as_ref().unwrap().trim().is_empty() {
                     bail!("New description cannot be empty");
                 }
                 for i in insert_indices.iter() {
                     if *i > state.tasks.len() {
-                        bail!("Index {i} is out of bounds for length {}, ", state.tasks.len());
+                        bail!(
+                            "Index {i} is out of bounds — valid insertion indices are 0..={} (current list has {} tasks)",
+                            state.tasks.len(),
+                            state.tasks.len()
+                        );
                     }
                 }
             },
@@ -447,13 +459,17 @@ impl TodoList {
             } => {
                 let state = TodoListState::load(os, id).await?;
                 if has_duplicates(remove_indices) {
-                    bail!("Removal indices must be unique")
+                    bail!("Removal indices must be unique — each index must appear only once")
                 } else if new_description.is_some() && new_description.as_ref().unwrap().trim().is_empty() {
                     bail!("New description cannot be empty");
                 }
                 for i in remove_indices.iter() {
                     if *i >= state.tasks.len() {
-                        bail!("Index {i} is out of bounds for length {}, ", state.tasks.len());
+                        bail!(
+                            "Index {i} is out of bounds — valid indices are 0..{} (current list has {} tasks)",
+                            state.tasks.len(),
+                            state.tasks.len()
+                        );
                     }
                 }
             },


### PR DESCRIPTION
## Issue

Closes #3184

## Problem

When the model sends invalid `todo_list` parameters for large todo lists, the validation error messages were too terse for the model to self-correct:

```
Tool validation failed: Insertion indices must be unique
Tool validation failed: Must provide an index for every new task
Tool validation failed: Index 44 is out of bounds for length 43,
```

These messages don't give the model enough context to understand what correction is needed — especially the count mismatch and bounds errors.

## Fix

Improve all three validation error messages with actionable context:

| Before | After |
|--------|-------|
| `Insertion indices must be unique` | `Insertion indices must be unique — each task must have a distinct index` |
| `Must provide an index for every new task` | `Must provide an index for every new task — got 5 tasks but 3 indices` |
| `Index 44 is out of bounds for length 43,` | `Index 44 is out of bounds — valid insertion indices are 0..=43 (current list has 43 tasks)` |

The same improvement is applied to `Complete` and `Remove` operations.

## Testing

```bash
# Run the full test suite to check for regressions
cargo test -p chat_cli
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.