### PR TITLE
docs(agent-format): make the allowedTools Examples block valid JSON (#3851)

### DIFF
--- a/docs/agent-format.md
+++ b/docs/agent-format.md
@@ -219,26 +219,19 @@ Optionally, you can also prefix native tools with the namespace `@builtin`.
 ```json
 {
   "allowedTools": [
-    // Exact matches
     "fs_read",
     "knowledge",
     "@server/specific_tool",
-    
-    // Native tool wildcards
-    "fs_*",                    // All filesystem tools
-    "execute_*",               // All execute tools
-    "*_test",                  // Any tool ending in _test
-    @builtin,                // All native tools
-    
-    // MCP tool wildcards
-    "@server/api_*",           // All API tools from server
-    "@server/read_*",          // All read tools from server
-    "@git-server/get_*_info",  // Tools like get_user_info, get_repo_info
-    "@*/status",               // Status tool from any server
-    
-    // Server-level permissions
-    "@fetch",                  // All tools from fetch server
-    "@git-*"                   // All tools from any git-* server
+    "fs_*",
+    "execute_*",
+    "*_test",
+    "@builtin",
+    "@server/api_*",
+    "@server/read_*",
+    "@git-server/get_*_info",
+    "@*/status",
+    "@fetch",
+    "@git-*"
   ]
 }
 ```


### PR DESCRIPTION
Fixes #3851.

The `allowedTools` Examples block in `docs/agent-format.md` is fenced as ` ```json ` but isn't valid JSON — it has inline `//` comments and an unquoted `@builtin`, so copy-pasting it (or anything that parses the fenced block) fails to parse.

This drops the `//` comments and quotes `@builtin`. The pattern meanings are already explained in the bullet list and "Pattern Matching Rules" just above/below, so no information is lost. Verified the block now parses with `json.loads`.
