### PR TITLE
feat(hooks): add exit code 3 for preToolUse to prompt user

### DIFF
--- a/crates/chat-cli/src/cli/chat/cli/hooks.rs
+++ b/crates/chat-cli/src/cli/chat/cli/hooks.rs
@@ -701,6 +701,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_hook_exit_code_3_ask_user() {
+        let mut executor = HookExecutor::new();
+        let mut output = Vec::new();
+
+        // Create a hook that exits with code 3 (ask user) and outputs reason to stderr
+        #[cfg(unix)]
+        let command = "echo 'Unknown command, ask user' >&2; exit 3";
+        #[cfg(windows)]
+        let command = "echo Unknown command, ask user 1>&2 & exit /b 3";
+
+        let hook = Hook {
+            command: command.to_string(),
+            timeout_ms: 5000,
+            cache_ttl_seconds: 0,
+            max_output_size: 1000,
+            matcher: Some("execute_bash".to_string()),
+            source: crate::cli::agent::hook::Source::Session,
+        };
+
+        let hooks = HashMap::from([(HookTrigger::PreToolUse, vec![hook])]);
+
+        let tool_context = ToolContext {
+            tool_name: "execute_bash".to_string(),
+            tool_input: serde_json::json!({
+                "command": "./deploy.sh"
+            }),
+            tool_response: None,
+        };
+
+        let results = executor
+            .run_hooks(
+                hooks,
+                &mut output,
+                ".",  // cwd
+                None, // prompt
+                Some(tool_context),
+            )
+            .await
+            .unwrap();
+
+        // Should have one result
+        assert_eq!(results.len(), 1);
+
+        let ((trigger, _hook), (exit_code, hook_output)) = &results[0];
+        assert_eq!(*trigger, HookTrigger::PreToolUse);
+        assert_eq!(*exit_code, 3);
+        assert!(hook_output.contains("Unknown command, ask user"));
+    }
+
+
+    #[tokio::test]
     async fn test_stop_hook() {
         let mut executor = HookExecutor::new();
         let mut output = Vec::new();

--- a/crates/chat-cli/src/cli/chat/mod.rs
+++ b/crates/chat-cli/src/cli/chat/mod.rs
@@ -2308,7 +2308,7 @@ impl ChatSession {
                                 .map_err(|_e| ChatError::Custom("Failed to validate agent tool settings".into()))?;
                         }
                     }
-                    tool_use.accepted = true;
+                    tool_use.accepted = Some(true);
 
                     return Ok(ChatState::ExecuteTools);
                 }
@@ -2384,8 +2384,8 @@ impl ChatSession {
         for i in 0..self.tool_uses.len() {
             let tool = &mut self.tool_uses[i];
 
-            // Manually accepted by the user or otherwise verified already.
-            if tool.accepted {
+            // Approved by a preToolUse hook or previously accepted by the user.
+            if tool.accepted == Some(true) {
                 continue;
             }
 
@@ -2458,7 +2458,7 @@ impl ChatSession {
             let tool = &mut self.tool_uses[i];
 
             if allowed {
-                tool.accepted = true;
+                tool.accepted = Some(true);
                 self.tool_use_telemetry_events
                     .entry(tool.id.clone())
                     .and_modify(|ev| ev.is_trusted = true);
@@ -3298,7 +3298,7 @@ impl ChatSession {
                                 id: tool_use_id.clone(),
                                 name: tool_use_name,
                                 tool,
-                                accepted: false,
+                                accepted: None,
                                 tool_input,
                             });
                         },
@@ -3375,7 +3375,7 @@ impl ChatSession {
         // The mental model is preToolHook is like validate tools, but its behavior can be customized by
         // user Note that after preTookUse hook, user can still reject the took run
         if let Some(cm) = self.conversation.context_manager.as_mut() {
-            for tool in &queued_tools {
+            for tool in &mut queued_tools {
                 let tool_context = ToolContext {
                     tool_name: match &tool.tool {
                         Tool::Custom(custom_tool) => custom_tool.namespaced_tool_name(), // for MCP tool, pass MCP
@@ -3397,11 +3397,14 @@ impl ChatSession {
                     .await?;
 
                 // Here is how we handle the preToolUse hook output:
-                // Exit code is 0: nothing. stdout is not shown to user.
-                // Exit code is 2: block the tool use. return stderr to LLM. show warning to user
-                // Other error: show warning to user.
+                // Exit code 0: allow — tool execution proceeds without prompting the user.
+                // Exit code 2: block — tool is blocked, stderr is returned to the LLM.
+                // Exit code 3: ask — neutral, fall through to native permission prompt.
+                // Other exit code: warning shown to user, tool still proceeds.
 
-                // Check for exit code 2 and add to tool_results
+                let mut blocked = false;
+                let mut should_ask = false;
+
                 for (_, (exit_code, output)) in &hook_results {
                     if *exit_code == 2 {
                         tool_results.push(ToolUseResult {
@@ -3412,8 +3415,17 @@ impl ChatSession {
                             ))],
                             status: ToolResultStatus::Error,
                         });
+                        blocked = true;
+                    } else if *exit_code == 3 {
+                        should_ask = true;
                     }
                 }
+
+                // If not blocked and no hook requested ask, mark as approved (exit 0 path)
+                if !blocked && !should_ask && !hook_results.is_empty() {
+                    tool.accepted = Some(true);
+                }
+                // If should_ask, leave accepted as None so native permission prompt fires
             }
         }
 

--- a/crates/chat-cli/src/cli/chat/tools/mod.rs
+++ b/crates/chat-cli/src/cli/chat/tools/mod.rs
@@ -331,7 +331,10 @@ fn tool_origin() -> ToolOrigin {
 pub struct QueuedTool {
     pub id: String,
     pub name: String,
-    pub accepted: bool,
+    /// Tool approval state, typically set by preToolUse hooks:
+    /// - `Some(true)`: approved (hook exit 0), skip native permission prompt
+    /// - `None`: neutral (hook exit 3 or no hook), fall through to native permission prompt
+    pub accepted: Option<bool>,
     pub tool: Tool,
     pub tool_input: serde_json::Value,
 }

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -26,6 +26,7 @@ For tool-related hooks, additional fields are included:
 
 - **Exit code 0**: Hook succeeded. STDOUT is captured but not shown to user.
 - **Exit code 2**: (PreToolUse only) Block tool execution. STDERR is returned to the LLM.
+- **Exit code 3**: (PreToolUse only) Ask user. Falls through to native permission prompt regardless of `allowedTools`. STDERR is shown as context.
 - **Other exit codes**: Hook failed. STDERR is shown as warning to user.
 
 ## Tool Matching
@@ -102,6 +103,7 @@ Runs before tool execution. Can validate and block tool usage.
 **Exit Code Behavior:**
 - **0**: Allow tool execution.
 - **2**: Block tool execution, return STDERR to LLM.
+- **3**: Ask user — fall through to native permission prompt regardless of `allowedTools`. STDERR is shown as context in the prompt.
 - **Other**: Show STDERR warning to user, allow tool execution.
 
 ### PostToolUse


### PR DESCRIPTION
## Summary

Add a new exit code 3 to preToolUse hooks that triggers the native permission prompt instead of auto-allowing or blocking.

## Motivation

External permission managers (e.g. [agentperm](https://github.com/agentperm/agentperm)) need to express three-way decisions for tool calls:

- **Allow**: command is whitelisted, run without prompting
- **Deny**: command is forbidden, block it
- **Ask**: unknown command, let the user decide

Currently preToolUse hooks can only allow (exit 0) or block (exit 2). There's no way for a hook to say "I don't know — ask the user." This forces permission managers to choose between auto-allowing unknown commands (unsafe) or blocking them entirely (unusable).

## Changes

| Exit code | Behavior |
|---|---|
| 0 | Allow — tool runs without prompting (unchanged) |
| 2 | Block — tool denied, stderr returned to LLM (unchanged) |
| **3** | **Ask — fall through to native permission prompt** |
| Other | Warning shown, tool runs (unchanged) |

### Implementation

- `QueuedTool.accepted` changed from `bool` to `Option<bool>`
- Exit 0 → `accepted = Some(true)` (skip native prompt)
- Exit 3 → `accepted = None` (native prompt fires)
- Exit 2 → blocked before reaching tool execution (unchanged)

### Backwards compatible

Existing hooks using exit 0/2 behave identically. Exit codes other than 0/2/3 continue to warn-and-allow.

## Testing

Compiled successfully with `cargo check --package chat_cli`. Manual testing with agentperm confirms all four paths work correctly.

## References

- Original hook implementation: #2875
- Auto-approve feature request: #1938