### PR TITLE
fix(use_aws): stop defaulting profile_name to 'default'

### DIFF
--- a/crates/chat-cli/src/cli/chat/tools/tool_index.json
+++ b/crates/chat-cli/src/cli/chat/tools/tool_index.json
@@ -187,7 +187,7 @@
         },
         "profile_name": {
           "type": "string",
-          "description": "Optional: AWS profile name to use from ~/.aws/credentials. Defaults to default profile if not specified."
+          "description": "Optional: AWS profile name to use from ~/.aws/credentials. Only specify if the user explicitly mentions a profile name. If omitted, the AWS default credential chain is used (environment variables, instance profile, etc)."
         },
         "label": {
           "type": "string",
@@ -305,10 +305,10 @@
         "command": {
           "type": "string",
           "enum": [
-            "create", 
-            "complete", 
-            "load", 
-            "add", 
+            "create",
+            "complete",
+            "load",
+            "add",
             "remove",
             "lookup"
           ],
@@ -377,7 +377,9 @@
           }
         }
       },
-      "required": ["command"]
+      "required": [
+        "command"
+      ]
     }
   },
   "delegate": {
@@ -385,64 +387,63 @@
     "description": "Launch and manage asynchronous agent processes. This tool allows you to delegate tasks to agents that run independently in the background.\n\nOperations:\n- launch: Start a new task with an agent (requires task parameter, agent is optional)\n- status: Check agent status and get full output if completed. Agent is optional - defaults to 'all' if not specified\n\nIf no agent is specified for launch, uses 'default_agent'. Only one task can run per agent at a time. Files are stored in ~/.aws/amazonq/.subagents/\n\nIMPORTANT: If a specific agent is requested but not found, DO NOT automatically retry with 'default_agent' or any other agent. Simply report the error and available agents to the user.\n\nExample usage:\n1. Launch with agent: {\"operation\": \"launch\", \"agent\": \"rust-agent\", \"task\": \"Create a snake game\"}\n2. Launch without agent: {\"operation\": \"launch\", \"task\": \"Write a Python script\"}\n3. Check specific agent: {\"operation\": \"status\", \"agent\": \"rust-agent\"}\n4. Check all agents: {\"operation\": \"status\", \"agent\": \"all\"}\n5. Check all agents (shorthand): {\"operation\": \"status\"}",
     "input_schema": {
       "type": "object",
-        "properties": {
-          "operation": {
-            "description": "Operation to perform: launch, status, or list",
-            "$ref": "#/$defs/Operation"
-          },
-          "agent": {
-            "description": "Agent name to use (optional - uses \"q_cli_default\" if not specified)",
-            "type": [
-              "string",
-              "null"
-            ],
-            "default": null
-          },
-          "task": {
-            "description": "Task description (required for launch operation). This process is supposed to be async. DO NOT query immediately after launching a task.",
-            "type": [
-              "string",
-              "null"
-            ],
-            "default": null
-          }
+      "properties": {
+        "operation": {
+          "description": "Operation to perform: launch, status, or list",
+          "$ref": "#/$defs/Operation"
         },
-        "required": [
-          "operation"
-        ],
-        "$defs": {
-          "Operation": {
-            "oneOf": [
-              {
-                "description": "Launch a new agent with a specified task",
-                "type": "string",
-                "const": "launch"
-              },
-              {
-                "description": "Check the status of a specific agent or all agents if None is provided",
-                "type": "object",
-                "properties": {
-                  "status": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                },
-                "required": [
-                  "status"
-                ],
-                "additionalProperties": false
-              },
-              {
-                "description": "List all available agents",
-                "type": "string",
-                "const": "list"
-              }
-            ]
-          }
+        "agent": {
+          "description": "Agent name to use (optional - uses \"q_cli_default\" if not specified)",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
         },
-        "required": ["operation"]
+        "task": {
+          "description": "Task description (required for launch operation). This process is supposed to be async. DO NOT query immediately after launching a task.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "operation"
+      ],
+      "$defs": {
+        "Operation": {
+          "oneOf": [
+            {
+              "description": "Launch a new agent with a specified task",
+              "type": "string",
+              "const": "launch"
+            },
+            {
+              "description": "Check the status of a specific agent or all agents if None is provided",
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "status"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "description": "List all available agents",
+              "type": "string",
+              "const": "list"
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/crates/chat-cli/src/cli/chat/tools/use_aws.rs
+++ b/crates/chat-cli/src/cli/chat/tools/use_aws.rs
@@ -235,7 +235,6 @@ mod tests {
             "service_name": "ecs",
             "operation_name": "list-task-definitions",
             "region": "us-west-2",
-            "profile_name": "default",
             "label": ""
         }};
         assert!(!cmd.requires_acceptance());
@@ -243,7 +242,6 @@ mod tests {
             "service_name": "lambda",
             "operation_name": "list-functions",
             "region": "us-west-2",
-            "profile_name": "default",
             "label": ""
         }};
         assert!(!cmd.requires_acceptance());
@@ -251,7 +249,6 @@ mod tests {
             "service_name": "s3",
             "operation_name": "put-object",
             "region": "us-west-2",
-            "profile_name": "default",
             "label": ""
         }};
         assert!(cmd.requires_acceptance());
@@ -267,7 +264,6 @@ mod tests {
                 "KeyConditionExpression": "PartitionKey = :pkValue"
             },
             "region": "us-west-2",
-            "profile_name": "default",
             "label": ""
         }};
         let params = cmd.cli_parameters().unwrap();
@@ -297,7 +293,6 @@ mod tests {
             // okay for this test
             "parameters": {},
             "region": "us-west-2",
-            "profile_name": "default",
             "label": ""
         });
 
@@ -320,7 +315,6 @@ mod tests {
             "operation_name": "ls",
             "parameters": {},
             "region": "us-west-2",
-            "profile_name": "default",
             "label": ""
         });
         let out = serde_json::from_value::<UseAws>(v)
@@ -349,7 +343,6 @@ mod tests {
             "service_name": "s3",
             "operation_name": "put-object",
             "region": "us-west-2",
-            "profile_name": "default",
             "label": ""
         }};
 
@@ -377,7 +370,6 @@ mod tests {
             "service_name": "api_gateway",
             "operation_name": "request",
             "region": "us-west-2",
-            "profile_name": "default",
             "label": ""
         }};
 
@@ -403,7 +395,6 @@ mod tests {
             "service_name": "s3",
             "operation_name": "list-objects",
             "region": "us-west-2",
-            "profile_name": "default",
             "label": ""
         }};
 
@@ -417,7 +408,6 @@ mod tests {
             "service_name": "s3",
             "operation_name": "put-object",
             "region": "us-west-2",
-            "profile_name": "default",
             "label": ""
         }};
 
@@ -450,7 +440,6 @@ mod tests {
             "service_name": "s3",
             "operation_name": "list-objects",
             "region": "us-west-2",
-            "profile_name": "default",
             "label": ""
         }};
 
@@ -463,7 +452,6 @@ mod tests {
             "service_name": "s3",
             "operation_name": "put-object",
             "region": "us-west-2",
-            "profile_name": "default",
             "label": ""
         }};
 
@@ -497,7 +485,6 @@ mod tests {
             "service_name": "s3",
             "operation_name": "list-objects",
             "region": "us-west-2",
-            "profile_name": "default",
             "label": ""
         }};
 


### PR DESCRIPTION
## Issue

Closes #1045

## Problem

When a user has no AWS profile named `default`, the `use_aws` tool fails with:

```
Unable to locate credentials. You can configure credentials by running "aws configure".
```

This happens because:
1. The `profile_name` field description says *"Defaults to default profile if not specified"* — the model reads this and always fills in `profile_name: "default"`
2. All 13 tool examples in `use_aws.rs` hardcode `"profile_name": "default"`, reinforcing this behavior

The invoke logic already handles `None` correctly — when `profile_name` is `None`, no `--profile` flag is passed and the AWS default credential chain is used. The bug is entirely in the tool description and examples.

## Fix

1. **Update `profile_name` description** to clarify it should only be set when the user explicitly names a profile:

   > *"Only specify if the user explicitly mentions a profile name. If omitted, the AWS default credential chain is used (environment variables, instance profile, etc)."*

2. **Remove `"profile_name": "default"` from all tool examples** so the model does not learn to always include it.

No runtime code change needed.

## Testing

```bash
cargo test -p chat_cli
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.