### PR TITLE
Fix login hang on Linux when the browser isn't already running

### DIFF
--- a/crates/chat-cli/src/util/open.rs
+++ b/crates/chat-cli/src/util/open.rs
@@ -47,6 +47,9 @@ fn open_command(url: impl AsRef<str>) -> std::process::Command {
     command
 }
 
+#[cfg(not(target_os = "macos"))]
+const OPEN_EXIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
 /// Returns bool indicating whether the URL was opened successfully
 #[allow(dead_code)]
 pub fn open_url(url: impl AsRef<str>) -> Result<(), Error> {
@@ -54,16 +57,27 @@ pub fn open_url(url: impl AsRef<str>) -> Result<(), Error> {
         if #[cfg(target_os = "macos")] {
             open_macos(url)
         } else {
-            match open_command(url).output() {
-                Ok(output) => {
-                    tracing::trace!(?output, "open_url output");
-                    if output.status.success() {
-                        Ok(())
-                    } else {
-                        Err(Error::Failed)
-                    }
-                },
-                Err(err) => Err(err.into()),
+            use std::process::Stdio;
+
+            let mut child = open_command(url)
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()?;
+            let deadline = std::time::Instant::now() + OPEN_EXIT_TIMEOUT;
+            loop {
+                match child.try_wait() {
+                    Ok(Some(status)) => {
+                        tracing::trace!(?status, "open_url exited");
+                        return if status.success() { Ok(()) } else { Err(Error::Failed) };
+                    },
+                    Ok(None) if std::time::Instant::now() >= deadline => {
+                        tracing::trace!("open_url did not exit within timeout, assuming success");
+                        return Ok(());
+                    },
+                    Ok(None) => std::thread::sleep(std::time::Duration::from_millis(100)),
+                    Err(err) => return Err(err.into()),
+                }
             }
         }
     }
@@ -75,16 +89,23 @@ pub async fn open_url_async(url: impl AsRef<str>) -> Result<(), Error> {
         if #[cfg(target_os = "macos")] {
             open_macos(url)
         } else {
-            match tokio::process::Command::from(open_command(url)).output().await {
-                Ok(output) => {
-                    tracing::trace!(?output, "open_url_async output");
-                    if output.status.success() {
-                        Ok(())
-                    } else {
-                        Err(Error::Failed)
-                    }
+            use std::process::Stdio;
+
+            let mut child = tokio::process::Command::from(open_command(url))
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()?;
+            match tokio::time::timeout(OPEN_EXIT_TIMEOUT, child.wait()).await {
+                Ok(Ok(status)) => {
+                    tracing::trace!(?status, "open_url_async exited");
+                    if status.success() { Ok(()) } else { Err(Error::Failed) }
                 },
-                Err(err) => Err(err.into()),
+                Ok(Err(err)) => Err(err.into()),
+                Err(_) => {
+                    tracing::trace!("open_url_async did not exit within timeout, assuming success");
+                    Ok(())
+                },
             }
         }
     }


### PR DESCRIPTION
q login (and downstream kiro-cli login) hangs forever on Linux when the browser isn't already running. The login flow awaits open_url_async before it starts accepting connections on the OAuth callback server, and open_url_async uses .output(), which pipes stdout/stderr and waits for the child to exit. On desktops xdg-open doesn't recognize (Hyprland, sway, etc) it runs the browser in the foreground, so a freshly launched browser inherits those pipes and never exits. Result: the CLI waits for the browser to close while the browser tab waits for the callback response.

I hit this with kiro-cli 2.10.0 on Arch Linux under Hyprland and traced it on a live hang: the callback request was sitting unread in the listener's accept backlog (Recv-Q 760) while the freshly started browser held the write ends of the CLI's stdout/stderr pipes. With the browser already running the opener hands off and exits, which is why login normally works.

Fix: spawn the opener with stdin/stdout/stderr on /dev/null and wait for exit with a 5 second cap. A quick non-zero exit (no handler available, headless box) is still reported as a failure so the device flow fallback keeps working. If the opener is still running after 5 seconds it's fronting the browser, which means the URL was opened, so we treat it as success. cargo check passes.
