### PR TITLE
Q CLI is now Kiro CLI and should be invoked as `kiro-cli` rather than `q`

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report_template.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report_template.yml
@@ -12,9 +12,9 @@ body:
     options:
     - label: "I have searched [github.com/aws/amazon-q-developer-cli/issues](https://github.com/aws/amazon-q-developer-cli/issues?q=) and there are no duplicates of my issue"
       required: true
-    - label: "I have run `q doctor` in the affected terminal session"
+    - label: "I have run `kiro-cli doctor` in the affected terminal session"
       required: true
-    - label: "I have run `q restart` and replicated the issue again"
+    - label: "I have run `kiro-cli restart` and replicated the issue again"
       required: true
 
 - type: input
@@ -50,5 +50,5 @@ body:
   id: "environment"
   attributes:
     label: "Environment"
-    description: "If possible, run `q diagnostic` and paste the output below."
+    description: "If possible, run `kiro-cli diagnostic` and paste the output below."
     render: yaml


### PR DESCRIPTION
*Issue #, if available:*
None.

*Description of changes:*
Q CLI is now Kiro CLI and should be invoked as `kiro-cli` rather than `q`.
Update the command hint in the bug report template to align with the program. 
I have also checked the `install.sh` script inside `kirocli-x86_64-linux.zip`, and it now only installs these three binaries; `q` is not included.
```bash
CLI_BINARY_NAME="kiro-cli"
CHAT_BINARY_NAME="kiro-cli-chat"
PTY_BINARY_NAME="kiro-cli-term"
...
    install -m 755 "$SCRIPT_DIR/bin/$CLI_BINARY_NAME" "$HOME/.local/bin/"
    install -m 755 "$SCRIPT_DIR/bin/$CHAT_BINARY_NAME" "$HOME/.local/bin/"
    install -m 755 "$SCRIPT_DIR/bin/$PTY_BINARY_NAME" "$HOME/.local/bin/"
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
